### PR TITLE
Fix "sprecher" data & Migrate array-based "sprecher" to object-based "sprechrollen"

### DIFF
--- a/D3F-MetadataCollector/D3F-MetadataCollector/Metadata.swift
+++ b/D3F-MetadataCollector/D3F-MetadataCollector/Metadata.swift
@@ -25,7 +25,7 @@ class Höreinheit: Codable {
 	var beschreibung: String?
 	var veröffentlichungsdatum: String?
 	var kapitel: [Kapitel]?
-	var sprecher: [[String]]?
+	var sprechrollen: [Sprechrolle]?
 	var links: Links?
 	var unvollständig: Bool?
 }
@@ -105,6 +105,22 @@ class Kapitel: Codable, Equatable {
 }
 
 
+class Sprechrolle: Codable, Equatable {
+	var rolle: String
+	var sprecher: String
+	var pseudonym: String?
+	
+	init(rolle: String, sprecher: String) {
+		self.rolle = rolle
+		self.sprecher = sprecher
+	}
+	
+	static func == (lhs: Sprechrolle, rhs: Sprechrolle) -> Bool {
+		return lhs.rolle == rhs.rolle && lhs.sprecher == rhs.sprecher && lhs.pseudonym == rhs.pseudonym
+	}
+}
+
+
 class Links: Codable {
 	var json: String?
 	var ffmetadata: String?
@@ -153,13 +169,17 @@ extension Metadata {
 			"beschreibung",
 			"veröffentlichungsdatum",
 			"kapitel",
-			"sprecher",
+			"sprechrollen",
 			"links",
 			"unvollständig",
 			
 			"titel",
 			"start",
 			"end",
+			
+			"rolle",
+			"sprecher",
+			"pseudonym",
 			
 			"json",
 			"ffmetadata",

--- a/D3F-MetadataCollector/D3F-MetadataCollector/MetadataCollector.swift
+++ b/D3F-MetadataCollector/D3F-MetadataCollector/MetadataCollector.swift
@@ -450,13 +450,13 @@ class MetadataCollector {
 			throw CSVParseError.invalidCSVComponentFormat(component: 4, info: "invalid date format \"\(datumDMY)\"")
 		}
 		let veröffentlichungsdatum = datumDMY.reversed().joined(separator: "-")
-		let sprecher: [[String]] = try convertString(component: 5).components(separatedBy: "\n").map { (sprecherRolleString) in
+		let sprechrollen: [Sprechrolle] = try convertString(component: 5).components(separatedBy: "\n").map { (sprecherRolleString) in
 			let seperator = sprecherRolleString.contains(" - ") ? " - " : ": "
-			let sprecherRolleComponents = sprecherRolleString.components(separatedBy: seperator)
+			let sprecherRolleComponents = sprecherRolleString.components(separatedBy: seperator).map { $0.trimmingCharacters(in: .whitespaces)  }
 			guard sprecherRolleComponents.count == 2 else {
 				throw CSVParseError.invalidCSVComponentFormat(component: 5, info: "\"\(sprecherRolleComponents)\"")
 			}
-			return sprecherRolleComponents.map { $0.trimmingCharacters(in: .whitespaces)  }
+			return Sprechrolle(rolle: sprecherRolleComponents[0], sprecher: sprecherRolleComponents[1])
 		}
 		
 		
@@ -476,7 +476,7 @@ class MetadataCollector {
 		update(&folge.titel, to: folgenTitel, description: "titel")
 		update(&folge.beschreibung, to: beschreibung, description: "beschreibung")
 		update(&folge.veröffentlichungsdatum, to: veröffentlichungsdatum, description: "veröffentlichungsdatum")
-		update(&folge.sprecher, to: sprecher, description: "sprecher")
+		update(&folge.sprechrollen, to: sprechrollen, description: "sprechrollen")
 	}
 	
 	

--- a/D3F-MetadataExporter/D3F-MetadataExporter/FFmetadata.swift
+++ b/D3F-MetadataExporter/D3F-MetadataExporter/FFmetadata.swift
@@ -105,8 +105,8 @@ extension FFmetadata {
 	private init(withBasicTagsFrom höreinheit: Höreinheit) {
 		// First sprecher as artist
 		let artist: String? = {
-			if let firstSprecher = höreinheit.sprecher?.first, firstSprecher.count >= 2 {
-				return firstSprecher[1]
+			if let firstSprechrolle = höreinheit.sprechrollen?.first {
+				return firstSprechrolle.sprecher
 			}
 			return nil
 		}()

--- a/data/Master_DiE_DR3i.json
+++ b/data/Master_DiE_DR3i.json
@@ -325,11 +325,11 @@
           "Holger Löwenberg"
         ],
         [
-          "Mrs. Torrence",
+          "Mrs. Torrance",
           "Katja Brügger"
         ],
         [
-          "Shelley",
+          "Shelley Torrance",
           "Saskia Weckler"
         ],
         [
@@ -1537,7 +1537,7 @@
           "Rainer Schmitt"
         ],
         [
-          "Tante Mathilda",
+          "Tante Mathilda Jones",
           "Karin Lieneweg"
         ],
         [

--- a/data/Master_DiE_DR3i.json
+++ b/data/Master_DiE_DR3i.json
@@ -283,71 +283,71 @@
       "hörspielskriptautor" : "Ivar Leon Menger",
       "beschreibung" : "Eine Nacht in einem Luxushotel, direkt an der malerischen Steilküste Nordkaliforniens? Normalerweise ein Grund zur Freude. Doch nicht für Jupiter, Peter und Bob! Denn Die Dr3i müssen um ihr Leben fürchten! Und das, obwohl das unheimliche Hotel vollkommen menschenleer ist …\nErlebe das erste interaktive Hörspiel mit Jupiter Jones, Peter Crenshaw und Bob Andrews! Mit einem Knopfdruck auf deinem CD-Player kannst du mitbestimmen, welche Lösungswege die drei Detektive bei diesem mysteriösen Abenteuer einschlagen sollen.\nAuf 2 CDs erwarten dich viele ungelöste Rätsel und Geheimnisse, sowie 16 alternative Enden!",
       "veröffentlichungsdatum" : "2006-11-24",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jones",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Overlook",
-          "Joachim Kerzel"
-        ],
-        [
-          "Portier Stanley",
-          "Lutz Mackensy"
-        ],
-        [
-          "Liftboy Jack",
-          "Jan-David Rönfeldt"
-        ],
-        [
-          "Barkeeper Lloyd",
-          "Roman Kretschmer"
-        ],
-        [
-          "Mr. Torrance",
-          "Holger Löwenberg"
-        ],
-        [
-          "Mrs. Torrance",
-          "Katja Brügger"
-        ],
-        [
-          "Shelley Torrance",
-          "Saskia Weckler"
-        ],
-        [
-          "Stuart",
-          "Nicolas König"
-        ],
-        [
-          "Danny",
-          "Patrick Bach"
-        ],
-        [
-          "Police Officer",
-          "Jürgen Thormann"
-        ],
-        [
-          "Nachrichtensprecher",
-          "Bernd Klose"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda Jones",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Overlook",
+          "sprecher" : "Joachim Kerzel"
+        },
+        {
+          "rolle" : "Portier Stanley",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Liftboy Jack",
+          "sprecher" : "Jan-David Rönfeldt"
+        },
+        {
+          "rolle" : "Barkeeper Lloyd",
+          "sprecher" : "Roman Kretschmer"
+        },
+        {
+          "rolle" : "Mr. Torrance",
+          "sprecher" : "Holger Löwenberg"
+        },
+        {
+          "rolle" : "Mrs. Torrance",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Shelley Torrance",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Stuart",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Danny",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Police Officer",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "Bernd Klose"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/metadata.json",
@@ -643,67 +643,67 @@
           "end" : 7993773
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Ashby",
-          "Sabine Hahn"
-        ],
-        [
-          "Charles Prendergast",
-          "Rolf Nagel"
-        ],
-        [
-          "Richard Crandall",
-          "Konstantin Graudus"
-        ],
-        [
-          "Kirk Prendergast",
-          "Wolf Frass"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ],
-        [
-          "Jonathan Godfrey",
-          "Erik Schäffler"
-        ],
-        [
-          "Carlos",
-          "Eduardo Garcia"
-        ],
-        [
-          "Garrett",
-          "Dietrich Adam"
-        ],
-        [
-          "Riteman",
-          "Till Demtrøder"
-        ],
-        [
-          "Stanley",
-          "Lutz Schnell"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Ashby",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Charles Prendergast",
+          "sprecher" : "Rolf Nagel"
+        },
+        {
+          "rolle" : "Richard Crandall",
+          "sprecher" : "Konstantin Graudus"
+        },
+        {
+          "rolle" : "Kirk Prendergast",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Jonathan Godfrey",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Carlos",
+          "sprecher" : "Eduardo Garcia"
+        },
+        {
+          "rolle" : "Garrett",
+          "sprecher" : "Dietrich Adam"
+        },
+        {
+          "rolle" : "Riteman",
+          "sprecher" : "Till Demtrøder"
+        },
+        {
+          "rolle" : "Stanley",
+          "sprecher" : "Lutz Schnell"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/1/metadata.json",
@@ -780,59 +780,59 @@
           "end" : 4634013
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sylvester Meyzel",
-          "Wolfgang Völz"
-        ],
-        [
-          "Dorothy Winter",
-          "Doris Kunstmann"
-        ],
-        [
-          "Mr. Hendrik",
-          "Utz Richter"
-        ],
-        [
-          "Kassiererin",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Inspektor Tomlin",
-          "Klaus Dittmann"
-        ],
-        [
-          "Mr. X",
-          "Dirk Eichhorn"
-        ],
-        [
-          "Tao",
-          "Tilman Madaus"
-        ],
-        [
-          "Supermarkt-Durchsage",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sylvester Meyzel",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Dorothy Winter",
+          "sprecher" : "Doris Kunstmann"
+        },
+        {
+          "rolle" : "Mr. Hendrik",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Kassiererin",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Inspektor Tomlin",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Mr. X",
+          "sprecher" : "Dirk Eichhorn"
+        },
+        {
+          "rolle" : "Tao",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Supermarkt-Durchsage",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/2/metadata.json",
@@ -915,51 +915,51 @@
           "end" : 4113813
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "James Taylor",
-          "Wanja Mues"
-        ],
-        [
-          "Ray Wells",
-          "Dietrich Adam"
-        ],
-        [
-          "Frank Caspian",
-          "Christian Redl"
-        ],
-        [
-          "Jonathan Grant",
-          "Bernd Stephan"
-        ],
-        [
-          "Christy Grant",
-          "Anja Topf"
-        ],
-        [
-          "George Drummond",
-          "Eberhard Haar"
-        ],
-        [
-          "Tom Drummond",
-          "Patrick Bach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "James Taylor",
+          "sprecher" : "Wanja Mues"
+        },
+        {
+          "rolle" : "Ray Wells",
+          "sprecher" : "Dietrich Adam"
+        },
+        {
+          "rolle" : "Frank Caspian",
+          "sprecher" : "Christian Redl"
+        },
+        {
+          "rolle" : "Jonathan Grant",
+          "sprecher" : "Bernd Stephan"
+        },
+        {
+          "rolle" : "Christy Grant",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "George Drummond",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Tom Drummond",
+          "sprecher" : "Patrick Bach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/3/metadata.json",
@@ -1032,63 +1032,64 @@
           "end" : 4747133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus Jones",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda Jones",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mr. Walker",
-          "Gustav-Adolph Artz"
-        ],
-        [
-          "Donald Forthland",
-          "Günter Lüdke"
-        ],
-        [
-          "Shane Montana",
-          "Jürgen Thormann"
-        ],
-        [
-          "Jim",
-          "Wolfgang Berger"
-        ],
-        [
-          "Doc Brown",
-          "Tim Wenderoth"
-        ],
-        [
-          "Finnegan",
-          "Fabian Harloff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus Jones",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda Jones",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mr. Walker",
+          "sprecher" : "Gustav-Adolph Artz"
+        },
+        {
+          "rolle" : "Donald Forthland",
+          "sprecher" : "Günter Lüdke"
+        },
+        {
+          "rolle" : "Shane Montana",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Jim",
+          "sprecher" : "Wolfgang Berger"
+        },
+        {
+          "rolle" : "Doc Brown",
+          "sprecher" : "Tim Wenderoth"
+        },
+        {
+          "rolle" : "Finnegan",
+          "sprecher" : "Fabian Harloff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/4/metadata.json",
@@ -1161,47 +1162,47 @@
           "end" : 4409520
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jack Doolan",
-          "Eckart Dux"
-        ],
-        [
-          "Harold",
-          "Gernot Endemann"
-        ],
-        [
-          "Miss Lana",
-          "Sabine Schmidt-Kirchner"
-        ],
-        [
-          "Mademoiselle Nadine",
-          "Jennie Appel"
-        ],
-        [
-          "Toby Grissom",
-          "Lothar Grützner"
-        ],
-        [
-          "Frank Mortimer",
-          "Karl-Friedrich Gerster"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jack Doolan",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Harold",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Miss Lana",
+          "sprecher" : "Sabine Schmidt-Kirchner"
+        },
+        {
+          "rolle" : "Mademoiselle Nadine",
+          "sprecher" : "Jennie Appel"
+        },
+        {
+          "rolle" : "Toby Grissom",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Frank Mortimer",
+          "sprecher" : "Karl-Friedrich Gerster"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/5/metadata.json",
@@ -1269,51 +1270,51 @@
           "end" : 3924760
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ellen Maxell",
-          "Traudel Sperber"
-        ],
-        [
-          "Audrey Moonshadow",
-          "Judy Winter"
-        ],
-        [
-          "Sandy Stryker",
-          "Martina Regenhardt"
-        ],
-        [
-          "Mandy Honeyball",
-          "Celine Fontanges"
-        ],
-        [
-          "Mars Chaplin",
-          "Rainer Schmitt"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Assistent",
-          "Dirk Bach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ellen Maxell",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Audrey Moonshadow",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Sandy Stryker",
+          "sprecher" : "Martina Regenhardt"
+        },
+        {
+          "rolle" : "Mandy Honeyball",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Mars Chaplin",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Assistent",
+          "sprecher" : "Dirk Bach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/6/metadata.json",
@@ -1381,67 +1382,68 @@
           "end" : 3920920
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jones",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus Jones",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Marty Stevens",
-          "Lutz Harder"
-        ],
-        [
-          "Joshua Apeh",
-          "Achim Schülke"
-        ],
-        [
-          "Claudia Salazar",
-          "Marion Elskis"
-        ],
-        [
-          "Ralf Dempsey",
-          "Robin Brosch"
-        ],
-        [
-          "Marvin Cox",
-          "Jörg Gillner"
-        ],
-        [
-          "Anna",
-          "Micaëla Kreißler"
-        ],
-        [
-          "George",
-          "Erik Schäffler"
-        ],
-        [
-          "Hapa",
-          "Michael Weckler"
-        ],
-        [
-          "Lastwagenfahrer",
-          "Tim Wenderoth"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda Jones",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus Jones",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Marty Stevens",
+          "sprecher" : "Lutz Harder"
+        },
+        {
+          "rolle" : "Joshua Apeh",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Claudia Salazar",
+          "sprecher" : "Marion Elskis"
+        },
+        {
+          "rolle" : "Ralf Dempsey",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Marvin Cox",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Anna",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Hapa",
+          "sprecher" : "Michael Weckler"
+        },
+        {
+          "rolle" : "Lastwagenfahrer",
+          "sprecher" : "Tim Wenderoth"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/7/metadata.json",
@@ -1499,67 +1501,67 @@
           "end" : 4627360
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Taro Togati",
-          "Stefan Brönneke"
-        ],
-        [
-          "Officer Hunter",
-          "Jürgen Kluckert"
-        ],
-        [
-          "Türsteher",
-          "Arndt Schmöle"
-        ],
-        [
-          "Motelangestellter",
-          "Jelko von Tiele-Winckler"
-        ],
-        [
-          "Museumsdirektor",
-          "Rainer Schmitt"
-        ],
-        [
-          "Tante Mathilda Jones",
-          "Karin Lieneweg"
-        ],
-        [
-          "Harvey Denton",
-          "Klaus Herm"
-        ],
-        [
-          "Mrs. Fox",
-          "Nana Spier"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Arthur Heatherly",
-          "Rainer Brandt"
-        ],
-        [
-          "Melissa Heatherly",
-          "Stephanie Damare"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Taro Togati",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Officer Hunter",
+          "sprecher" : "Jürgen Kluckert"
+        },
+        {
+          "rolle" : "Türsteher",
+          "sprecher" : "Arndt Schmöle"
+        },
+        {
+          "rolle" : "Motelangestellter",
+          "sprecher" : "Jelko von Tiele-Winckler"
+        },
+        {
+          "rolle" : "Museumsdirektor",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Tante Mathilda Jones",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Harvey Denton",
+          "sprecher" : "Klaus Herm"
+        },
+        {
+          "rolle" : "Mrs. Fox",
+          "sprecher" : "Nana Spier"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Arthur Heatherly",
+          "sprecher" : "Rainer Brandt"
+        },
+        {
+          "rolle" : "Melissa Heatherly",
+          "sprecher" : "Stephanie Damare"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/8/metadata.json",

--- a/data/Master_DiE_DR3i.json
+++ b/data/Master_DiE_DR3i.json
@@ -686,7 +686,7 @@
         ],
         [
           "Jonathan Godfrey",
-          "Eric Schäffler"
+          "Erik Schäffler"
         ],
         [
           "Carlos",
@@ -827,7 +827,7 @@
         ],
         [
           "Tao",
-          "Tilman Maddaus"
+          "Tilman Madaus"
         ],
         [
           "Supermarkt-Durchsage",
@@ -1051,7 +1051,7 @@
         ],
         [
           "Onkel Titus Jones",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda Jones",
@@ -1404,7 +1404,7 @@
         ],
         [
           "Onkel Titus Jones",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Marty Stevens",
@@ -1428,11 +1428,11 @@
         ],
         [
           "Anna",
-          "Micaela Kreissler"
+          "Micaëla Kreißler"
         ],
         [
           "George",
-          "Eric Schaeffler"
+          "Erik Schäffler"
         ],
         [
           "Hapa",
@@ -1558,7 +1558,7 @@
         ],
         [
           "Melissa Heatherly",
-          "Stephanie Kirchberger"
+          "Stephanie Damare"
         ]
       ],
       "links" : {

--- a/data/Master_Kurzgeschichten.json
+++ b/data/Master_Kurzgeschichten.json
@@ -119,7 +119,7 @@
                 ],
                 [
                   "Patricia",
-                  "Rhea Harder"
+                  "Rhea Harder-Vennewald"
                 ],
                 [
                   "Peter Shawn",
@@ -389,7 +389,7 @@
                 ],
                 [
                   "John",
-                  "Martin Sichel"
+                  "Martin Sichel [Sascha Draeger]"
                 ]
               ],
               "links" : {
@@ -613,7 +613,7 @@
                 ],
                 [
                   "Meerjungfrau",
-                  "Pamela Punti"
+                  "Pamela Punti [Heikedine Körting]"
                 ]
               ],
               "links" : {
@@ -772,7 +772,7 @@
                 ],
                 [
                   "Onkel Titus Jonas",
-                  "Hans Meinhardt"
+                  "Hans Meinhardt [Andreas E. Beurmann]"
                 ]
               ],
               "links" : {
@@ -931,7 +931,7 @@
                 ],
                 [
                   "Onkel Titus Jonas",
-                  "Hans Meinhardt"
+                  "Hans Meinhardt [Andreas E. Beurmann]"
                 ],
                 [
                   "Tante Mathilda Jonas",
@@ -943,11 +943,11 @@
                 ],
                 [
                   "Diego",
-                  "Stefan Benson"
+                  "Stephan Benson"
                 ],
                 [
                   "Mercedes",
-                  "Wanda Osten"
+                  "Wanda Osten [Hella von der Osten-Sacken]"
                 ]
               ],
               "links" : {
@@ -1004,7 +1004,7 @@
                 ],
                 [
                   "Onkel Titus Jonas",
-                  "Hans Meinhardt"
+                  "Hans Meinhardt [Andreas E. Beurmann]"
                 ],
                 [
                   "Off-Sprecherin",
@@ -1061,7 +1061,7 @@
                 ],
                 [
                   "Onkel Titus Jonas",
-                  "Hans Meinhardt"
+                  "Hans Meinhardt [Andreas E. Beurmann]"
                 ],
                 [
                   "Ian Carew",
@@ -1235,7 +1235,7 @@
                 ],
                 [
                   "Nancy McMonigal",
-                  "Gerlinde Dilge"
+                  "Gerlinde Dillge"
                 ],
                 [
                   "Tom",
@@ -1247,7 +1247,7 @@
                 ],
                 [
                   "Joe",
-                  "Oliver Reichmann"
+                  "Olaf Reichmann"
                 ],
                 [
                   "Ben",
@@ -1407,7 +1407,7 @@
                 ],
                 [
                   "Onkel Titus Jonas",
-                  "Hans Meinhardt"
+                  "Hans Meinhardt [Andreas E. Beurmann]"
                 ],
                 [
                   "Tante Mathilda Jonas",
@@ -1542,7 +1542,7 @@
                 ],
                 [
                   "Kelly",
-                  "Juliane Szalay-Pracht"
+                  "Juliane Szalay"
                 ],
                 [
                   "Patrick",
@@ -1725,7 +1725,7 @@
                 ],
                 [
                   "Helen",
-                  "Balancinha Blanc (Dorette Hugo)"
+                  "Balancinha Blanc [Dorette Hugo]"
                 ],
                 [
                   "Ellen",
@@ -1840,6 +1840,10 @@
                 [
                   "Sarah",
                   "Christiane Leuchtmann"
+                ],
+                [
+                  "Albert",
+                  "Franzisko Löwe"
                 ]
               ],
               "links" : {
@@ -1912,7 +1916,7 @@
                 ],
                 [
                   "Ericsson",
-                  "Detlev Tams"
+                  "Detlef Tams"
                 ],
                 [
                   "Sprecher/Moderator",
@@ -2087,7 +2091,7 @@
                 ],
                 [
                   "Blacky",
-                  "Pamela Punti"
+                  "Pamela Punti [Heikedine Körting]"
                 ],
                 [
                   "Kassiererin",

--- a/data/Master_Kurzgeschichten.json
+++ b/data/Master_Kurzgeschichten.json
@@ -16,15 +16,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -73,15 +73,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -106,15 +106,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -143,7 +143,7 @@
               "veröffentlichungsdatum" : "2011-12-08",
               "sprecher" : [
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ]
               ],
@@ -196,15 +196,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -216,11 +216,11 @@
                   "Guido Bernadotte"
                 ],
                 [
-                  "1. Mann",
+                  "Mann 1",
                   "Rasmus Rakete"
                 ],
                 [
-                  "2. Mann",
+                  "Mann 2",
                   "Patrick Perales"
                 ]
               ],
@@ -237,7 +237,7 @@
               "veröffentlichungsdatum" : "2011-12-12",
               "sprecher" : [
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ]
               ],
@@ -258,15 +258,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -291,19 +291,19 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
-                  "Tante Mathilda Jonas",
+                  "Tante Mathilda",
                   "Karin Lieneweg"
                 ],
                 [
@@ -360,23 +360,23 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
-                  "Tante Mathilda Jonas",
+                  "Tante Mathilda",
                   "Karin Lieneweg"
                 ],
                 [
-                  "Blacky/Mynah",
+                  "Blacky",
                   "Heikedine Körting"
                 ],
                 [
@@ -405,7 +405,7 @@
               "veröffentlichungsdatum" : "2011-12-20",
               "sprecher" : [
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ]
               ],
@@ -426,15 +426,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -467,15 +467,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -487,15 +487,15 @@
                   "Joachim Kappl"
                 ],
                 [
-                  "1. Mann",
+                  "Mann 1",
                   "Patrick Bach"
                 ],
                 [
-                  "2. Mann",
+                  "Mann 2",
                   "Frank Meyer-Brockmann"
                 ],
                 [
-                  "3. Mann",
+                  "Mann 3",
                   "Roy Martens"
                 ]
               ],
@@ -576,15 +576,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -649,15 +649,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -755,23 +755,23 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
-                  "Tante Mathilda Jonas",
+                  "Tante Mathilda",
                   "Karin Lieneweg"
                 ],
                 [
-                  "Onkel Titus Jonas",
+                  "Onkel Titus",
                   "Hans Meinhardt [Andreas E. Beurmann]"
                 ]
               ],
@@ -808,15 +808,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -918,23 +918,23 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
-                  "Onkel Titus Jonas",
+                  "Onkel Titus",
                   "Hans Meinhardt [Andreas E. Beurmann]"
                 ],
                 [
-                  "Tante Mathilda Jonas",
+                  "Tante Mathilda",
                   "Karin Lieneweg"
                 ],
                 [
@@ -983,15 +983,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -1003,7 +1003,7 @@
                   "Ben Hecker"
                 ],
                 [
-                  "Onkel Titus Jonas",
+                  "Onkel Titus",
                   "Hans Meinhardt [Andreas E. Beurmann]"
                 ],
                 [
@@ -1044,23 +1044,23 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
-                  "Tante Mathilda Jonas",
+                  "Tante Mathilda",
                   "Karin Lieneweg"
                 ],
                 [
-                  "Onkel Titus Jonas",
+                  "Onkel Titus",
                   "Hans Meinhardt [Andreas E. Beurmann]"
                 ],
                 [
@@ -1169,15 +1169,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -1222,15 +1222,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -1290,15 +1290,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -1394,23 +1394,23 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
-                  "Onkel Titus Jonas",
+                  "Onkel Titus",
                   "Hans Meinhardt [Andreas E. Beurmann]"
                 ],
                 [
-                  "Tante Mathilda Jonas",
+                  "Tante Mathilda",
                   "Karin Lieneweg"
                 ],
                 [
@@ -1467,15 +1467,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -1525,15 +1525,15 @@
                   "Thomas Fritsch"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -1667,15 +1667,15 @@
               ],
               "sprecher" : [
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ]
               ],
@@ -1712,15 +1712,15 @@
                   "Axel Milberg"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -1810,19 +1810,19 @@
                   "Axel Milberg"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
-                  "Tante Mathilda Jonas",
+                  "Tante Mathilda",
                   "Karin Lieneweg"
                 ],
                 [
@@ -1879,15 +1879,15 @@
                   "Axel Milberg"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -2001,15 +2001,15 @@
                   "Axel Milberg"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [
@@ -2078,15 +2078,15 @@
                   "Axel Milberg"
                 ],
                 [
-                  "Justus Jonas",
+                  "Justus Jonas, Erster Detektiv",
                   "Oliver Rohrbeck"
                 ],
                 [
-                  "Peter Shaw",
+                  "Peter Shaw, Zweiter Detektiv",
                   "Jens Wawrczeck"
                 ],
                 [
-                  "Bob Andrews",
+                  "Bob Andrews, Recherchen und Archiv",
                   "Andreas Fröhlich"
                 ],
                 [

--- a/data/Master_Kurzgeschichten.json
+++ b/data/Master_Kurzgeschichten.json
@@ -10,51 +10,51 @@
               "autor" : "Kari Erlhoff",
               "beschreibung" : "Mr. Vancura ist Schauspieler und sammelt alles, was mit dem Orient zu tun hat. Sein ganzer Stolz ist eine Wunderlampe, in der ein richtiger Dschinn lebt. Aber der Dschinn ist verschwunden …",
               "veröffentlichungsdatum" : "2011-12-02",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Mr. Vancura",
-                  "Lutz Herkenrath"
-                ],
-                [
-                  "Mrs. Fox",
-                  "Susan Jarling"
-                ],
-                [
-                  "Inspektor Cotta",
-                  "Holger Mahlich"
-                ],
-                [
-                  "Mr. Shaw",
-                  "Rasmus Borowski"
-                ],
-                [
-                  "Shannon",
-                  "Kerstin Draeger"
-                ],
-                [
-                  "Mr. Mosley",
-                  "Neil Malik Abdullah"
-                ],
-                [
-                  "Mann",
-                  "Thor W. Müller"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Mr. Vancura",
+                  "sprecher" : "Lutz Herkenrath"
+                },
+                {
+                  "rolle" : "Mrs. Fox",
+                  "sprecher" : "Susan Jarling"
+                },
+                {
+                  "rolle" : "Inspektor Cotta",
+                  "sprecher" : "Holger Mahlich"
+                },
+                {
+                  "rolle" : "Mr. Shaw",
+                  "sprecher" : "Rasmus Borowski"
+                },
+                {
+                  "rolle" : "Shannon",
+                  "sprecher" : "Kerstin Draeger"
+                },
+                {
+                  "rolle" : "Mr. Mosley",
+                  "sprecher" : "Neil Malik Abdullah"
+                },
+                {
+                  "rolle" : "Mann",
+                  "sprecher" : "Thor W. Müller"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/1/metadata.json",
@@ -67,27 +67,27 @@
               "autor" : "Marco Sonnleitner",
               "beschreibung" : "Das neuste Hobby von Justus Jonas ist die Ahnenforschung.\nUnd dabei macht er eines Tages eine unglaubliche Entdeckung …",
               "veröffentlichungsdatum" : "2011-12-04",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Cowboy",
-                  "Achim Schülke"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Cowboy",
+                  "sprecher" : "Achim Schülke"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/2/metadata.json",
@@ -100,35 +100,35 @@
               "autor" : "Marco Sonnleitner",
               "beschreibung" : "Peter erhält eine E-Mail: Kelly ist entführt worden! Den drei ??? bleibt weniger als eine Stunde Zeit, sie zu finden und zu befreien …",
               "veröffentlichungsdatum" : "2011-12-06",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Patricia",
-                  "Rhea Harder-Vennewald"
-                ],
-                [
-                  "Peter Shawn",
-                  "Leonhard Mahlich"
-                ],
-                [
-                  "Mann",
-                  "Helgo Liebig"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Patricia",
+                  "sprecher" : "Rhea Harder-Vennewald"
+                },
+                {
+                  "rolle" : "Peter Shawn",
+                  "sprecher" : "Leonhard Mahlich"
+                },
+                {
+                  "rolle" : "Mann",
+                  "sprecher" : "Helgo Liebig"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/3/metadata.json",
@@ -141,11 +141,11 @@
               "autor" : "Hendrik Buchna",
               "beschreibung" : "Auf dem Autorasthof \"Eagle Ranch\" geschehen merkwürdige Dinge und die drei ??? erhalten den Auftrag, herauszufinden, was es damit auf sich hat …",
               "veröffentlichungsdatum" : "2011-12-08",
-              "sprecher" : [
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/4/metadata.json",
@@ -190,39 +190,39 @@
               "autor" : "Marco Sonnleitner",
               "beschreibung" : "Als die drei ??? vom Strand kommen und auf dem Weg nach Hause sind, sehen sie ein SOS-Signal, das aus einem Haus gesendet wird. Eigentlich steht das Haus leer …",
               "veröffentlichungsdatum" : "2011-12-10",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Marty",
-                  "Philipp Draeger"
-                ],
-                [
-                  "Fred",
-                  "Guido Bernadotte"
-                ],
-                [
-                  "Mann 1",
-                  "Rasmus Rakete"
-                ],
-                [
-                  "Mann 2",
-                  "Patrick Perales"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Marty",
+                  "sprecher" : "Philipp Draeger"
+                },
+                {
+                  "rolle" : "Fred",
+                  "sprecher" : "Guido Bernadotte"
+                },
+                {
+                  "rolle" : "Mann 1",
+                  "sprecher" : "Rasmus Rakete"
+                },
+                {
+                  "rolle" : "Mann 2",
+                  "sprecher" : "Patrick Perales"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/5/metadata.json",
@@ -235,11 +235,11 @@
               "autor" : "Hendrik Buchna",
               "beschreibung" : "Auf dem Weg nach Hause wird Peter plötzlich von einem unheimlichen, grauen Dämon verfolgt. Ihm bleibt nur noch ein Ausweg: Die Flucht …",
               "veröffentlichungsdatum" : "2011-12-12",
-              "sprecher" : [
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/6/metadata.json",
@@ -252,27 +252,27 @@
               "autor" : "Kari Erlhoff",
               "beschreibung" : "Peters ehemalige Klavierlehrerin, Mrs. Floyd, engagiert die drei ???, um herauszufinden, wo ihre verstorbene Mutter ihr Erbe versteckt haben könnte …",
               "veröffentlichungsdatum" : "2011-12-14",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Mrs. Floyd",
-                  "Gabriele Libbach"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Mrs. Floyd",
+                  "sprecher" : "Gabriele Libbach"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/7/metadata.json",
@@ -285,31 +285,31 @@
               "autor" : "Hendrik Buchna",
               "beschreibung" : "Die drei ??? erhalten den Auftrag, bei der Übergabe einer schwarzen Nadel dabei zu sein. Aber geht es dabei wirklich nur um das Schmuckstück?",
               "veröffentlichungsdatum" : "2011-12-16",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Vincent Grimes",
-                  "Konstantin Graudus"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Vincent Grimes",
+                  "sprecher" : "Konstantin Graudus"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/8/metadata.json",
@@ -354,43 +354,44 @@
               "autor" : "Kari Erlhoff",
               "beschreibung" : "Blacky, der Papagei der drei ???, benimmt sich seit ein paar Tagen höchst sonderbar.\nWas ist der Grund für die merkwürdigen Sprüche, die der Vogel plötzlich zitiert …",
               "veröffentlichungsdatum" : "2011-12-18",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Blacky",
-                  "Heikedine Körting"
-                ],
-                [
-                  "Juliet",
-                  "Anne Moll"
-                ],
-                [
-                  "Scott",
-                  "Tommaso Cacciapuoti"
-                ],
-                [
-                  "John",
-                  "Martin Sichel [Sascha Draeger]"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Blacky",
+                  "sprecher" : "Heikedine Körting"
+                },
+                {
+                  "rolle" : "Juliet",
+                  "sprecher" : "Anne Moll"
+                },
+                {
+                  "rolle" : "Scott",
+                  "sprecher" : "Tommaso Cacciapuoti"
+                },
+                {
+                  "rolle" : "John",
+                  "sprecher" : "Sascha Draeger",
+                  "pseudonym" : "Martin Sichel"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/9/metadata.json",
@@ -403,11 +404,11 @@
               "autor" : "Marco Sonnleitner",
               "beschreibung" : "Die drei ??? sollen von der Stadt Rocky Beach für ihr Lebenswerk geehrt werden. Und prompt sitzen sie gleich wieder mitten in einem neuen Fall …",
               "veröffentlichungsdatum" : "2011-12-20",
-              "sprecher" : [
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/10/metadata.json",
@@ -420,35 +421,35 @@
               "autor" : "Kari Erlhoff",
               "beschreibung" : "Kellys Tante wird erpresst und die drei ??? sollen bei der Übergabe des Geldes behilflich sein. Aber in dem Motel, in dem Peter und Kelly absteigen, passieren merkwürdige Dinge …",
               "veröffentlichungsdatum" : "2011-12-22",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Kelly",
-                  "Juliane Szalay"
-                ],
-                [
-                  "Norman",
-                  "Eckart Dux"
-                ],
-                [
-                  "Frau",
-                  "Anja Topf"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Kelly",
+                  "sprecher" : "Juliane Szalay"
+                },
+                {
+                  "rolle" : "Norman",
+                  "sprecher" : "Eckart Dux"
+                },
+                {
+                  "rolle" : "Frau",
+                  "sprecher" : "Anja Topf"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/11/metadata.json",
@@ -461,43 +462,43 @@
               "autor" : "Hendrik Buchna",
               "beschreibung" : "Rocky Beach versinkt im Schnee. Und zu allem Überfluss treibt gerade jetzt, wo die Polizei mehr oder weniger handlungsunfähig ist, ein krimineller Weihnachtsmann in der Stadt sein Unwesen …",
               "veröffentlichungsdatum" : "2011-12-24",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Inspektor Cotta",
-                  "Holger Mahlich"
-                ],
-                [
-                  "Mr. Darrow",
-                  "Joachim Kappl"
-                ],
-                [
-                  "Mann 1",
-                  "Patrick Bach"
-                ],
-                [
-                  "Mann 2",
-                  "Frank Meyer-Brockmann"
-                ],
-                [
-                  "Mann 3",
-                  "Roy Martens"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Inspektor Cotta",
+                  "sprecher" : "Holger Mahlich"
+                },
+                {
+                  "rolle" : "Mr. Darrow",
+                  "sprecher" : "Joachim Kappl"
+                },
+                {
+                  "rolle" : "Mann 1",
+                  "sprecher" : "Patrick Bach"
+                },
+                {
+                  "rolle" : "Mann 2",
+                  "sprecher" : "Frank Meyer-Brockmann"
+                },
+                {
+                  "rolle" : "Mann 3",
+                  "sprecher" : "Roy Martens"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/12/metadata.json",
@@ -570,51 +571,52 @@
                   "end" : 1596747
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Emily White",
-                  "Sabine Hahn"
-                ],
-                [
-                  "Judy Fradkin",
-                  "Ursula Heyer"
-                ],
-                [
-                  "Aladin",
-                  "Heidi Schaffrath"
-                ],
-                [
-                  "Aschenputtel",
-                  "Regina Lemnitz"
-                ],
-                [
-                  "Prinzessin",
-                  "Renate Pichler"
-                ],
-                [
-                  "Rotkäppchen",
-                  "Angela Stresemann"
-                ],
-                [
-                  "Meerjungfrau",
-                  "Pamela Punti [Heikedine Körting]"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Emily White",
+                  "sprecher" : "Sabine Hahn"
+                },
+                {
+                  "rolle" : "Judy Fradkin",
+                  "sprecher" : "Ursula Heyer"
+                },
+                {
+                  "rolle" : "Aladin",
+                  "sprecher" : "Heidi Schaffrath"
+                },
+                {
+                  "rolle" : "Aschenputtel",
+                  "sprecher" : "Regina Lemnitz"
+                },
+                {
+                  "rolle" : "Prinzessin",
+                  "sprecher" : "Renate Pichler"
+                },
+                {
+                  "rolle" : "Rotkäppchen",
+                  "sprecher" : "Angela Stresemann"
+                },
+                {
+                  "rolle" : "Meerjungfrau",
+                  "sprecher" : "Heikedine Körting",
+                  "pseudonym" : "Pamela Punti"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/metadata.json",
@@ -643,43 +645,43 @@
                   "end" : 1477173
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Mr. Andrews",
-                  "Henry König"
-                ],
-                [
-                  "Mrs. Andrews",
-                  "Konstanze Ullmer"
-                ],
-                [
-                  "Arzt",
-                  "Erik Schäffler"
-                ],
-                [
-                  "Mrs. Wallace",
-                  "Angela Stresemann"
-                ],
-                [
-                  "Bobby",
-                  "Merete Brettschneider"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Mr. Andrews",
+                  "sprecher" : "Henry König"
+                },
+                {
+                  "rolle" : "Mrs. Andrews",
+                  "sprecher" : "Konstanze Ullmer"
+                },
+                {
+                  "rolle" : "Arzt",
+                  "sprecher" : "Erik Schäffler"
+                },
+                {
+                  "rolle" : "Mrs. Wallace",
+                  "sprecher" : "Angela Stresemann"
+                },
+                {
+                  "rolle" : "Bobby",
+                  "sprecher" : "Merete Brettschneider"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/metadata.json",
@@ -749,31 +751,32 @@
                   "end" : 1574187
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Onkel Titus",
-                  "Hans Meinhardt [Andreas E. Beurmann]"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/metadata.json",
@@ -802,47 +805,47 @@
                   "end" : 1174080
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Croupier",
-                  "Gosta Liptow"
-                ],
-                [
-                  "Carl Hopkins, Physiker",
-                  "Ben Hecker"
-                ],
-                [
-                  "Miller, Schiffsdetektiv",
-                  "Michael Grimm"
-                ],
-                [
-                  "Kapitän Sherwood",
-                  "Horst Naumann"
-                ],
-                [
-                  "Theodore Quaid",
-                  "Dietrich Adam"
-                ],
-                [
-                  "Jamie Peterson, Barmann",
-                  "Patrick Bach"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Croupier",
+                  "sprecher" : "Gosta Liptow"
+                },
+                {
+                  "rolle" : "Carl Hopkins, Physiker",
+                  "sprecher" : "Ben Hecker"
+                },
+                {
+                  "rolle" : "Miller, Schiffsdetektiv",
+                  "sprecher" : "Michael Grimm"
+                },
+                {
+                  "rolle" : "Kapitän Sherwood",
+                  "sprecher" : "Horst Naumann"
+                },
+                {
+                  "rolle" : "Theodore Quaid",
+                  "sprecher" : "Dietrich Adam"
+                },
+                {
+                  "rolle" : "Jamie Peterson, Barmann",
+                  "sprecher" : "Patrick Bach"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/metadata.json",
@@ -912,43 +915,45 @@
                   "end" : 1389800
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Onkel Titus",
-                  "Hans Meinhardt [Andreas E. Beurmann]"
-                ],
-                [
-                  "Tante Mathilda",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Handerson",
-                  "Wolfgang Rositzka"
-                ],
-                [
-                  "Diego",
-                  "Stephan Benson"
-                ],
-                [
-                  "Mercedes",
-                  "Wanda Osten [Hella von der Osten-Sacken]"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Handerson",
+                  "sprecher" : "Wolfgang Rositzka"
+                },
+                {
+                  "rolle" : "Diego",
+                  "sprecher" : "Stephan Benson"
+                },
+                {
+                  "rolle" : "Mercedes",
+                  "sprecher" : "Hella von der Osten-Sacken",
+                  "pseudonym" : "Wanda Osten"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/metadata.json",
@@ -977,39 +982,40 @@
                   "end" : 1409027
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Nayeli",
-                  "Stefan Brönneke"
-                ],
-                [
-                  "Barker",
-                  "Ben Hecker"
-                ],
-                [
-                  "Onkel Titus",
-                  "Hans Meinhardt [Andreas E. Beurmann]"
-                ],
-                [
-                  "Off-Sprecherin",
-                  "Claudia Stocksieker"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Nayeli",
+                  "sprecher" : "Stefan Brönneke"
+                },
+                {
+                  "rolle" : "Barker",
+                  "sprecher" : "Ben Hecker"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                },
+                {
+                  "rolle" : "Off-Sprecherin",
+                  "sprecher" : "Claudia Stocksieker"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/metadata.json",
@@ -1038,35 +1044,36 @@
                   "end" : 1099640
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Onkel Titus",
-                  "Hans Meinhardt [Andreas E. Beurmann]"
-                ],
-                [
-                  "Ian Carew",
-                  "Sascha Draeger"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                },
+                {
+                  "rolle" : "Ian Carew",
+                  "sprecher" : "Sascha Draeger"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/metadata.json",
@@ -1163,31 +1170,31 @@
                   "end" : 950800
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Hüne",
-                  "Johannes Semm"
-                ],
-                [
-                  "Marvin Gray",
-                  "Horst Stark"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Hüne",
+                  "sprecher" : "Johannes Semm"
+                },
+                {
+                  "rolle" : "Marvin Gray",
+                  "sprecher" : "Horst Stark"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/1/metadata.json",
@@ -1216,51 +1223,51 @@
                   "end" : 1198507
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Nancy McMonigal",
-                  "Gerlinde Dillge"
-                ],
-                [
-                  "Tom",
-                  "Wolfgang Rositzka"
-                ],
-                [
-                  "Rod",
-                  "Herbert Tennigkeit"
-                ],
-                [
-                  "Joe",
-                  "Olaf Reichmann"
-                ],
-                [
-                  "Ben",
-                  "Stephan Chrzescinski"
-                ],
-                [
-                  "Mariann",
-                  "Simone Ritscher"
-                ],
-                [
-                  "TV-Sprecher",
-                  "Holger Wemhoff"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Nancy McMonigal",
+                  "sprecher" : "Gerlinde Dillge"
+                },
+                {
+                  "rolle" : "Tom",
+                  "sprecher" : "Wolfgang Rositzka"
+                },
+                {
+                  "rolle" : "Rod",
+                  "sprecher" : "Herbert Tennigkeit"
+                },
+                {
+                  "rolle" : "Joe",
+                  "sprecher" : "Olaf Reichmann"
+                },
+                {
+                  "rolle" : "Ben",
+                  "sprecher" : "Stephan Chrzescinski"
+                },
+                {
+                  "rolle" : "Mariann",
+                  "sprecher" : "Simone Ritscher"
+                },
+                {
+                  "rolle" : "TV-Sprecher",
+                  "sprecher" : "Holger Wemhoff"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/2/metadata.json",
@@ -1284,31 +1291,31 @@
                   "end" : 1502960
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Malcolm Fever",
-                  "Tilo Schmitz"
-                ],
-                [
-                  "Lucy Hopkins",
-                  "Topsy Küppers"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Malcolm Fever",
+                  "sprecher" : "Tilo Schmitz"
+                },
+                {
+                  "rolle" : "Lucy Hopkins",
+                  "sprecher" : "Topsy Küppers"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/3/metadata.json",
@@ -1388,51 +1395,52 @@
                   "end" : 1748867
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Onkel Titus",
-                  "Hans Meinhardt [Andreas E. Beurmann]"
-                ],
-                [
-                  "Tante Mathilda",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Professor Selby",
-                  "Claus Wilcke"
-                ],
-                [
-                  "Oberpriesterin",
-                  "Elga Schütz"
-                ],
-                [
-                  "Kevin",
-                  "Patrick Mölleken"
-                ],
-                [
-                  "Mann in Kutte",
-                  "Rüdiger Hellmann"
-                ],
-                [
-                  "Radio",
-                  "Wilhelm Wieben"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Professor Selby",
+                  "sprecher" : "Claus Wilcke"
+                },
+                {
+                  "rolle" : "Oberpriesterin",
+                  "sprecher" : "Elga Schütz"
+                },
+                {
+                  "rolle" : "Kevin",
+                  "sprecher" : "Patrick Mölleken"
+                },
+                {
+                  "rolle" : "Mann in Kutte",
+                  "sprecher" : "Rüdiger Hellmann"
+                },
+                {
+                  "rolle" : "Radio",
+                  "sprecher" : "Wilhelm Wieben"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/4/metadata.json",
@@ -1461,31 +1469,31 @@
                   "end" : 1136386
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Mr. Tilton",
-                  "Christian Senger"
-                ],
-                [
-                  "Mr. Walsh",
-                  "Christian Rudolf"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Mr. Tilton",
+                  "sprecher" : "Christian Senger"
+                },
+                {
+                  "rolle" : "Mr. Walsh",
+                  "sprecher" : "Christian Rudolf"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/5/metadata.json",
@@ -1519,51 +1527,51 @@
                   "end" : 1684120
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Weise Frau",
-                  "Dorothea Hagena"
-                ],
-                [
-                  "Kelly",
-                  "Juliane Szalay"
-                ],
-                [
-                  "Patrick",
-                  "Nicolas König"
-                ],
-                [
-                  "Samuel",
-                  "Johannes Semm"
-                ],
-                [
-                  "Kenneth",
-                  "Olaf Reichmann"
-                ],
-                [
-                  "Liz Zapata",
-                  "Merete Brettschneider"
-                ],
-                [
-                  "Skinny Norris",
-                  "Michael Harck"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Weise Frau",
+                  "sprecher" : "Dorothea Hagena"
+                },
+                {
+                  "rolle" : "Kelly",
+                  "sprecher" : "Juliane Szalay"
+                },
+                {
+                  "rolle" : "Patrick",
+                  "sprecher" : "Nicolas König"
+                },
+                {
+                  "rolle" : "Samuel",
+                  "sprecher" : "Johannes Semm"
+                },
+                {
+                  "rolle" : "Kenneth",
+                  "sprecher" : "Olaf Reichmann"
+                },
+                {
+                  "rolle" : "Liz Zapata",
+                  "sprecher" : "Merete Brettschneider"
+                },
+                {
+                  "rolle" : "Skinny Norris",
+                  "sprecher" : "Michael Harck"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/6/metadata.json",
@@ -1665,19 +1673,19 @@
                   "end" : 2240920
                 }
               ],
-              "sprecher" : [
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/metadata.json",
@@ -1706,35 +1714,36 @@
                   "end" : 1855920
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Helen",
-                  "Balancinha Blanc [Dorette Hugo]"
-                ],
-                [
-                  "Ellen",
-                  "Dorette Hugo"
-                ],
-                [
-                  "Vater",
-                  "Douglas Welbat"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Helen",
+                  "sprecher" : "Dorette Hugo",
+                  "pseudonym" : "Balancinha Blanc"
+                },
+                {
+                  "rolle" : "Ellen",
+                  "sprecher" : "Dorette Hugo"
+                },
+                {
+                  "rolle" : "Vater",
+                  "sprecher" : "Douglas Welbat"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/metadata.json",
@@ -1804,47 +1813,47 @@
                   "end" : 1889653
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Skinny Norris",
-                  "Michael Harck"
-                ],
-                [
-                  "Marc Kingstone",
-                  "Rainer Brandt"
-                ],
-                [
-                  "Aaron Kingstone",
-                  "Tommi Piper"
-                ],
-                [
-                  "Sarah",
-                  "Christiane Leuchtmann"
-                ],
-                [
-                  "Albert",
-                  "Franzisko Löwe"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Skinny Norris",
+                  "sprecher" : "Michael Harck"
+                },
+                {
+                  "rolle" : "Marc Kingstone",
+                  "sprecher" : "Rainer Brandt"
+                },
+                {
+                  "rolle" : "Aaron Kingstone",
+                  "sprecher" : "Tommi Piper"
+                },
+                {
+                  "rolle" : "Sarah",
+                  "sprecher" : "Christiane Leuchtmann"
+                },
+                {
+                  "rolle" : "Albert",
+                  "sprecher" : "Franzisko Löwe"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/metadata.json",
@@ -1873,59 +1882,59 @@
                   "end" : 1767387
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Kelly Madigan",
-                  "Juliane Szalay"
-                ],
-                [
-                  "Mrs. McGee",
-                  "Alice Krimmel"
-                ],
-                [
-                  "Toby",
-                  "A. Stengelin"
-                ],
-                [
-                  "Mrs. Wells",
-                  "Heidi Schaffrath"
-                ],
-                [
-                  "Junge",
-                  "Linus Tauber"
-                ],
-                [
-                  "Mädchen",
-                  "Katinka Jaekel"
-                ],
-                [
-                  "Ericsson",
-                  "Detlef Tams"
-                ],
-                [
-                  "Sprecher/Moderator",
-                  "Oliver Böttcher"
-                ],
-                [
-                  "Tarek Shabana",
-                  "Werner Wilkening"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Kelly Madigan",
+                  "sprecher" : "Juliane Szalay"
+                },
+                {
+                  "rolle" : "Mrs. McGee",
+                  "sprecher" : "Alice Krimmel"
+                },
+                {
+                  "rolle" : "Toby",
+                  "sprecher" : "A. Stengelin"
+                },
+                {
+                  "rolle" : "Mrs. Wells",
+                  "sprecher" : "Heidi Schaffrath"
+                },
+                {
+                  "rolle" : "Junge",
+                  "sprecher" : "Linus Tauber"
+                },
+                {
+                  "rolle" : "Mädchen",
+                  "sprecher" : "Katinka Jaekel"
+                },
+                {
+                  "rolle" : "Ericsson",
+                  "sprecher" : "Detlef Tams"
+                },
+                {
+                  "rolle" : "Sprecher/Moderator",
+                  "sprecher" : "Oliver Böttcher"
+                },
+                {
+                  "rolle" : "Tarek Shabana",
+                  "sprecher" : "Werner Wilkening"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/metadata.json",
@@ -1995,55 +2004,55 @@
                   "end" : 2256800
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tasha",
-                  "Victoria Zöller"
-                ],
-                [
-                  "Domino Laverna",
-                  "Sabine Hahn"
-                ],
-                [
-                  "Biff Rodgers, Reporter",
-                  "Daniel Schütter"
-                ],
-                [
-                  "Lesley Dimple",
-                  "Ann Montenbruck"
-                ],
-                [
-                  "Zeus Zenon Johnson",
-                  "Michael Prelle"
-                ],
-                [
-                  "Computer",
-                  "Peter Bayer"
-                ],
-                [
-                  "Off-Sprecher",
-                  "Frank Roder"
-                ],
-                [
-                  "Sprecher",
-                  "Andreas Birnbaum"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tasha",
+                  "sprecher" : "Victoria Zöller"
+                },
+                {
+                  "rolle" : "Domino Laverna",
+                  "sprecher" : "Sabine Hahn"
+                },
+                {
+                  "rolle" : "Biff Rodgers, Reporter",
+                  "sprecher" : "Daniel Schütter"
+                },
+                {
+                  "rolle" : "Lesley Dimple",
+                  "sprecher" : "Ann Montenbruck"
+                },
+                {
+                  "rolle" : "Zeus Zenon Johnson",
+                  "sprecher" : "Michael Prelle"
+                },
+                {
+                  "rolle" : "Computer",
+                  "sprecher" : "Peter Bayer"
+                },
+                {
+                  "rolle" : "Off-Sprecher",
+                  "sprecher" : "Frank Roder"
+                },
+                {
+                  "rolle" : "Sprecher",
+                  "sprecher" : "Andreas Birnbaum"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/metadata.json",
@@ -2072,35 +2081,36 @@
                   "end" : 1718507
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas, Erster Detektiv",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw, Zweiter Detektiv",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews, Recherchen und Archiv",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Blacky",
-                  "Pamela Punti [Heikedine Körting]"
-                ],
-                [
-                  "Kassiererin",
-                  "Angela Stresemann"
-                ],
-                [
-                  "Inspektor Cotta",
-                  "Holger Mahlich"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Blacky",
+                  "sprecher" : "Heikedine Körting",
+                  "pseudonym" : "Pamela Punti"
+                },
+                {
+                  "rolle" : "Kassiererin",
+                  "sprecher" : "Angela Stresemann"
+                },
+                {
+                  "rolle" : "Inspektor Cotta",
+                  "sprecher" : "Holger Mahlich"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/metadata.json",

--- a/data/Master_Serie.json
+++ b/data/Master_Serie.json
@@ -428,7 +428,7 @@
           "Alexander Körting"
         ],
         [
-          "Hauptkommissar Reynolds",
+          "Kommissar Reynolds",
           "Horst Frank"
         ],
         [
@@ -527,7 +527,7 @@
           "Stephan Chrzescinski"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -635,7 +635,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -651,7 +651,7 @@
           "Richard Lauffen"
         ],
         [
-          "Hauptkommissar Reynolds",
+          "Kommissar Reynolds",
           "Horst Frank"
         ],
         [
@@ -869,7 +869,7 @@
           "Alexander Stubbe [Peter Kirchberger]"
         ],
         [
-          "Hauptkommissar Reynolds",
+          "Kommissar Reynolds",
           "Horst Frank"
         ],
         [
@@ -972,11 +972,11 @@
           "Andreas Fröhlich"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -1008,7 +1008,7 @@
           "Werner Cartano"
         ],
         [
-          "Hauptkommissar Reynolds",
+          "Kommissar Reynolds",
           "Horst Frank"
         ]
       ],
@@ -1087,7 +1087,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -1202,7 +1202,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -1338,11 +1338,11 @@
           "Albert Giro [Wolfgang Kubach]"
         ],
         [
-          "Hauptkommissar Reynolds",
+          "Kommissar Reynolds",
           "Horst Frank"
         ],
         [
-          "Mr Jankins",
+          "Mr. Jankins",
           "Lothar Zibell"
         ]
       ],
@@ -1421,7 +1421,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -1449,7 +1449,7 @@
           "Gernot Endemann"
         ],
         [
-          "Hauptkommissar Reynolds",
+          "Kommissar Reynolds",
           "Horst Frank"
         ],
         [
@@ -1655,11 +1655,11 @@
           "Andreas Fröhlich"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -1881,7 +1881,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Hauptkommissar Reynolds",
+          "Kommissar Reynolds",
           "Horst Frank"
         ],
         [
@@ -2221,7 +2221,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Hauptkommissar Reynolds",
+          "Kommissar Reynolds",
           "Horst Frank"
         ],
         [
@@ -2578,7 +2578,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Skinny",
+          "Skinny Norris",
           "Andreas von der Meden"
         ],
         [
@@ -3713,7 +3713,7 @@
           "Wolfgang Kubach"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Peter Kirchberger"
         ],
         [
@@ -4165,7 +4165,7 @@
           "Günter Pfitzmann"
         ],
         [
-          "Kommissar",
+          "Kommissar Reynolds",
           "Günther Flesch"
         ],
         [
@@ -4478,7 +4478,7 @@
           "Andreas von der Meden"
         ],
         [
-          "Hauptkomm. Reynolds",
+          "Kommissar Reynolds",
           "Günther Flesch"
         ],
         [
@@ -4831,7 +4831,7 @@
           "Eric Vaessen"
         ],
         [
-          "Kom. Reynolds",
+          "Kommissar Reynolds",
           "Wolfgang Draeger"
         ],
         [
@@ -5069,7 +5069,7 @@
           "Manfred Bendixen [Günter König]"
         ],
         [
-          "Mathilda",
+          "Tante Mathilda",
           "Ursula Vogel"
         ]
       ],
@@ -5370,7 +5370,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Herr Andrews",
+          "Mr. Andrews",
           "Günter König"
         ],
         [
@@ -5605,7 +5605,7 @@
           "Fred Maire"
         ],
         [
-          "Herr Andrews",
+          "Mr. Andrews",
           "Günter König"
         ]
       ],
@@ -5793,7 +5793,7 @@
           "Gerd Baltus"
         ],
         [
-          "Sax",
+          "Sax Sandler",
           "Andreas Mannkopff"
         ],
         [
@@ -6369,11 +6369,11 @@
           "Arthur Brauss"
         ],
         [
-          "Morton, Chauffeur",
+          "Morton",
           "Andreas von der Meden"
         ],
         [
-          "Cotta, Polizeiinspektor",
+          "Inspektor Cotta",
           "Michael Poelchau"
         ],
         [
@@ -7157,7 +7157,7 @@
           "Karin Lieneweg"
         ],
         [
-          "Morton, Chauffeur",
+          "Morton",
           "Andreas von der Meden"
         ],
         [
@@ -7417,11 +7417,11 @@
           "Francesca Chiavon"
         ],
         [
-          "1. Italiener",
+          "Italiener 1",
           "Marcello Grassi"
         ],
         [
-          "2. Italiener",
+          "Italiener 2",
           "Luigi Pane"
         ]
       ],
@@ -7529,11 +7529,11 @@
           "Lutz Schnell"
         ],
         [
-          "1. Polizist",
+          "Polizist 1",
           "Boris von Sychowski"
         ],
         [
-          "2. Polizist",
+          "Polizist 2",
           "Frank Meyer-Brockmann"
         ]
       ],
@@ -7621,11 +7621,11 @@
           "Antje Roosch"
         ],
         [
-          "1. Mann",
+          "Mann 1",
           "Nicolas König"
         ],
         [
-          "2. Mann",
+          "Mann 2",
           "Lutz Schnell"
         ]
       ],
@@ -7749,7 +7749,7 @@
           "Heikedine Körting"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ]
       ],
@@ -8101,15 +8101,15 @@
           "Dieter Ohlendiek"
         ],
         [
-          "2. Wächter",
+          "Wächter 2",
           "Michael Lott"
         ],
         [
-          "1. Polizist",
+          "Polizist 1",
           "Torben Liebrecht"
         ],
         [
-          "2. Polizist",
+          "Polizist 2",
           "Rene Spiegelberger"
         ],
         [
@@ -8305,11 +8305,11 @@
           "Andreas Fröhlich"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -8541,7 +8541,7 @@
           "Beate Hasenau"
         ],
         [
-          "Dr. Franklin",
+          "Clarissa Franklin",
           "Judy Winter"
         ],
         [
@@ -8663,11 +8663,11 @@
           "Klaus-Peter Kaehler"
         ],
         [
-          "1. Mann",
+          "Mann 1",
           "Helmut Ahner"
         ],
         [
-          "2. Mann",
+          "Mann 2",
           "Richard Ems"
         ],
         [
@@ -8745,11 +8745,11 @@
           "Andreas Fröhlich"
         ],
         [
-          "Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
-          "Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -8757,7 +8757,7 @@
           "Manfred Steffen"
         ],
         [
-          "Morton, Chauffeur",
+          "Morton",
           "Andreas von der Meden"
         ],
         [
@@ -9081,7 +9081,7 @@
           "Carlos Goiach"
         ],
         [
-          "Papagei",
+          "Blacky",
           "Heikedine Körting"
         ]
       ],
@@ -9331,11 +9331,11 @@
           "Andreas Fröhlich"
         ],
         [
-          "Jelena",
+          "Jelena Charkova",
           "Alexandra Doerk"
         ],
         [
-          "Mr. Charkov, Jelenas Vater",
+          "Mr. Charkov",
           "Klaus Dittmann"
         ],
         [
@@ -10173,11 +10173,11 @@
           "Lothar Grützner"
         ],
         [
-          "Mrs. Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -10251,7 +10251,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -10353,7 +10353,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Jelena Charkov",
+          "Jelena Charkova",
           "Alexandra Doerk"
         ],
         [
@@ -10888,7 +10888,7 @@
               "Andreas von der Meden"
             ],
             [
-              "Jelena",
+              "Jelena Charkova",
               "Alexandra Doerk"
             ],
             [
@@ -10977,7 +10977,7 @@
               "Andreas von der Meden"
             ],
             [
-              "Jelena",
+              "Jelena Charkova",
               "Alexandra Doerk"
             ],
             [
@@ -11074,7 +11074,7 @@
               "Andreas Fröhlich"
             ],
             [
-              "Jelena",
+              "Jelena Charkova",
               "Alexandra Doerk"
             ],
             [
@@ -11144,7 +11144,7 @@
           "Andreas von der Meden"
         ],
         [
-          "Jelena",
+          "Jelena Charkova",
           "Alexandra Doerk"
         ],
         [
@@ -11462,7 +11462,7 @@
           "Dorette Hugo"
         ],
         [
-          "Victor Hugenay",
+          "Hugenay",
           "Albert Giro [Wolfgang Kubach]"
         ],
         [
@@ -11586,7 +11586,7 @@
           "Holger Mahlich"
         ],
         [
-          "Mrs. Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ]
       ],
@@ -11678,7 +11678,7 @@
           "Nadja Reichardt"
         ],
         [
-          "Mr Harry Falkner",
+          "Mr. Harry Falkner",
           "Wolfgang Hartmann"
         ],
         [
@@ -11798,11 +11798,11 @@
           "Manuela Dahm"
         ],
         [
-          "1. Sanitäter",
+          "Sanitäter 1",
           "Robert Missler"
         ],
         [
-          "2. Sanitäter",
+          "Sanitäter 2",
           "Hartmut Kollakowsky"
         ],
         [
@@ -11914,7 +11914,7 @@
           "Prof. Dr. Zhu"
         ],
         [
-          "Mr Zhang",
+          "Mr. Zhang",
           "Ingo Feder"
         ],
         [
@@ -12640,7 +12640,7 @@
           "Madeleine Weingart"
         ],
         [
-          "Mrs Silverstone",
+          "Mrs. Silverstone",
           "Katrin Wasow"
         ],
         [
@@ -12776,7 +12776,7 @@
           "Hannelore Wüst"
         ],
         [
-          "Mrs Willow",
+          "Mrs. Willow",
           "Elga Schütz"
         ],
         [
@@ -12923,15 +12923,15 @@
           "Ingeborg Kallweit"
         ],
         [
-          "Mr Horowitz",
+          "Mr. Horowitz",
           "Rolf Jülich"
         ],
         [
-          "Mr Rothman",
+          "Mr. Rothman",
           "Peter Weis"
         ],
         [
-          "Mrs O'Rien",
+          "Mrs. O'Rien",
           "Victoria Trauttmansdorff"
         ]
       ],
@@ -13147,7 +13147,7 @@
           "Holger Mahlich"
         ],
         [
-          "Godwin",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -13422,7 +13422,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -13561,7 +13561,7 @@
           "Marco Sand"
         ],
         [
-          "Mrs Bancroft",
+          "Mrs. Bancroft",
           "Ilka Kirsch"
         ],
         [
@@ -13682,7 +13682,7 @@
           "Susanne Sternberg"
         ],
         [
-          "Jelena",
+          "Jelena Charkova",
           "Alexandra Doerk"
         ],
         [
@@ -13787,7 +13787,7 @@
           "Nick Seidensticker"
         ],
         [
-          "Mr Campbell",
+          "Mr. Campbell",
           "Gerhart Hinze"
         ],
         [
@@ -13803,11 +13803,11 @@
           "Thorsten Weber"
         ],
         [
-          "Mr Kingsley",
+          "Mr. Kingsley",
           "Herbert Tennigkeit"
         ],
         [
-          "Mrs Kingsley",
+          "Mrs. Kingsley",
           "Tina Rehfeld-Wildmann"
         ],
         [
@@ -14146,15 +14146,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -14279,15 +14279,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -14339,7 +14339,7 @@
               "Nick Heidfeld"
             ],
             [
-              "Onkel Titus Jonas",
+              "Onkel Titus",
               "Hans Meinhardt [Andreas E. Beurmann]"
             ]
           ],
@@ -14442,15 +14442,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -14494,11 +14494,11 @@
               "Frank Thannhäuser"
             ],
             [
-              "Onkel Titus Jonas",
+              "Onkel Titus",
               "Hans Meinhardt [Andreas E. Beurmann]"
             ],
             [
-              "Tante Mathilda Jonas",
+              "Tante Mathilda",
               "Karin Lieneweg"
             ],
             [
@@ -14524,15 +14524,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -14540,11 +14540,11 @@
           "Jannik Endemann"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
@@ -14737,7 +14737,7 @@
           "Lothar Grützner"
         ],
         [
-          "Papagei",
+          "Blacky",
           "Heikedine Körting"
         ]
       ],
@@ -14973,7 +14973,7 @@
           "Andreas Fröhlich"
         ],
         [
-          "Mrs Bennett",
+          "Mrs. Bennett",
           "Renate Pichler"
         ],
         [
@@ -14997,7 +14997,7 @@
           "Gosta Liptow"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ]
       ],
@@ -15314,11 +15314,11 @@
           "Lutz Herkenrath"
         ],
         [
-          "1. Polizist",
+          "Polizist 1",
           "Robert Missler"
         ],
         [
-          "2. Polizist",
+          "Polizist 2",
           "Edgar Hoppe"
         ],
         [
@@ -15786,15 +15786,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -16060,15 +16060,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -16201,15 +16201,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -16326,15 +16326,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -16438,19 +16438,19 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
-          "Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -16585,15 +16585,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -16722,19 +16722,19 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -16871,15 +16871,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -17018,15 +17018,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -17151,19 +17151,19 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -17187,7 +17187,7 @@
           "Holger Mahlich"
         ],
         [
-          "Godwin",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -17279,15 +17279,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -17427,15 +17427,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -17564,15 +17564,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -17612,7 +17612,7 @@
           "Holger Mahlich"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -17693,15 +17693,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -17729,11 +17729,11 @@
           "Dagmar Dreke"
         ],
         [
-          "1. Mann",
+          "Mann 1",
           "Tetje Mierendorf"
         ],
         [
-          "2. Mann",
+          "Mann 2",
           "Gosta Liptow"
         ]
       ],
@@ -17831,15 +17831,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -17986,15 +17986,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -18153,15 +18153,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -18299,15 +18299,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -18389,15 +18389,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -18619,15 +18619,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -18779,15 +18779,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -18823,11 +18823,11 @@
           "Utz Richter"
         ],
         [
-          "1. Mann",
+          "Mann 1",
           "Rasmus Borowski"
         ],
         [
-          "2. Mann",
+          "Mann 2",
           "Joachim Kappl"
         ],
         [
@@ -18839,7 +18839,7 @@
           "Rainer Schmitt"
         ],
         [
-          "Fernsehr-Sprecher",
+          "Fernsehe-Sprecher",
           "Jannik Schümann"
         ],
         [
@@ -18930,15 +18930,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -19087,15 +19087,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -19103,7 +19103,7 @@
           "Holger Mahlich"
         ],
         [
-          "Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -19275,15 +19275,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -19426,15 +19426,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -19562,15 +19562,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -19606,7 +19606,7 @@
           "Mike Olsowski"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -19703,15 +19703,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -19751,19 +19751,19 @@
           "Konstanze Ullmer"
         ],
         [
-          "1. Mann",
+          "Mann 1",
           "Olaf Kreutzenbeck"
         ],
         [
-          "2. Mann",
+          "Mann 2",
           "Rainer Fritzsche"
         ],
         [
-          "3. Mann",
+          "Mann 3",
           "Claus Fuchs"
         ],
         [
-          "4. Mann",
+          "Mann 4",
           "Jannik Endemann"
         ]
       ],
@@ -19846,15 +19846,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -19882,11 +19882,11 @@
           "Peter Weis"
         ],
         [
-          "1. Mann",
+          "Mann 1",
           "Robin Brosch"
         ],
         [
-          "2. Mann",
+          "Mann 2",
           "Gerhart Hinze"
         ]
       ],
@@ -19959,15 +19959,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -20007,7 +20007,7 @@
           "Holger Mahlich"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -20109,15 +20109,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -20240,15 +20240,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -20367,15 +20367,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -20461,15 +20461,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -20592,15 +20592,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -20717,15 +20717,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -20848,15 +20848,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -20872,7 +20872,7 @@
           "Mogens von Gadow"
         ],
         [
-          "Miss Woodrow",
+          "Mrs. Woodrow",
           "Carin Abicht"
         ],
         [
@@ -20994,15 +20994,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -21140,15 +21140,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -21279,15 +21279,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -21429,15 +21429,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -21473,11 +21473,11 @@
           "Ulrich Potofski"
         ],
         [
-          "1. Mann",
+          "Mann 1",
           "Achim Schülke"
         ],
         [
-          "2. Mann",
+          "Mann 2",
           "Fabian Harloff"
         ],
         [
@@ -21588,15 +21588,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -21628,7 +21628,7 @@
           "Lutz Harder"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -21714,15 +21714,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -21831,15 +21831,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -21859,7 +21859,7 @@
           "Till Demtrøder"
         ],
         [
-          "Inspektor Cottahol",
+          "Inspektor Cotta",
           "Holger Mahlich"
         ],
         [
@@ -21961,15 +21961,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -22033,11 +22033,11 @@
               "Klaus Krückemeyer"
             ],
             [
-              "1. Polizist",
+              "Polizist 1",
               "Tim Kreuer"
             ],
             [
-              "2. Polizist",
+              "Polizist 2",
               "Jesse Grimm"
             ],
             [
@@ -22114,15 +22114,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -22238,15 +22238,15 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -22282,7 +22282,7 @@
               "Heinz Lieven"
             ],
             [
-              "3. Polizist",
+              "Polizist 3",
               "Wolfgang Kaven"
             ],
             [
@@ -22311,15 +22311,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -22383,11 +22383,11 @@
           "Klaus Krückemeyer"
         ],
         [
-          "1. Polizist",
+          "Polizist 1",
           "Tim Kreuer"
         ],
         [
-          "2. Polizist",
+          "Polizist 2",
           "Jesse Grimm"
         ],
         [
@@ -22435,7 +22435,7 @@
           "Heinz Lieven"
         ],
         [
-          "3. Polizist",
+          "Polizist 3",
           "Wolfgang Kaven"
         ],
         [
@@ -22524,15 +22524,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -22641,15 +22641,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -22758,15 +22758,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -22862,15 +22862,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -23014,7 +23014,7 @@
           "Holger Mahlich"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -23150,11 +23150,11 @@
           "Hugo Richert"
         ],
         [
-          "1. Junge",
+          "Junge 1",
           "Louis Körting"
         ],
         [
-          "2. Junge",
+          "Junge 2",
           "Henrik Bichels"
         ],
         [
@@ -23245,7 +23245,7 @@
           "Holger Mahlich"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -24078,7 +24078,7 @@
           "Reinhilt Schneider"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -24504,11 +24504,11 @@
           "Barbara Schipper"
         ],
         [
-          "1. Chinese",
+          "Chinese 1",
           "Frank Richartz"
         ],
         [
-          "2. Chinese",
+          "Chinese 2",
           "Erik Schäffler"
         ],
         [
@@ -24880,11 +24880,11 @@
           "Erik Schäffler"
         ],
         [
-          "1. Mann",
+          "Mann 1",
           "Ingo Menowski"
         ],
         [
-          "2. Mann",
+          "Mann 2",
           "Riko Tauber"
         ]
       ],
@@ -24979,7 +24979,7 @@
           "Andreas Birnbaum"
         ],
         [
-          "Frank Corman /Mr Giggles",
+          "Frank Corman / Mr Giggles",
           "Lutz Mackensy"
         ],
         [
@@ -25722,7 +25722,7 @@
           "Rüdiger Schulzki"
         ],
         [
-          "Inspector Cotta",
+          "Inspektor Cotta",
           "Holger Mahlich"
         ],
         [
@@ -26639,7 +26639,7 @@
           "Holger Mahlich"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -26838,11 +26838,11 @@
           "Werner Wilkening"
         ],
         [
-          "Offizier der Küstenwache (1)",
+          "Offizier der Küstenwache 1",
           "Thorsten Laussch"
         ],
         [
-          "Offizier der Küstenwache (2)",
+          "Offizier der Küstenwache 2",
           "Andreas Birnbaum"
         ]
       ],
@@ -27131,11 +27131,11 @@
           "Lovis Harloff"
         ],
         [
-          "Mrs Carmichael",
+          "Mrs. Carmichael",
           "Anne Moll"
         ],
         [
-          "Mr Jeremiah Carmichael",
+          "Mr. Jeremiah Carmichael",
           "Peter Bieringer"
         ],
         [
@@ -27622,7 +27622,7 @@
           "Carolyn Walsh"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [
@@ -27860,7 +27860,7 @@
           "Heikedine Körting"
         ],
         [
-          "Godween",
+          "Goodween",
           "André Minninger"
         ],
         [

--- a/data/Master_Serie.json
+++ b/data/Master_Serie.json
@@ -49,55 +49,57 @@
           "end" : 3144160
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Fentriss, Schriftsteller",
-          "Richard Lauffen"
-        ],
-        [
-          "Mr. Claudius, Kunsthändler",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Mrs. Claudius",
-          "Ingrid Andree"
-        ],
-        [
-          "Miss Waggoner",
-          "Katharina Brauren"
-        ],
-        [
-          "Carlos",
-          "Stefan Brönneke"
-        ],
-        [
-          "Onkel Ramos",
-          "Juan Perez [Karl-Ulrich Meves]"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro [Wolfgang Kubach]"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Fentriss, Schriftsteller",
+          "sprecher" : "Richard Lauffen"
+        },
+        {
+          "rolle" : "Mr. Claudius, Kunsthändler",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Mrs. Claudius",
+          "sprecher" : "Ingrid Andree"
+        },
+        {
+          "rolle" : "Miss Waggoner",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Carlos",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Onkel Ramos",
+          "sprecher" : "Karl-Ulrich Meves",
+          "pseudonym" : "Juan Perez"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/001/metadata.json",
@@ -156,63 +158,66 @@
           "end" : 2738933
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Patrick Kenneth",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Java-Jim",
-          "Heinz Überreiter [Gottfried Kramer]"
-        ],
-        [
-          "Mrs. Flora Gunn",
-          "Veronika Weckler"
-        ],
-        [
-          "Cluny Gunn",
-          "Fabian Harloff"
-        ],
-        [
-          "Rory",
-          "Klaus-Peter Reisch [Peter Buchholz]"
-        ],
-        [
-          "Stebins",
-          "Hans Meinhardt [Karl-Ulrich Meves]"
-        ],
-        [
-          "Mr. Widner",
-          "Ernst von Klipstein"
-        ],
-        [
-          "Verwalter von Powder Gulch",
-          "Reiner Brönneke"
-        ],
-        [
-          "Bibliothekarin",
-          "Katharina Brauren"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Patrick Kenneth",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Java-Jim",
+          "sprecher" : "Gottfried Kramer",
+          "pseudonym" : "Heinz Überreiter"
+        },
+        {
+          "rolle" : "Mrs. Flora Gunn",
+          "sprecher" : "Veronika Weckler"
+        },
+        {
+          "rolle" : "Cluny Gunn",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Rory",
+          "sprecher" : "Peter Buchholz",
+          "pseudonym" : "Klaus-Peter Reisch"
+        },
+        {
+          "rolle" : "Stebins",
+          "sprecher" : "Karl-Ulrich Meves",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Mr. Widner",
+          "sprecher" : "Ernst von Klipstein"
+        },
+        {
+          "rolle" : "Verwalter von Powder Gulch",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Bibliothekarin",
+          "sprecher" : "Katharina Brauren"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/002/metadata.json",
@@ -271,59 +276,62 @@
           "end" : 2748440
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Prentice",
-          "Hans Hessling"
-        ],
-        [
-          "Niedland",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Pfarrer",
-          "Ernst von Klipstein"
-        ],
-        [
-          "Mrs. Boogle",
-          "Katharina Brauren"
-        ],
-        [
-          "Sonny Elmquist",
-          "Philip Kunzmann [Gernot Endemann]"
-        ],
-        [
-          "Mr. Murphy",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "Miss Chalmers",
-          "Pamela Punti [Heikedine Körting]"
-        ],
-        [
-          "Mr. Hassel",
-          "Rolf Hundertwasser [Wolfgang Kubach]"
-        ],
-        [
-          "Polizist",
-          "Rolf Mamero"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Prentice",
+          "sprecher" : "Hans Hessling"
+        },
+        {
+          "rolle" : "Niedland",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Pfarrer",
+          "sprecher" : "Ernst von Klipstein"
+        },
+        {
+          "rolle" : "Mrs. Boogle",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Sonny Elmquist",
+          "sprecher" : "Gernot Endemann",
+          "pseudonym" : "Philip Kunzmann"
+        },
+        {
+          "rolle" : "Mr. Murphy",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "Miss Chalmers",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Mr. Hassel",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Rolf Hundertwasser"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Rolf Mamero"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/003/metadata.json",
@@ -382,71 +390,74 @@
           "end" : 2662960
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Andy Carson",
-          "Stefan Schwade"
-        ],
-        [
-          "Mr. Carson",
-          "Reiner Brönneke"
-        ],
-        [
-          "Khan, der Kraftmensch",
-          "René Genesis"
-        ],
-        [
-          "Einzigartiger Gabbo",
-          "Iwan Raszinsky [Karl-Ulrich Meves]"
-        ],
-        [
-          "Iwan",
-          "Boris Stepin [Wolfgang Kubach]"
-        ],
-        [
-          "Junge 1",
-          "Philip Baader [Stefan Brönneke]"
-        ],
-        [
-          "Junge 2",
-          "Alexander Körting"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Der alte Mann",
-          "Lothar Grützner"
-        ],
-        [
-          "Wachmann",
-          "Peter Buchholz"
-        ],
-        [
-          "Jahrmarktfrau",
-          "Heikedine Körting"
-        ],
-        [
-          "Funksprecher",
-          "Gernot Endemann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Andy Carson",
+          "sprecher" : "Stefan Schwade"
+        },
+        {
+          "rolle" : "Mr. Carson",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Khan, der Kraftmensch",
+          "sprecher" : "René Genesis"
+        },
+        {
+          "rolle" : "Einzigartiger Gabbo",
+          "sprecher" : "Karl-Ulrich Meves",
+          "pseudonym" : "Iwan Raszinsky"
+        },
+        {
+          "rolle" : "Iwan",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Boris Stepin"
+        },
+        {
+          "rolle" : "Junge 1",
+          "sprecher" : "Stefan Brönneke",
+          "pseudonym" : "Philip Baader"
+        },
+        {
+          "rolle" : "Junge 2",
+          "sprecher" : "Alexander Körting"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Der alte Mann",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Jahrmarktfrau",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Funksprecher",
+          "sprecher" : "Gernot Endemann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/004/metadata.json",
@@ -505,59 +516,59 @@
           "end" : 2960987
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "August August, genannt Gus",
-          "Stephan Chrzescinski"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Dwiggins",
-          "Joachim Wolff"
-        ],
-        [
-          "Mr. Rhandur",
-          "Gottfried Kramer"
-        ],
-        [
-          "Joe",
-          "Peter Buchholz"
-        ],
-        [
-          "Lisa",
-          "Madeleine Stolze"
-        ],
-        [
-          "Mutter",
-          "Renate Pichler"
-        ],
-        [
-          "Patrick Kenneth",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Bauarbeiter",
-          "Gernot Endemann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "August August, genannt Gus",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Dwiggins",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Mr. Rhandur",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Lisa",
+          "sprecher" : "Madeleine Stolze"
+        },
+        {
+          "rolle" : "Mutter",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Patrick Kenneth",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Bauarbeiter",
+          "sprecher" : "Gernot Endemann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/005/metadata.json",
@@ -617,67 +628,69 @@
           "end" : 2752640
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Patrick Kenneth",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Gulliver",
-          "Joachim Wolff"
-        ],
-        [
-          "Mr. Maximillian",
-          "Richard Lauffen"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Mrs. Miller",
-          "Marianne Wolters [Marianne Kehlau]"
-        ],
-        [
-          "Mr. Grant",
-          "Hans Meinhardt [Lothar Grützner]"
-        ],
-        [
-          "Auktionator",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Fred Brown",
-          "Peter Buchholz"
-        ],
-        [
-          "Hauswirt",
-          "Reiner Brönneke"
-        ],
-        [
-          "Mann",
-          "Karl-Ulrich Meves"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Patrick Kenneth",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Gulliver",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Mr. Maximillian",
+          "sprecher" : "Richard Lauffen"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Mrs. Miller",
+          "sprecher" : "Marianne Kehlau",
+          "pseudonym" : "Marianne Wolters"
+        },
+        {
+          "rolle" : "Mr. Grant",
+          "sprecher" : "Lothar Grützner",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Auktionator",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Fred Brown",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Hauswirt",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Karl-Ulrich Meves"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/006/metadata.json",
@@ -736,47 +749,48 @@
           "end" : 2721773
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "H. H. Allen",
-          "Werner Cartano"
-        ],
-        [
-          "Mr. Shelby",
-          "Richard Lauffen"
-        ],
-        [
-          "Mr. Carter",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "Jack Morgan",
-          "Klaus Klein [Wolfgang Kubach]"
-        ],
-        [
-          "Harry Morgan",
-          "Reiner Brönneke"
-        ],
-        [
-          "Telephonistin",
-          "Reinhilt Schneider"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "H. H. Allen",
+          "sprecher" : "Werner Cartano"
+        },
+        {
+          "rolle" : "Mr. Shelby",
+          "sprecher" : "Richard Lauffen"
+        },
+        {
+          "rolle" : "Mr. Carter",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Jack Morgan",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Klaus Klein"
+        },
+        {
+          "rolle" : "Harry Morgan",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Telephonistin",
+          "sprecher" : "Reinhilt Schneider"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/007/metadata.json",
@@ -835,67 +849,69 @@
           "end" : 3203720
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Chang",
-          "Torsten Sense"
-        ],
-        [
-          "Patrick Kenneth",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Miss Lydia Green",
-          "Marianne Kehlau"
-        ],
-        [
-          "Harold Carlson",
-          "Alexander Stubbe [Peter Kirchberger]"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Jensen",
-          "Rolf Mamero"
-        ],
-        [
-          "Won",
-          "Victor Bernard [Ernst von Klipstein]"
-        ],
-        [
-          "Wongs Diener",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "Li",
-          "Renate Pichler"
-        ],
-        [
-          "Männer bei Greens Haus",
-          "Reiner Brönneke, Gernot Endemann"
-        ],
-        [
-          "Polizist",
-          "Peter Buchholz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Chang",
+          "sprecher" : "Torsten Sense"
+        },
+        {
+          "rolle" : "Patrick Kenneth",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Miss Lydia Green",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Harold Carlson",
+          "sprecher" : "Peter Kirchberger",
+          "pseudonym" : "Alexander Stubbe"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Jensen",
+          "sprecher" : "Rolf Mamero"
+        },
+        {
+          "rolle" : "Won",
+          "sprecher" : "Ernst von Klipstein",
+          "pseudonym" : "Victor Bernard"
+        },
+        {
+          "rolle" : "Wongs Diener",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "Li",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Männer bei Greens Haus",
+          "sprecher" : "Reiner Brönneke, Gernot Endemann"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Peter Buchholz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/008/metadata.json",
@@ -954,63 +970,66 @@
           "end" : 2832680
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Professor Carswell",
-          "Theodor Anzinger [Volker Bogdan]"
-        ],
-        [
-          "Hal Carswell",
-          "Oliver Mink"
-        ],
-        [
-          "Gräfin",
-          "Henriette Bischoff [Gisela Trowe]"
-        ],
-        [
-          "Armand Marechal",
-          "Joachim Wolff"
-        ],
-        [
-          "De Groot",
-          "René Genesis"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Maxwell James",
-          "Werner Cartano"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Professor Carswell",
+          "sprecher" : "Volker Bogdan",
+          "pseudonym" : "Theodor Anzinger"
+        },
+        {
+          "rolle" : "Hal Carswell",
+          "sprecher" : "Oliver Mink"
+        },
+        {
+          "rolle" : "Gräfin",
+          "sprecher" : "Gisela Trowe",
+          "pseudonym" : "Henriette Bischoff"
+        },
+        {
+          "rolle" : "Armand Marechal",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "De Groot",
+          "sprecher" : "René Genesis"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Maxwell James",
+          "sprecher" : "Werner Cartano"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/009/metadata.json",
@@ -1069,63 +1088,65 @@
           "end" : 3043693
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Patrick",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Professor Yarborough",
-          "Karl Walter Diess"
-        ],
-        [
-          "Wilkins, sein Butler",
-          "Ulrich Matschoss"
-        ],
-        [
-          "Professor Freeman",
-          "Viktor Bramer [Klaus Stieringer]"
-        ],
-        [
-          "Achmed",
-          "Ali Branowitch [Joachim Wolff]"
-        ],
-        [
-          "Hamid",
-          "Alexander Körting"
-        ],
-        [
-          "Harry",
-          "Peter Buchholz"
-        ],
-        [
-          "Joe",
-          "Reiner Brönneke"
-        ],
-        [
-          "Uhrenmacher",
-          "Gernot Endemann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Professor Yarborough",
+          "sprecher" : "Karl Walter Diess"
+        },
+        {
+          "rolle" : "Wilkins, sein Butler",
+          "sprecher" : "Ulrich Matschoss"
+        },
+        {
+          "rolle" : "Professor Freeman",
+          "sprecher" : "Klaus Stieringer",
+          "pseudonym" : "Viktor Bramer"
+        },
+        {
+          "rolle" : "Achmed",
+          "sprecher" : "Joachim Wolff",
+          "pseudonym" : "Ali Branowitch"
+        },
+        {
+          "rolle" : "Hamid",
+          "sprecher" : "Alexander Körting"
+        },
+        {
+          "rolle" : "Harry",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Uhrenmacher",
+          "sprecher" : "Gernot Endemann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/010/metadata.json",
@@ -1184,43 +1205,43 @@
           "end" : 2894907
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Stephen Terrill",
-          "Wolf Rahtjen"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mr. Grant",
-          "Horst Breiter"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Stephen Terrill",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mr. Grant",
+          "sprecher" : "Horst Breiter"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/011/metadata.json",
@@ -1280,71 +1301,75 @@
           "end" : 2736347
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Felix",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "Mrs. Smith",
-          "Maria Benders [Brigitte Alexis]"
-        ],
-        [
-          "Harry",
-          "Marco Beddies"
-        ],
-        [
-          "Mrs. King",
-          "Helga Bammert"
-        ],
-        [
-          "Julie Taylor",
-          "Renate Pichler"
-        ],
-        [
-          "Martha Harris",
-          "Eva Gelb"
-        ],
-        [
-          "Carlos",
-          "Hans-Werner Kuhn [Günther Heising]"
-        ],
-        [
-          "Gerald Cramer",
-          "Volker Brandt"
-        ],
-        [
-          "Gerald Watson",
-          "Werner van Thiel [Werner Cartano]"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro [Wolfgang Kubach]"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Mr. Jankins",
-          "Lothar Zibell"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Felix",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "Mrs. Smith",
+          "sprecher" : "Brigitte Alexis",
+          "pseudonym" : "Maria Benders"
+        },
+        {
+          "rolle" : "Harry",
+          "sprecher" : "Marco Beddies"
+        },
+        {
+          "rolle" : "Mrs. King",
+          "sprecher" : "Helga Bammert"
+        },
+        {
+          "rolle" : "Julie Taylor",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Martha Harris",
+          "sprecher" : "Eva Gelb"
+        },
+        {
+          "rolle" : "Carlos",
+          "sprecher" : "Günther Heising",
+          "pseudonym" : "Hans-Werner Kuhn"
+        },
+        {
+          "rolle" : "Gerald Cramer",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Gerald Watson",
+          "sprecher" : "Werner Cartano",
+          "pseudonym" : "Werner van Thiel"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Mr. Jankins",
+          "sprecher" : "Lothar Zibell"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/012/metadata.json",
@@ -1403,67 +1428,68 @@
           "end" : 2640320
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Harris",
-          "Günther Heising"
-        ],
-        [
-          "Miss Sanchez",
-          "Marlene Lindner [Cordula Hubrich]"
-        ],
-        [
-          "Ted Sanchez",
-          "Nicolas Körting"
-        ],
-        [
-          "Sanders",
-          "Torsten Sense"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Natches",
-          "Gernot Endemann"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Prof. Meeker",
-          "Josef Dahmen"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Polizist",
-          "Joachim Wolff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Harris",
+          "sprecher" : "Günther Heising"
+        },
+        {
+          "rolle" : "Miss Sanchez",
+          "sprecher" : "Cordula Hubrich",
+          "pseudonym" : "Marlene Lindner"
+        },
+        {
+          "rolle" : "Ted Sanchez",
+          "sprecher" : "Nicolas Körting"
+        },
+        {
+          "rolle" : "Sanders",
+          "sprecher" : "Torsten Sense"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Natches",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Prof. Meeker",
+          "sprecher" : "Josef Dahmen"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Joachim Wolff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/013/metadata.json",
@@ -1522,63 +1548,63 @@
           "end" : 2550187
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Smathers",
-          "Josef Dahmen"
-        ],
-        [
-          "Mr. Jensen",
-          "Wolf Rahtjen"
-        ],
-        [
-          "Patrick",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Kenneth",
-          "Lutz Mackensy"
-        ],
-        [
-          "Kathleen",
-          "Brigitte Alexis"
-        ],
-        [
-          "Mr. Joe Hammond",
-          "Volker Brandt"
-        ],
-        [
-          "Mrs. Hammond",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Richardsen",
-          "Joachim Wolff"
-        ],
-        [
-          "Polizist",
-          "Horst Stark"
-        ],
-        [
-          "Lieferant",
-          "Franz-Josef Steffens"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Smathers",
+          "sprecher" : "Josef Dahmen"
+        },
+        {
+          "rolle" : "Mr. Jensen",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Kenneth",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Kathleen",
+          "sprecher" : "Brigitte Alexis"
+        },
+        {
+          "rolle" : "Mr. Joe Hammond",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Mrs. Hammond",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Richardsen",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Lieferant",
+          "sprecher" : "Franz-Josef Steffens"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/014/metadata.json",
@@ -1637,67 +1663,68 @@
           "end" : 2385253
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Miss Larson",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Jim Hall",
-          "Horst Stark"
-        ],
-        [
-          "Mike Hall",
-          "Mathias Lorenz"
-        ],
-        [
-          "Eastland",
-          "Karl Walter Diess"
-        ],
-        [
-          "Olsen",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "Hank Murphy",
-          "Harald Pages"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Doc Dawson",
-          "Wolfgang Jürgen"
-        ],
-        [
-          "Dobbsie",
-          "Joachim Wolff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Miss Larson",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Jim Hall",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Mike Hall",
+          "sprecher" : "Mathias Lorenz"
+        },
+        {
+          "rolle" : "Eastland",
+          "sprecher" : "Karl Walter Diess"
+        },
+        {
+          "rolle" : "Olsen",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "Hank Murphy",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Doc Dawson",
+          "sprecher" : "Wolfgang Jürgen"
+        },
+        {
+          "rolle" : "Dobbsie",
+          "sprecher" : "Joachim Wolff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/015/metadata.json",
@@ -1756,55 +1783,56 @@
           "end" : 2551347
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Darnley",
-          "Gisela Trowe"
-        ],
-        [
-          "Jeff Darnley",
-          "Mike Henning"
-        ],
-        [
-          "Jenny Darnley",
-          "Marlen Krause"
-        ],
-        [
-          "Senior Santora",
-          "Jürgen Thormann"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Gomez",
-          "Karl-Heinz Gerdesmann"
-        ],
-        [
-          "Brotverkäufer",
-          "Harald Pages"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Darnley",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Jeff Darnley",
+          "sprecher" : "Mike Henning"
+        },
+        {
+          "rolle" : "Jenny Darnley",
+          "sprecher" : "Marlen Krause"
+        },
+        {
+          "rolle" : "Senior Santora",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Gomez",
+          "sprecher" : "Karl-Heinz Gerdesmann"
+        },
+        {
+          "rolle" : "Brotverkäufer",
+          "sprecher" : "Harald Pages"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/016/metadata.json",
@@ -1863,59 +1891,60 @@
           "end" : 2524840
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Nelly Towne",
-          "Pamela Punti [Heikedine Körting]"
-        ],
-        [
-          "Billy Towne",
-          "Peer Siegel"
-        ],
-        [
-          "Ordner",
-          "Lothar Grützner"
-        ],
-        [
-          "Lopez",
-          "Hans Irle"
-        ],
-        [
-          "Dillon",
-          "Gottfried Kramer"
-        ],
-        [
-          "Roger Callow",
-          "Hans Daniel"
-        ],
-        [
-          "Kellnerin",
-          "Heidi Schaffrath"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Nelly Towne",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Billy Towne",
+          "sprecher" : "Peer Siegel"
+        },
+        {
+          "rolle" : "Ordner",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Lopez",
+          "sprecher" : "Hans Irle"
+        },
+        {
+          "rolle" : "Dillon",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Roger Callow",
+          "sprecher" : "Hans Daniel"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Heidi Schaffrath"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/017/metadata.json",
@@ -1973,67 +2002,68 @@
           "end" : 2606493
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sam",
-          "Joachim Wolff"
-        ],
-        [
-          "Chris Markos",
-          "Stephan Chrzescinski"
-        ],
-        [
-          "Kommissar Nostigon",
-          "Volker Brandt"
-        ],
-        [
-          "Mr. Shaw",
-          "Joachim Richert"
-        ],
-        [
-          "Denton",
-          "Karl-Heinz Gerdesmann"
-        ],
-        [
-          "Farraday",
-          "Gottfried Kramer"
-        ],
-        [
-          "Jeff",
-          "Harald Pages"
-        ],
-        [
-          "Bill Ballinger",
-          "Günther Flesch"
-        ],
-        [
-          "Jim Ballinger",
-          "Heinz Werder [Hans Irle]"
-        ],
-        [
-          "Mr. Norris",
-          "Horst Schick"
-        ],
-        [
-          "Mrs. Barton",
-          "Marianne Kehlau"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sam",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Chris Markos",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Kommissar Nostigon",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Denton",
+          "sprecher" : "Karl-Heinz Gerdesmann"
+        },
+        {
+          "rolle" : "Farraday",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Jeff",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Bill Ballinger",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Jim Ballinger",
+          "sprecher" : "Hans Irle",
+          "pseudonym" : "Heinz Werder"
+        },
+        {
+          "rolle" : "Mr. Norris",
+          "sprecher" : "Horst Schick"
+        },
+        {
+          "rolle" : "Mrs. Barton",
+          "sprecher" : "Marianne Kehlau"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/018/metadata.json",
@@ -2092,59 +2122,59 @@
           "end" : 2676573
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dalton",
-          "Jürgen Thormann"
-        ],
-        [
-          "Mrs. Dalton",
-          "Helga Bammert"
-        ],
-        [
-          "Hardin",
-          "Christian Mey"
-        ],
-        [
-          "Prof. Walsh",
-          "Joachim Rake"
-        ],
-        [
-          "Ben Jackson",
-          "Günther Flesch"
-        ],
-        [
-          "Wreston",
-          "Ulrich Benthien"
-        ],
-        [
-          "Cardigo",
-          "Harald Pages"
-        ],
-        [
-          "Waldo Turner",
-          "Lothar Grützner"
-        ],
-        [
-          "Taucher",
-          "Joachim Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dalton",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Mrs. Dalton",
+          "sprecher" : "Helga Bammert"
+        },
+        {
+          "rolle" : "Hardin",
+          "sprecher" : "Christian Mey"
+        },
+        {
+          "rolle" : "Prof. Walsh",
+          "sprecher" : "Joachim Rake"
+        },
+        {
+          "rolle" : "Ben Jackson",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Wreston",
+          "sprecher" : "Ulrich Benthien"
+        },
+        {
+          "rolle" : "Cardigo",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Waldo Turner",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Taucher",
+          "sprecher" : "Joachim Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/019/metadata.json",
@@ -2203,63 +2233,63 @@
           "end" : 2816907
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mihai Eftimin",
-          "Volker Brandt"
-        ],
-        [
-          "Dr. Radulescu",
-          "Günther Flesch"
-        ],
-        [
-          "Potter",
-          "Karl-Heinz Gerdesmann"
-        ],
-        [
-          "Mrs. Dobson",
-          "Marianne Kehlau"
-        ],
-        [
-          "Tom Dobson",
-          "Alexander Körting"
-        ],
-        [
-          "Farrier",
-          "Gottfried Kramer"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Polizist",
-          "Hans Irle"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mihai Eftimin",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Dr. Radulescu",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Potter",
+          "sprecher" : "Karl-Heinz Gerdesmann"
+        },
+        {
+          "rolle" : "Mrs. Dobson",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Tom Dobson",
+          "sprecher" : "Alexander Körting"
+        },
+        {
+          "rolle" : "Farrier",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Hans Irle"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/020/metadata.json",
@@ -2318,67 +2348,70 @@
           "end" : 2547813
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Dalton",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Christina Dalton",
-          "Karina Leising [Heikedine Körting]"
-        ],
-        [
-          "Frankie Bender",
-          "Oliver Mink"
-        ],
-        [
-          "H. P. Clay",
-          "Lothar Grützner"
-        ],
-        [
-          "Jim Clay",
-          "Markus Meiering [Dieter B. Gerlach]"
-        ],
-        [
-          "Walter Quail",
-          "Christian Mey"
-        ],
-        [
-          "Trödler Hummer",
-          "Joachim Richert"
-        ],
-        [
-          "Jason Wilkes",
-          "Joachim Rake"
-        ],
-        [
-          "Chiang",
-          "Tom Barrows [Jürgen Thormann]"
-        ],
-        [
-          "Diakon Kastner",
-          "Hans Irle"
-        ],
-        [
-          "Butler",
-          "Hans Daniel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Dalton",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Christina Dalton",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Karina Leising"
+        },
+        {
+          "rolle" : "Frankie Bender",
+          "sprecher" : "Oliver Mink"
+        },
+        {
+          "rolle" : "H. P. Clay",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Jim Clay",
+          "sprecher" : "Dieter B. Gerlach",
+          "pseudonym" : "Markus Meiering"
+        },
+        {
+          "rolle" : "Walter Quail",
+          "sprecher" : "Christian Mey"
+        },
+        {
+          "rolle" : "Trödler Hummer",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Jason Wilkes",
+          "sprecher" : "Joachim Rake"
+        },
+        {
+          "rolle" : "Chiang",
+          "sprecher" : "Jürgen Thormann",
+          "pseudonym" : "Tom Barrows"
+        },
+        {
+          "rolle" : "Diakon Kastner",
+          "sprecher" : "Hans Irle"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Hans Daniel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/021/metadata.json",
@@ -2437,71 +2470,74 @@
           "end" : 2635960
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Rawley",
-          "Horst Stark"
-        ],
-        [
-          "Mr. Frank",
-          "Siegfried Wald"
-        ],
-        [
-          "Mr. Togati",
-          "Reiner Brönneke"
-        ],
-        [
-          "Taro",
-          "Stefan Brönneke"
-        ],
-        [
-          "Patrick",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Miss Agawam",
-          "Ursula Vogel"
-        ],
-        [
-          "Jordan",
-          "Hans Meinhardt [Franz-Josef Steffens]"
-        ],
-        [
-          "Chuck",
-          "Roland Fabricius [Wolfgang Kaven]"
-        ],
-        [
-          "Liliputaner",
-          "Erich Büttner [Joachim Wolff]"
-        ],
-        [
-          "Wachmann im Museum",
-          "Gottfried Kramer"
-        ],
-        [
-          "Hafenpolizist",
-          "Peter Kirchberger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Rawley",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Mr. Frank",
+          "sprecher" : "Siegfried Wald"
+        },
+        {
+          "rolle" : "Mr. Togati",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Taro",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Miss Agawam",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Jordan",
+          "sprecher" : "Franz-Josef Steffens",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Chuck",
+          "sprecher" : "Wolfgang Kaven",
+          "pseudonym" : "Roland Fabricius"
+        },
+        {
+          "rolle" : "Liliputaner",
+          "sprecher" : "Joachim Wolff",
+          "pseudonym" : "Erich Büttner"
+        },
+        {
+          "rolle" : "Wachmann im Museum",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Hafenpolizist",
+          "sprecher" : "Peter Kirchberger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/022/metadata.json",
@@ -2560,67 +2596,73 @@
           "end" : 2565680
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Cody",
-          "Simon Schuchardt [Wolfgang Kaven]"
-        ],
-        [
-          "Diego Alvaro",
-          "Jan Odle"
-        ],
-        [
-          "Pico Alvaro",
-          "Mathias Lorenz"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Assistent",
-          "Claes Holmcrantz [Gernot Endemann]"
-        ],
-        [
-          "Sheriff",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "Tulsa",
-          "Klaus Klein [Siegfried Wald]"
-        ],
-        [
-          "Cap",
-          "Fritz Wegely [Joachim Wolff]"
-        ],
-        [
-          "Pike",
-          "Philip Mehringer [Franz-Josef Steffens]"
-        ],
-        [
-          "Mr. Shaw",
-          "Franz-Josef Steffens"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Cody",
+          "sprecher" : "Wolfgang Kaven",
+          "pseudonym" : "Simon Schuchardt"
+        },
+        {
+          "rolle" : "Diego Alvaro",
+          "sprecher" : "Jan Odle"
+        },
+        {
+          "rolle" : "Pico Alvaro",
+          "sprecher" : "Mathias Lorenz"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Assistent",
+          "sprecher" : "Gernot Endemann",
+          "pseudonym" : "Claes Holmcrantz"
+        },
+        {
+          "rolle" : "Sheriff",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Tulsa",
+          "sprecher" : "Siegfried Wald",
+          "pseudonym" : "Klaus Klein"
+        },
+        {
+          "rolle" : "Cap",
+          "sprecher" : "Joachim Wolff",
+          "pseudonym" : "Fritz Wegely"
+        },
+        {
+          "rolle" : "Pike",
+          "sprecher" : "Franz-Josef Steffens",
+          "pseudonym" : "Philip Mehringer"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Franz-Josef Steffens"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/023/metadata.json",
@@ -2679,71 +2721,73 @@
           "end" : 2537893
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Bengt",
-          "Charles Regnier"
-        ],
-        [
-          "Britta",
-          "Ingeburg Kanstein"
-        ],
-        [
-          "Lars Holmqvist",
-          "Gernot Endemann"
-        ],
-        [
-          "Young",
-          "Horst Stark"
-        ],
-        [
-          "Forsborg",
-          "Richard Heelel [Franz-Josef Steffens]"
-        ],
-        [
-          "Mann",
-          "Siegfried Wald"
-        ],
-        [
-          "Frau",
-          "Brigitte Alexis"
-        ],
-        [
-          "Köhler",
-          "Hans Meinhardt [Reiner Brönneke]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Wärter",
-          "Joachim Wolff"
-        ],
-        [
-          "Kellner",
-          "Peter Kirchberger"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Bengt",
+          "sprecher" : "Charles Regnier"
+        },
+        {
+          "rolle" : "Britta",
+          "sprecher" : "Ingeburg Kanstein"
+        },
+        {
+          "rolle" : "Lars Holmqvist",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Young",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Forsborg",
+          "sprecher" : "Franz-Josef Steffens",
+          "pseudonym" : "Richard Heelel"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Siegfried Wald"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Brigitte Alexis"
+        },
+        {
+          "rolle" : "Köhler",
+          "sprecher" : "Reiner Brönneke",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Wärter",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Kellner",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/024/metadata.json",
@@ -2802,67 +2846,67 @@
           "end" : 2782427
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Allie Jamison",
-          "Katrin Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Asmodi",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Dr. Shaitan",
-          "Lutz Mackensy"
-        ],
-        [
-          "Noxworth",
-          "Christian Rode"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Prof. Barrister",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "Marie",
-          "Susanne Wulkow"
-        ],
-        [
-          "der \"Clochard\"",
-          "Karl-Heinz Gerdesmann"
-        ],
-        [
-          "Patricia Osborne",
-          "Barbara Focke"
-        ],
-        [
-          "Mann am Grundstück",
-          "Wolfgang Kaven"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Allie Jamison",
+          "sprecher" : "Katrin Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Asmodi",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Dr. Shaitan",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Noxworth",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Prof. Barrister",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Marie",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "der \"Clochard\"",
+          "sprecher" : "Karl-Heinz Gerdesmann"
+        },
+        {
+          "rolle" : "Patricia Osborne",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Mann am Grundstück",
+          "sprecher" : "Wolfgang Kaven"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/025/metadata.json",
@@ -2921,55 +2965,55 @@
           "end" : 2628080
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Allie Jamison",
-          "Katrin Fröhlich"
-        ],
-        [
-          "Harrison Osborne",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "Thurgood",
-          "Jürgen Thormann"
-        ],
-        [
-          "Sheriff",
-          "Gottfried Kramer"
-        ],
-        [
-          "Mrs. Macomber",
-          "Gisela Trowe"
-        ],
-        [
-          "Atkinson",
-          "Klaus Stieringer"
-        ],
-        [
-          "Manny",
-          "Lothar Grützner"
-        ],
-        [
-          "Gasper",
-          "Rolf Mamero"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Allie Jamison",
+          "sprecher" : "Katrin Fröhlich"
+        },
+        {
+          "rolle" : "Harrison Osborne",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Thurgood",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Sheriff",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Mrs. Macomber",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Atkinson",
+          "sprecher" : "Klaus Stieringer"
+        },
+        {
+          "rolle" : "Manny",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Gasper",
+          "sprecher" : "Rolf Mamero"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/026/metadata.json",
@@ -3028,59 +3072,60 @@
           "end" : 3108893
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Horace Tremayne",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "William Tremayne",
-          "Günther Flesch"
-        ],
-        [
-          "Marvin Gray",
-          "Horst Stark"
-        ],
-        [
-          "Madeline Bainbridge",
-          "Ursula Vogel"
-        ],
-        [
-          "Mr. Thomas",
-          "Lothar Grützner"
-        ],
-        [
-          "Jefferson",
-          "Christian Rode"
-        ],
-        [
-          "Clara Adams",
-          "Ingeburg Kanstein"
-        ],
-        [
-          "Grean",
-          "Manuel Hümpel [Rüdiger Schulzki]"
-        ],
-        [
-          "Schrottplatzwart",
-          "Siegfried Wald"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Horace Tremayne",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "William Tremayne",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Marvin Gray",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Madeline Bainbridge",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Mr. Thomas",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Jefferson",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Clara Adams",
+          "sprecher" : "Ingeburg Kanstein"
+        },
+        {
+          "rolle" : "Grean",
+          "sprecher" : "Rüdiger Schulzki",
+          "pseudonym" : "Manuel Hümpel"
+        },
+        {
+          "rolle" : "Schrottplatzwart",
+          "sprecher" : "Siegfried Wald"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/027/metadata.json",
@@ -3139,67 +3184,70 @@
           "end" : 2875787
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Reporter",
-          "Peter Kirchberger"
-        ],
-        [
-          "Fred, Extremist",
-          "Heinrich Baum [Karl-Walter Diess]"
-        ],
-        [
-          "Walt, Extremist",
-          "Friedhelm Hubertus [Siegfried Wald]"
-        ],
-        [
-          "Gordon Mackenzie",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Adam Ndula",
-          "Hans Meinhardt [Henry Kielmann]"
-        ],
-        [
-          "Jan Carew",
-          "Sascha Draeger"
-        ],
-        [
-          "Polizist im Suchtrupp",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Hauswirt",
-          "Hubert Mittendorf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Fred, Extremist",
+          "sprecher" : "Karl-Walter Diess",
+          "pseudonym" : "Heinrich Baum"
+        },
+        {
+          "rolle" : "Walt, Extremist",
+          "sprecher" : "Siegfried Wald",
+          "pseudonym" : "Friedhelm Hubertus"
+        },
+        {
+          "rolle" : "Gordon Mackenzie",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Adam Ndula",
+          "sprecher" : "Henry Kielmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Jan Carew",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Polizist im Suchtrupp",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Hauswirt",
+          "sprecher" : "Hubert Mittendorf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/028/metadata.json",
@@ -3342,63 +3390,64 @@
           "end" : 2522293
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Joachim Richert"
-        ],
-        [
-          "Crowe",
-          "Henry Kielmann"
-        ],
-        [
-          "Käptn Jason",
-          "Karl Walter Diess"
-        ],
-        [
-          "MacGruder",
-          "Siegfried Wald"
-        ],
-        [
-          "Hanley",
-          "Lothar Grützner"
-        ],
-        [
-          "Torao",
-          "Joko Talmann [Rüdiger Schulzki]"
-        ],
-        [
-          "Berg",
-          "Andreas E. Beurmann / Wolfgang Draeger"
-        ],
-        [
-          "Yamura",
-          "Hubert Mittendorf"
-        ],
-        [
-          "Die Gebrüder Connors",
-          "Nicolas Körting, Lothar Grützner"
-        ],
-        [
-          "Weston",
-          "Joachim Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Crowe",
+          "sprecher" : "Henry Kielmann"
+        },
+        {
+          "rolle" : "Käptn Jason",
+          "sprecher" : "Karl Walter Diess"
+        },
+        {
+          "rolle" : "MacGruder",
+          "sprecher" : "Siegfried Wald"
+        },
+        {
+          "rolle" : "Hanley",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Torao",
+          "sprecher" : "Rüdiger Schulzki",
+          "pseudonym" : "Joko Talmann"
+        },
+        {
+          "rolle" : "Berg",
+          "sprecher" : "Andreas E. Beurmann / Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Yamura",
+          "sprecher" : "Hubert Mittendorf"
+        },
+        {
+          "rolle" : "Die Gebrüder Connors",
+          "sprecher" : "Nicolas Körting, Lothar Grützner"
+        },
+        {
+          "rolle" : "Weston",
+          "sprecher" : "Joachim Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/030/metadata.json",
@@ -3457,67 +3506,69 @@
           "end" : 2984573
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Shelby Tuckerman",
-          "Pinkas Braun"
-        ],
-        [
-          "Mr. Hitfield",
-          "Christian Riege [Manfred Steffen]"
-        ],
-        [
-          "Mr. Bonestell",
-          "Joachim Richert"
-        ],
-        [
-          "Mrs. Denicola",
-          "Katharina Brauren"
-        ],
-        [
-          "Eileen",
-          "Ruth Niehaus"
-        ],
-        [
-          "Ernie",
-          "Helmut Zierl"
-        ],
-        [
-          "Polizist",
-          "Harald Pages"
-        ],
-        [
-          "Hoang Van Dong",
-          "Chen Lung Chung [Volker Brandt]"
-        ],
-        [
-          "Frau an der Bushaltestelle",
-          "Ursula Vogel"
-        ],
-        [
-          "Nachrichtensprecher",
-          "Joachim Wolff"
-        ],
-        [
-          "Patrick",
-          "Joachim Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Shelby Tuckerman",
+          "sprecher" : "Pinkas Braun"
+        },
+        {
+          "rolle" : "Mr. Hitfield",
+          "sprecher" : "Manfred Steffen",
+          "pseudonym" : "Christian Riege"
+        },
+        {
+          "rolle" : "Mr. Bonestell",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Mrs. Denicola",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Eileen",
+          "sprecher" : "Ruth Niehaus"
+        },
+        {
+          "rolle" : "Ernie",
+          "sprecher" : "Helmut Zierl"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Hoang Van Dong",
+          "sprecher" : "Volker Brandt",
+          "pseudonym" : "Chen Lung Chung"
+        },
+        {
+          "rolle" : "Frau an der Bushaltestelle",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Joachim Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/031/metadata.json",
@@ -3576,63 +3627,65 @@
           "end" : 2652653
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dr. Woolley",
-          "Manfred Steffen"
-        ],
-        [
-          "Larry Conklin",
-          "Sylvester Merten [Helmut Zierl]"
-        ],
-        [
-          "Letitia Radford",
-          "Marianne Kehlau"
-        ],
-        [
-          "Mrs. Chumley",
-          "Renate Pichler"
-        ],
-        [
-          "Mrs. Burroughs",
-          "Katharina Brauren"
-        ],
-        [
-          "Mr. Burroughs",
-          "Martin Fichte [Joachim Wolff]"
-        ],
-        [
-          "Gary Malz",
-          "Volker Brandt"
-        ],
-        [
-          "Mr. Agnier",
-          "Willem Fricke"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Patrick",
-          "Joachim Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dr. Woolley",
+          "sprecher" : "Manfred Steffen"
+        },
+        {
+          "rolle" : "Larry Conklin",
+          "sprecher" : "Helmut Zierl",
+          "pseudonym" : "Sylvester Merten"
+        },
+        {
+          "rolle" : "Letitia Radford",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Mrs. Chumley",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Mrs. Burroughs",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Mr. Burroughs",
+          "sprecher" : "Joachim Wolff",
+          "pseudonym" : "Martin Fichte"
+        },
+        {
+          "rolle" : "Gary Malz",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Mr. Agnier",
+          "sprecher" : "Willem Fricke"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Joachim Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/032/metadata.json",
@@ -3691,63 +3744,64 @@
           "end" : 2657067
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Patrick",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Onkel Titus",
-          "Peter Kirchberger"
-        ],
-        [
-          "Mr. Barron",
-          "Pinkas Braun"
-        ],
-        [
-          "Mrs. Barron",
-          "Monika Peitsch"
-        ],
-        [
-          "Hank Detweiler",
-          "Siegfried Wald"
-        ],
-        [
-          "Elsie Spratt",
-          "Barbara Focke"
-        ],
-        [
-          "Leutnant Ferrante",
-          "Volkert Kraeft"
-        ],
-        [
-          "Bones",
-          "Siegfried Meyerheim [Helmut Zierl]"
-        ],
-        [
-          "vermeintlicher US-Präsident",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Mr. Barron",
+          "sprecher" : "Pinkas Braun"
+        },
+        {
+          "rolle" : "Mrs. Barron",
+          "sprecher" : "Monika Peitsch"
+        },
+        {
+          "rolle" : "Hank Detweiler",
+          "sprecher" : "Siegfried Wald"
+        },
+        {
+          "rolle" : "Elsie Spratt",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Leutnant Ferrante",
+          "sprecher" : "Volkert Kraeft"
+        },
+        {
+          "rolle" : "Bones",
+          "sprecher" : "Helmut Zierl",
+          "pseudonym" : "Siegfried Meyerheim"
+        },
+        {
+          "rolle" : "vermeintlicher US-Präsident",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/033/metadata.json",
@@ -3806,47 +3860,47 @@
           "end" : 2640213
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Shaw",
-          "Horst Schick"
-        ],
-        [
-          "Kapitän Joy",
-          "Helmut Ahner"
-        ],
-        [
-          "Jeremy Joy",
-          "Philip Siegel"
-        ],
-        [
-          "Joshua Evans",
-          "Douglas Welbat"
-        ],
-        [
-          "Major Karnes",
-          "Manfred Schermutzki"
-        ],
-        [
-          "Sam Davis",
-          "Utz Richter"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Horst Schick"
+        },
+        {
+          "rolle" : "Kapitän Joy",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Jeremy Joy",
+          "sprecher" : "Philip Siegel"
+        },
+        {
+          "rolle" : "Joshua Evans",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Major Karnes",
+          "sprecher" : "Manfred Schermutzki"
+        },
+        {
+          "rolle" : "Sam Davis",
+          "sprecher" : "Utz Richter"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/034/metadata.json",
@@ -3905,75 +3959,76 @@
           "end" : 3255933
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Eleonor",
-          "Susanne Wulkow"
-        ],
-        [
-          "Birkensteen",
-          "Oskar Kluge [Günter König]"
-        ],
-        [
-          "Terreano",
-          "Günter König"
-        ],
-        [
-          "Brandon",
-          "Douglas Welbat"
-        ],
-        [
-          "Hoffer",
-          "Eckart Dux"
-        ],
-        [
-          "McGee",
-          "Utz Richter"
-        ],
-        [
-          "Thalia",
-          "Ingeburg Kanstein"
-        ],
-        [
-          "Stefano",
-          "Andreas von der Meden"
-        ],
-        [
-          "John",
-          "Edgar Bessen"
-        ],
-        [
-          "Tankwart",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "LKW-Fahrer",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mann am Bahnhof",
-          "Christian Rode"
-        ],
-        [
-          "Bürgermeister",
-          "Edgar Bessen"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Eleonor",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Birkensteen",
+          "sprecher" : "Günter König",
+          "pseudonym" : "Oskar Kluge"
+        },
+        {
+          "rolle" : "Terreano",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Brandon",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Hoffer",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "McGee",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Thalia",
+          "sprecher" : "Ingeburg Kanstein"
+        },
+        {
+          "rolle" : "Stefano",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "John",
+          "sprecher" : "Edgar Bessen"
+        },
+        {
+          "rolle" : "Tankwart",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "LKW-Fahrer",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mann am Bahnhof",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Bürgermeister",
+          "sprecher" : "Edgar Bessen"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/035/metadata.json",
@@ -4032,47 +4087,47 @@
           "end" : 2896187
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Constance",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Slater",
-          "Helmut Ahner"
-        ],
-        [
-          "Donner",
-          "Jürgen Thormann"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Fischer",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "Ocean-World-Mitarbeiter",
-          "Peter Lakenmacher, Christian Rode"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Constance",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Slater",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Donner",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Fischer",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Ocean-World-Mitarbeiter",
+          "sprecher" : "Peter Lakenmacher, Christian Rode"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/036/metadata.json",
@@ -4131,55 +4186,55 @@
           "end" : 3293027
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Regina",
-          "Ursela Monn"
-        ],
-        [
-          "Teddy",
-          "Simon Jäger"
-        ],
-        [
-          "Mrs. Peabody",
-          "Gisela Trowe"
-        ],
-        [
-          "Burton",
-          "Günter Pfitzmann"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Günther Flesch"
-        ],
-        [
-          "Mooch",
-          "Joachim Richert"
-        ],
-        [
-          "Mr. Conine",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Fergus",
-          "Günther Dockerill"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Regina",
+          "sprecher" : "Ursela Monn"
+        },
+        {
+          "rolle" : "Teddy",
+          "sprecher" : "Simon Jäger"
+        },
+        {
+          "rolle" : "Mrs. Peabody",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Burton",
+          "sprecher" : "Günter Pfitzmann"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Mooch",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Mr. Conine",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Fergus",
+          "sprecher" : "Günther Dockerill"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/037/metadata.json",
@@ -4238,47 +4293,47 @@
           "end" : 2552053
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Shaw",
-          "Marianne Kehlau"
-        ],
-        [
-          "Mr. Peck",
-          "Wolfgang Völz"
-        ],
-        [
-          "Ed Snabel",
-          "Horst Naumann"
-        ],
-        [
-          "Bartlett",
-          "Jochen Sehrndt"
-        ],
-        [
-          "FBI-Agent Anderson",
-          "Lutz Mackensy"
-        ],
-        [
-          "Passantin",
-          "Ingrid Andree"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Mr. Peck",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Ed Snabel",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Bartlett",
+          "sprecher" : "Jochen Sehrndt"
+        },
+        {
+          "rolle" : "FBI-Agent Anderson",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Passantin",
+          "sprecher" : "Ingrid Andree"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/038/metadata.json",
@@ -4337,35 +4392,35 @@
           "end" : 2873960
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Blinky",
-          "Günter König"
-        ],
-        [
-          "Miss Melody",
-          "Gisela Trowe"
-        ],
-        [
-          "Frisbee",
-          "Hans Paetsch"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Blinky",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Miss Melody",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Frisbee",
+          "sprecher" : "Hans Paetsch"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/039/metadata.json",
@@ -4424,75 +4479,75 @@
           "end" : 2821360
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Jacobs",
-          "Horst Naumann"
-        ],
-        [
-          "Paul Jacobs",
-          "Sascha Draeger"
-        ],
-        [
-          "Onkel Titus",
-          "Gottfried Kramer"
-        ],
-        [
-          "Tante Mathilda",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Mr. Temple",
-          "Jochen Sehrndt"
-        ],
-        [
-          "Sarah Temple",
-          "Svenja Pages"
-        ],
-        [
-          "Willard Temple",
-          "Ben Becker"
-        ],
-        [
-          "Polizeileutnant",
-          "Günter König"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Günther Flesch"
-        ],
-        [
-          "Margon",
-          "Henry Kielmann"
-        ],
-        [
-          "William Margon",
-          "Michael Grimm"
-        ],
-        [
-          "Passanten",
-          "Lothar Grützner, Hans Hessling"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Jacobs",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Paul Jacobs",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Mr. Temple",
+          "sprecher" : "Jochen Sehrndt"
+        },
+        {
+          "rolle" : "Sarah Temple",
+          "sprecher" : "Svenja Pages"
+        },
+        {
+          "rolle" : "Willard Temple",
+          "sprecher" : "Ben Becker"
+        },
+        {
+          "rolle" : "Polizeileutnant",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Margon",
+          "sprecher" : "Henry Kielmann"
+        },
+        {
+          "rolle" : "William Margon",
+          "sprecher" : "Michael Grimm"
+        },
+        {
+          "rolle" : "Passanten",
+          "sprecher" : "Lothar Grützner, Hans Hessling"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/040/metadata.json",
@@ -4551,55 +4606,55 @@
           "end" : 3214520
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brewster",
-          "Horst Naumann"
-        ],
-        [
-          "Clifford",
-          "Douglas Welbat"
-        ],
-        [
-          "Marie",
-          "Svenja Pages"
-        ],
-        [
-          "Zindler",
-          "Karl Walter Diess"
-        ],
-        [
-          "Pamir",
-          "Manfred Steffen"
-        ],
-        [
-          "Martin",
-          "Frank-Dieter Tausch"
-        ],
-        [
-          "Botin",
-          "Beate Hasenau"
-        ],
-        [
-          "Kellner",
-          "Helmut Ahner"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brewster",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Clifford",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Marie",
+          "sprecher" : "Svenja Pages"
+        },
+        {
+          "rolle" : "Zindler",
+          "sprecher" : "Karl Walter Diess"
+        },
+        {
+          "rolle" : "Pamir",
+          "sprecher" : "Manfred Steffen"
+        },
+        {
+          "rolle" : "Martin",
+          "sprecher" : "Frank-Dieter Tausch"
+        },
+        {
+          "rolle" : "Botin",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Kellner",
+          "sprecher" : "Helmut Ahner"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/041/metadata.json",
@@ -4658,71 +4713,71 @@
           "end" : 2869227
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Michael Cross",
-          "Matthias Klimsa"
-        ],
-        [
-          "Mrs. Cross",
-          "Marianne Kehlau"
-        ],
-        [
-          "Mr. Cross",
-          "Horst Naumann"
-        ],
-        [
-          "Grady Markels",
-          "Gerd Baltus"
-        ],
-        [
-          "Brackmann",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "Margie",
-          "Monika Gabriel"
-        ],
-        [
-          "Nachrichtensprecher",
-          "Günther Flesch"
-        ],
-        [
-          "Sawyer",
-          "Jürgen Thormann"
-        ],
-        [
-          "Museumsbesucherin",
-          "Beate Hasenau"
-        ],
-        [
-          "Gärtner",
-          "Günther Dockerill"
-        ],
-        [
-          "Mr. Rossing",
-          "Eric Vaessen"
-        ],
-        [
-          "Rossings Assistentin",
-          "Claudia Schermutzki"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Michael Cross",
+          "sprecher" : "Matthias Klimsa"
+        },
+        {
+          "rolle" : "Mrs. Cross",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Mr. Cross",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Grady Markels",
+          "sprecher" : "Gerd Baltus"
+        },
+        {
+          "rolle" : "Brackmann",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Margie",
+          "sprecher" : "Monika Gabriel"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Sawyer",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Museumsbesucherin",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Gärtner",
+          "sprecher" : "Günther Dockerill"
+        },
+        {
+          "rolle" : "Mr. Rossing",
+          "sprecher" : "Eric Vaessen"
+        },
+        {
+          "rolle" : "Rossings Assistentin",
+          "sprecher" : "Claudia Schermutzki"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/042/metadata.json",
@@ -4781,79 +4836,79 @@
           "end" : 3050920
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Lucille",
-          "Petra Kaminski"
-        ],
-        [
-          "Charles",
-          "Henry Kielmann"
-        ],
-        [
-          "McLain",
-          "Rolf Jülich"
-        ],
-        [
-          "Verleiher",
-          "Hartmut Kollakowsky"
-        ],
-        [
-          "Kellnerin",
-          "Beate Hasenau"
-        ],
-        [
-          "Sears",
-          "Manfred Liptow"
-        ],
-        [
-          "Evans",
-          "Bernd Fallske"
-        ],
-        [
-          "Pelzhändler",
-          "Eric Vaessen"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Lucilles Mutter",
-          "Astrid Kollex"
-        ],
-        [
-          "Sekretärin",
-          "Eva Gelb"
-        ],
-        [
-          "Mädchen",
-          "Veronika Neugebauer"
-        ],
-        [
-          "Junge 1",
-          "Manou Lubowski"
-        ],
-        [
-          "Junge 2",
-          "Niki Nowotny"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Lucille",
+          "sprecher" : "Petra Kaminski"
+        },
+        {
+          "rolle" : "Charles",
+          "sprecher" : "Henry Kielmann"
+        },
+        {
+          "rolle" : "McLain",
+          "sprecher" : "Rolf Jülich"
+        },
+        {
+          "rolle" : "Verleiher",
+          "sprecher" : "Hartmut Kollakowsky"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Sears",
+          "sprecher" : "Manfred Liptow"
+        },
+        {
+          "rolle" : "Evans",
+          "sprecher" : "Bernd Fallske"
+        },
+        {
+          "rolle" : "Pelzhändler",
+          "sprecher" : "Eric Vaessen"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Lucilles Mutter",
+          "sprecher" : "Astrid Kollex"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Eva Gelb"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Veronika Neugebauer"
+        },
+        {
+          "rolle" : "Junge 1",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Junge 2",
+          "sprecher" : "Niki Nowotny"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/043/metadata.json",
@@ -4912,55 +4967,56 @@
           "end" : 3012147
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Milton",
-          "Horst Naumann"
-        ],
-        [
-          "Bonehead",
-          "Sascha Draeger"
-        ],
-        [
-          "Peggy",
-          "Veronika Neugebauer"
-        ],
-        [
-          "Footsie",
-          "Niki Nowotny"
-        ],
-        [
-          "Bloodhound",
-          "Manou Lubowski"
-        ],
-        [
-          "Lomax",
-          "Peter Pantel [Wolf Rahtjen]"
-        ],
-        [
-          "Tante Mathilda",
-          "Dorothea Kaiser"
-        ],
-        [
-          "Gordon Harker",
-          "Stefan Brönneke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Milton",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Bonehead",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Peggy",
+          "sprecher" : "Veronika Neugebauer"
+        },
+        {
+          "rolle" : "Footsie",
+          "sprecher" : "Niki Nowotny"
+        },
+        {
+          "rolle" : "Bloodhound",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Lomax",
+          "sprecher" : "Wolf Rahtjen",
+          "pseudonym" : "Peter Pantel"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Dorothea Kaiser"
+        },
+        {
+          "rolle" : "Gordon Harker",
+          "sprecher" : "Stefan Brönneke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/044/metadata.json",
@@ -5019,59 +5075,62 @@
           "end" : 2827347
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ingmar Ragnarson",
-          "Rolf E. Schenker"
-        ],
-        [
-          "Karl Ragnarson",
-          "Utz Richter"
-        ],
-        [
-          "Sam Ragnarson",
-          "Marco Kröger [Lutz Harder]"
-        ],
-        [
-          "Mr. Manning",
-          "Achim Schülke"
-        ],
-        [
-          "Mrs. Manning",
-          "Julia Mahnkopf [Micaëla Kreißler]"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mrs. Andrews",
-          "Anne Schermutzki"
-        ],
-        [
-          "Mr. Andrews",
-          "Manfred Bendixen [Günter König]"
-        ],
-        [
-          "Tante Mathilda",
-          "Ursula Vogel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ingmar Ragnarson",
+          "sprecher" : "Rolf E. Schenker"
+        },
+        {
+          "rolle" : "Karl Ragnarson",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Sam Ragnarson",
+          "sprecher" : "Lutz Harder",
+          "pseudonym" : "Marco Kröger"
+        },
+        {
+          "rolle" : "Mr. Manning",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Mrs. Manning",
+          "sprecher" : "Micaëla Kreißler",
+          "pseudonym" : "Julia Mahnkopf"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Anne Schermutzki"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König",
+          "pseudonym" : "Manfred Bendixen"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Ursula Vogel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/045/metadata.json",
@@ -5130,63 +5189,63 @@
           "end" : 2853253
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Harry Burnside",
-          "Thomas Naumann"
-        ],
-        [
-          "Millionär Pilcher",
-          "Michael von Rospatt"
-        ],
-        [
-          "Marilyn Pilcher",
-          "Gabriele Libbach"
-        ],
-        [
-          "Sekretär Sanchez",
-          "Walter Eltz"
-        ],
-        [
-          "Harald Durham",
-          "Ernst A. Frantz"
-        ],
-        [
-          "Frau Durham",
-          "Micaëla Kreißler"
-        ],
-        [
-          "Jim Westerbrook",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "Mrs. Westerbrook",
-          "Gerlinde Dillge"
-        ],
-        [
-          "Dr. Gonzaga",
-          "Manfred Liptow"
-        ],
-        [
-          "Ramon Navarro",
-          "Norbert Lange"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Harry Burnside",
+          "sprecher" : "Thomas Naumann"
+        },
+        {
+          "rolle" : "Millionär Pilcher",
+          "sprecher" : "Michael von Rospatt"
+        },
+        {
+          "rolle" : "Marilyn Pilcher",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Sekretär Sanchez",
+          "sprecher" : "Walter Eltz"
+        },
+        {
+          "rolle" : "Harald Durham",
+          "sprecher" : "Ernst A. Frantz"
+        },
+        {
+          "rolle" : "Frau Durham",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Jim Westerbrook",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "Mrs. Westerbrook",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Dr. Gonzaga",
+          "sprecher" : "Manfred Liptow"
+        },
+        {
+          "rolle" : "Ramon Navarro",
+          "sprecher" : "Norbert Lange"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/046/metadata.json",
@@ -5245,55 +5304,55 @@
           "end" : 2842373
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Kelly",
-          "Kerstin Draeger"
-        ],
-        [
-          "Julia Crown",
-          "Tessa Gasser"
-        ],
-        [
-          "Big Barney Crown",
-          "Wolfgang Völz"
-        ],
-        [
-          "Schwester Lazar",
-          "Hildegard Krekel"
-        ],
-        [
-          "Don Dellasandro",
-          "Jürgen Thormann"
-        ],
-        [
-          "Pandro Mischkin",
-          "Michael Harck"
-        ],
-        [
-          "Kranführer Dick",
-          "Ernst von Klipstein"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Julia Crown",
+          "sprecher" : "Tessa Gasser"
+        },
+        {
+          "rolle" : "Big Barney Crown",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Schwester Lazar",
+          "sprecher" : "Hildegard Krekel"
+        },
+        {
+          "rolle" : "Don Dellasandro",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Pandro Mischkin",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Kranführer Dick",
+          "sprecher" : "Ernst von Klipstein"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/047/metadata.json",
@@ -5352,55 +5411,55 @@
           "end" : 2878867
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Daniel",
-          "Gosta Liptow"
-        ],
-        [
-          "Mary",
-          "Anja Ziemer"
-        ],
-        [
-          "Häuptling Turner",
-          "Norbert Lange"
-        ],
-        [
-          "Schamane",
-          "Douglas Welbat"
-        ],
-        [
-          "Unternehmer Mancarrow",
-          "Holger Mahlich"
-        ],
-        [
-          "Ganove Biff",
-          "Lutz Harder"
-        ],
-        [
-          "Ganove George",
-          "Manfred Liptow"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Daniel",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Anja Ziemer"
+        },
+        {
+          "rolle" : "Häuptling Turner",
+          "sprecher" : "Norbert Lange"
+        },
+        {
+          "rolle" : "Schamane",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Unternehmer Mancarrow",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Ganove Biff",
+          "sprecher" : "Lutz Harder"
+        },
+        {
+          "rolle" : "Ganove George",
+          "sprecher" : "Manfred Liptow"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/048/metadata.json",
@@ -5459,51 +5518,52 @@
           "end" : 2670120
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Axel Griswold",
-          "Helgo Liebig"
-        ],
-        [
-          "Purvis",
-          "Heiner Kramm [Michael Quiatkowsky]"
-        ],
-        [
-          "Dan DeMento",
-          "Peter Heinrich"
-        ],
-        [
-          "Leo Rottweiler",
-          "Reiner Brönneke"
-        ],
-        [
-          "Steve Trash",
-          "Michael Griem"
-        ],
-        [
-          "Rainey Fields",
-          "Xenia Hey"
-        ],
-        [
-          "Junge",
-          "Leonhard Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Axel Griswold",
+          "sprecher" : "Helgo Liebig"
+        },
+        {
+          "rolle" : "Purvis",
+          "sprecher" : "Michael Quiatkowsky",
+          "pseudonym" : "Heiner Kramm"
+        },
+        {
+          "rolle" : "Dan DeMento",
+          "sprecher" : "Peter Heinrich"
+        },
+        {
+          "rolle" : "Leo Rottweiler",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Steve Trash",
+          "sprecher" : "Michael Griem"
+        },
+        {
+          "rolle" : "Rainey Fields",
+          "sprecher" : "Xenia Hey"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Leonhard Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/049/metadata.json",
@@ -5563,51 +5623,51 @@
           "end" : 3435173
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jon Travis",
-          "Rolf Becker"
-        ],
-        [
-          "Marty Morningbaum",
-          "Helmut Ahner"
-        ],
-        [
-          "Diller Rourke",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "Marble Ackbourne-Smith",
-          "Wolf Rahtjen"
-        ],
-        [
-          "Margo",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Kevin",
-          "Fred Maire"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jon Travis",
+          "sprecher" : "Rolf Becker"
+        },
+        {
+          "rolle" : "Marty Morningbaum",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Diller Rourke",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "Marble Ackbourne-Smith",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Margo",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Kevin",
+          "sprecher" : "Fred Maire"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/050/metadata.json",
@@ -5667,39 +5727,39 @@
           "end" : 3270107
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mercedes",
-          "Marianne Kehlau"
-        ],
-        [
-          "Brit",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Dusty Rice",
-          "Achim Schülke"
-        ],
-        [
-          "Ascension",
-          "Eckart Dux"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mercedes",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Brit",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Dusty Rice",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Ascension",
+          "sprecher" : "Eckart Dux"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/051/metadata.json",
@@ -5759,71 +5819,71 @@
           "end" : 3267773
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brick",
-          "Rainer Schmitt"
-        ],
-        [
-          "Thanom",
-          "Peter Heinrich"
-        ],
-        [
-          "Prem",
-          "Lutz Mackensy"
-        ],
-        [
-          "Butler",
-          "Gerd Baltus"
-        ],
-        [
-          "Sax Sandler",
-          "Andreas Mannkopff"
-        ],
-        [
-          "Celeste",
-          "Michaela Gröger"
-        ],
-        [
-          "Lara",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Rivers",
-          "Wolfgang Völz"
-        ],
-        [
-          "Hansen",
-          "Verena Wiet"
-        ],
-        [
-          "Maxi",
-          "Hildegard Krekel"
-        ],
-        [
-          "Quill",
-          "Matthias Bullach"
-        ],
-        [
-          "Tony",
-          "Michael Quiatkowsky"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brick",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Thanom",
+          "sprecher" : "Peter Heinrich"
+        },
+        {
+          "rolle" : "Prem",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Gerd Baltus"
+        },
+        {
+          "rolle" : "Sax Sandler",
+          "sprecher" : "Andreas Mannkopff"
+        },
+        {
+          "rolle" : "Celeste",
+          "sprecher" : "Michaela Gröger"
+        },
+        {
+          "rolle" : "Lara",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Rivers",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Hansen",
+          "sprecher" : "Verena Wiet"
+        },
+        {
+          "rolle" : "Maxi",
+          "sprecher" : "Hildegard Krekel"
+        },
+        {
+          "rolle" : "Quill",
+          "sprecher" : "Matthias Bullach"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Michael Quiatkowsky"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/052/metadata.json",
@@ -5883,59 +5943,59 @@
           "end" : 3203173
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Ty Cassey",
-          "Stefan Brönneke"
-        ],
-        [
-          "Inspektor Cole",
-          "Wolfgang Schimmelpfennig"
-        ],
-        [
-          "Kommissar Maxim",
-          "Peter Matić"
-        ],
-        [
-          "Gilbar",
-          "Rolf Becker"
-        ],
-        [
-          "Torres",
-          "Douglas Welbat"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Jake Hatch",
-          "Hans Barein"
-        ],
-        [
-          "Tiburon",
-          "Michael Quiatkowsky"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Ty Cassey",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Inspektor Cole",
+          "sprecher" : "Wolfgang Schimmelpfennig"
+        },
+        {
+          "rolle" : "Kommissar Maxim",
+          "sprecher" : "Peter Matić"
+        },
+        {
+          "rolle" : "Gilbar",
+          "sprecher" : "Rolf Becker"
+        },
+        {
+          "rolle" : "Torres",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Jake Hatch",
+          "sprecher" : "Hans Barein"
+        },
+        {
+          "rolle" : "Tiburon",
+          "sprecher" : "Michael Quiatkowsky"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/053/metadata.json",
@@ -5995,59 +6055,60 @@
           "end" : 3048040
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Buzz Newman",
-          "Christian Weber [Manou Lubowski]"
-        ],
-        [
-          "George Brandon",
-          "Fabian Harloff"
-        ],
-        [
-          "Jim Bernardie",
-          "Holger Mahlich"
-        ],
-        [
-          "Firestone",
-          "Peter Schiff"
-        ],
-        [
-          "Crocker",
-          "Lothar Grützner"
-        ],
-        [
-          "Lovell Madeira",
-          "Rainer Schmitt"
-        ],
-        [
-          "Vic Hammell",
-          "Ben Tappé"
-        ],
-        [
-          "Dan",
-          "Henry König"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Buzz Newman",
+          "sprecher" : "Manou Lubowski",
+          "pseudonym" : "Christian Weber"
+        },
+        {
+          "rolle" : "George Brandon",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Jim Bernardie",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Firestone",
+          "sprecher" : "Peter Schiff"
+        },
+        {
+          "rolle" : "Crocker",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Lovell Madeira",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Vic Hammell",
+          "sprecher" : "Ben Tappé"
+        },
+        {
+          "rolle" : "Dan",
+          "sprecher" : "Henry König"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/054/metadata.json",
@@ -6107,63 +6168,63 @@
           "end" : 3056533
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Trainer Tong",
-          "Michael Harck"
-        ],
-        [
-          "Trainer Duggan",
-          "Douglas Welbat"
-        ],
-        [
-          "Präsident Harper",
-          "Eric Vaessen"
-        ],
-        [
-          "Jerri",
-          "Samira Chanfir"
-        ],
-        [
-          "Nora",
-          "Ann Montenbruck"
-        ],
-        [
-          "Cory",
-          "Ben Tappé"
-        ],
-        [
-          "Norman",
-          "Henry König"
-        ],
-        [
-          "Powers",
-          "Hans Clarin"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Trainer Tong",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Trainer Duggan",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Präsident Harper",
+          "sprecher" : "Eric Vaessen"
+        },
+        {
+          "rolle" : "Jerri",
+          "sprecher" : "Samira Chanfir"
+        },
+        {
+          "rolle" : "Nora",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Cory",
+          "sprecher" : "Ben Tappé"
+        },
+        {
+          "rolle" : "Norman",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Powers",
+          "sprecher" : "Hans Clarin"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/055/metadata.json",
@@ -6223,63 +6284,63 @@
           "end" : 2967587
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Liz",
-          "Verena Großer"
-        ],
-        [
-          "Harold",
-          "Willi Röbke"
-        ],
-        [
-          "Dose",
-          "Jan-Friedrich Conrad"
-        ],
-        [
-          "Silas Ek",
-          "Hans Sievers"
-        ],
-        [
-          "Sekretär",
-          "Eckart Dux"
-        ],
-        [
-          "Jan",
-          "Stefan Brönneke"
-        ],
-        [
-          "Lys",
-          "Annika Pages"
-        ],
-        [
-          "Branson Barr",
-          "Michael Harck"
-        ],
-        [
-          "Norton Rome",
-          "Douglas Welbat"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Liz",
+          "sprecher" : "Verena Großer"
+        },
+        {
+          "rolle" : "Harold",
+          "sprecher" : "Willi Röbke"
+        },
+        {
+          "rolle" : "Dose",
+          "sprecher" : "Jan-Friedrich Conrad"
+        },
+        {
+          "rolle" : "Silas Ek",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Sekretär",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Jan",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Annika Pages"
+        },
+        {
+          "rolle" : "Branson Barr",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Norton Rome",
+          "sprecher" : "Douglas Welbat"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/056/metadata.json",
@@ -6339,55 +6400,55 @@
           "end" : 2605187
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mary, Artistin",
-          "Heidrun von Goessel"
-        ],
-        [
-          "Winkler, Zirkusdirektor",
-          "Helmut Ahner"
-        ],
-        [
-          "Pipo, Clown",
-          "Arthur Brauss"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Cotta",
-          "Michael Poelchau"
-        ],
-        [
-          "Alma",
-          "Eva Zlonitzky"
-        ],
-        [
-          "Schwester",
-          "Gerda-Maria Jürgens"
-        ],
-        [
-          "Shirley Kubinski",
-          "Thea Frank"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mary, Artistin",
+          "sprecher" : "Heidrun von Goessel"
+        },
+        {
+          "rolle" : "Winkler, Zirkusdirektor",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Pipo, Clown",
+          "sprecher" : "Arthur Brauss"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Michael Poelchau"
+        },
+        {
+          "rolle" : "Alma",
+          "sprecher" : "Eva Zlonitzky"
+        },
+        {
+          "rolle" : "Schwester",
+          "sprecher" : "Gerda-Maria Jürgens"
+        },
+        {
+          "rolle" : "Shirley Kubinski",
+          "sprecher" : "Thea Frank"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/057/metadata.json",
@@ -6447,59 +6508,60 @@
           "end" : 2711893
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "William Ashley",
-          "Franz Rudnick"
-        ],
-        [
-          "Burt Ashley",
-          "Knut Basewitz"
-        ],
-        [
-          "Pecker, Angestellter",
-          "Lutz Büschken"
-        ],
-        [
-          "Axel",
-          "Tobias Pauls"
-        ],
-        [
-          "Lys",
-          "Kerstin Draeger"
-        ],
-        [
-          "Mrs. Bloomingdale",
-          "Eva Zlonitzky"
-        ],
-        [
-          "Stella",
-          "Rebecca Völz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "William Ashley",
+          "sprecher" : "Franz Rudnick"
+        },
+        {
+          "rolle" : "Burt Ashley",
+          "sprecher" : "Knut Basewitz"
+        },
+        {
+          "rolle" : "Pecker, Angestellter",
+          "sprecher" : "Lutz Büschken"
+        },
+        {
+          "rolle" : "Axel",
+          "sprecher" : "Tobias Pauls"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Mrs. Bloomingdale",
+          "sprecher" : "Eva Zlonitzky"
+        },
+        {
+          "rolle" : "Stella",
+          "sprecher" : "Rebecca Völz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/058/metadata.json",
@@ -6559,59 +6621,59 @@
           "end" : 2667307
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ruth, Zeitungs-Journalistin",
-          "Hansi Jochmann"
-        ],
-        [
-          "Jean Baxter, TV-Journalistin",
-          "Heidrun von Goessel"
-        ],
-        [
-          "Van Well, Pressechef",
-          "Ulrich Faulhaber"
-        ],
-        [
-          "Sinagua, Indianerin",
-          "Samira Chanfir"
-        ],
-        [
-          "Chosmo, Journalist",
-          "Matthias Bullach"
-        ],
-        [
-          "Monsieur Jaubert",
-          "Michael Poelchau"
-        ],
-        [
-          "René Hancock",
-          "Thomas Schüler"
-        ],
-        [
-          "Joan Brown",
-          "Rebecca Völz"
-        ],
-        [
-          "Hendrik Walton, Fabrikant",
-          "Michael Mechel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ruth, Zeitungs-Journalistin",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Jean Baxter, TV-Journalistin",
+          "sprecher" : "Heidrun von Goessel"
+        },
+        {
+          "rolle" : "Van Well, Pressechef",
+          "sprecher" : "Ulrich Faulhaber"
+        },
+        {
+          "rolle" : "Sinagua, Indianerin",
+          "sprecher" : "Samira Chanfir"
+        },
+        {
+          "rolle" : "Chosmo, Journalist",
+          "sprecher" : "Matthias Bullach"
+        },
+        {
+          "rolle" : "Monsieur Jaubert",
+          "sprecher" : "Michael Poelchau"
+        },
+        {
+          "rolle" : "René Hancock",
+          "sprecher" : "Thomas Schüler"
+        },
+        {
+          "rolle" : "Joan Brown",
+          "sprecher" : "Rebecca Völz"
+        },
+        {
+          "rolle" : "Hendrik Walton, Fabrikant",
+          "sprecher" : "Michael Mechel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/059/metadata.json",
@@ -6671,63 +6733,64 @@
           "end" : 2826880
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Glenn Miles",
-          "Christian Stark"
-        ],
-        [
-          "Benny",
-          "Tobias Pauls"
-        ],
-        [
-          "Tom Descanso, Trainer",
-          "Prof. Justus Frantz"
-        ],
-        [
-          "Field, Lehrer",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "Hutchins, Sport-Reporter",
-          "Uwe Büschken"
-        ],
-        [
-          "Dr. Landman, Schuldirektor",
-          "Gerd Duwner"
-        ],
-        [
-          "Stan",
-          "Tilman Madaus"
-        ],
-        [
-          "Eleonore Sharp",
-          "Margot Linde [Eva Maria Bauer]"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Glenn Miles",
+          "sprecher" : "Christian Stark"
+        },
+        {
+          "rolle" : "Benny",
+          "sprecher" : "Tobias Pauls"
+        },
+        {
+          "rolle" : "Tom Descanso, Trainer",
+          "sprecher" : "Prof. Justus Frantz"
+        },
+        {
+          "rolle" : "Field, Lehrer",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "Hutchins, Sport-Reporter",
+          "sprecher" : "Uwe Büschken"
+        },
+        {
+          "rolle" : "Dr. Landman, Schuldirektor",
+          "sprecher" : "Gerd Duwner"
+        },
+        {
+          "rolle" : "Stan",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Eleonore Sharp",
+          "sprecher" : "Eva Maria Bauer",
+          "pseudonym" : "Margot Linde"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/060/metadata.json",
@@ -6787,63 +6850,63 @@
           "end" : 3569320
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Milton Mitchell",
-          "Holger Mahlich"
-        ],
-        [
-          "Fred Hall",
-          "Thomas Thomé"
-        ],
-        [
-          "Anne",
-          "Janina Richter"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Kellner",
-          "Thomas M. Stein"
-        ],
-        [
-          "Portland",
-          "Wolfgang Völz"
-        ],
-        [
-          "Inspektor Cotta",
-          "Willem Fricke"
-        ],
-        [
-          "Charlie",
-          "Anne Marr"
-        ],
-        [
-          "Kundin",
-          "Ursula Sieg"
-        ],
-        [
-          "Adams",
-          "Hans Hessling"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Milton Mitchell",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Fred Hall",
+          "sprecher" : "Thomas Thomé"
+        },
+        {
+          "rolle" : "Anne",
+          "sprecher" : "Janina Richter"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Kellner",
+          "sprecher" : "Thomas M. Stein"
+        },
+        {
+          "rolle" : "Portland",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Willem Fricke"
+        },
+        {
+          "rolle" : "Charlie",
+          "sprecher" : "Anne Marr"
+        },
+        {
+          "rolle" : "Kundin",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Adams",
+          "sprecher" : "Hans Hessling"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/061/metadata.json",
@@ -6903,63 +6966,63 @@
           "end" : 3563227
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Amanda Black",
-          "Beate Hasenau"
-        ],
-        [
-          "Mrs. Silverstone",
-          "Barbara Ratthey"
-        ],
-        [
-          "Mr. Garfield",
-          "Utz Richter"
-        ],
-        [
-          "Mr. Hartford",
-          "Hans Hessling"
-        ],
-        [
-          "Mrs. Hartford",
-          "Ursula Sieg"
-        ],
-        [
-          "Mrs. Green",
-          "Monika Werner"
-        ],
-        [
-          "Henry",
-          "Lutz Schnell"
-        ],
-        [
-          "Lys",
-          "Kerstin Draeger"
-        ],
-        [
-          "Linda",
-          "Janina Richter"
-        ],
-        [
-          "Inspektor Cotta",
-          "Willem Fricke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Amanda Black",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Mrs. Silverstone",
+          "sprecher" : "Barbara Ratthey"
+        },
+        {
+          "rolle" : "Mr. Garfield",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Mr. Hartford",
+          "sprecher" : "Hans Hessling"
+        },
+        {
+          "rolle" : "Mrs. Hartford",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Mrs. Green",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Henry",
+          "sprecher" : "Lutz Schnell"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Linda",
+          "sprecher" : "Janina Richter"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Willem Fricke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/062/metadata.json",
@@ -7019,63 +7082,64 @@
           "end" : 4014467
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Jimboy-Jonas",
-          "Frank Meyer-Brockmann"
-        ],
-        [
-          "Mr. Bow",
-          "Klaus Sonnenschein"
-        ],
-        [
-          "Eric Randolph",
-          "Achim Schülke"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Elizabeth",
-          "Verena Großer"
-        ],
-        [
-          "Lys",
-          "Kerstin Draeger"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Tamara Mostowsky",
-          "Astrid Kollex"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Jimboy-Jonas",
+          "sprecher" : "Frank Meyer-Brockmann"
+        },
+        {
+          "rolle" : "Mr. Bow",
+          "sprecher" : "Klaus Sonnenschein"
+        },
+        {
+          "rolle" : "Eric Randolph",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Elizabeth",
+          "sprecher" : "Verena Großer"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Tamara Mostowsky",
+          "sprecher" : "Astrid Kollex"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/063/metadata.json",
@@ -7135,63 +7199,64 @@
           "end" : 3969547
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Capistrano",
-          "Hans Sievers"
-        ],
-        [
-          "Sergeant Hawthrone",
-          "Jürgen Kopp"
-        ],
-        [
-          "Simon Oames",
-          "Peter Kirchberger"
-        ],
-        [
-          "Silvie Oames",
-          "Edith Hancke"
-        ],
-        [
-          "Michael Julius Oames",
-          "Günther Jerschke"
-        ],
-        [
-          "Mandy Taylor",
-          "Micaëla Kreißler"
-        ],
-        [
-          "Deborah Street",
-          "Astrid Kollex"
-        ],
-        [
-          "Greenwater",
-          "Norman Messer [André Minninger]"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Capistrano",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Sergeant Hawthrone",
+          "sprecher" : "Jürgen Kopp"
+        },
+        {
+          "rolle" : "Simon Oames",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Silvie Oames",
+          "sprecher" : "Edith Hancke"
+        },
+        {
+          "rolle" : "Michael Julius Oames",
+          "sprecher" : "Günther Jerschke"
+        },
+        {
+          "rolle" : "Mandy Taylor",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Deborah Street",
+          "sprecher" : "Astrid Kollex"
+        },
+        {
+          "rolle" : "Greenwater",
+          "sprecher" : "André Minninger",
+          "pseudonym" : "Norman Messer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/064/metadata.json",
@@ -7251,71 +7316,71 @@
           "end" : 3579173
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Alex Burlington",
-          "Klaus Sonnenschein"
-        ],
-        [
-          "Richard Applebloome",
-          "Tilman Madaus"
-        ],
-        [
-          "Robert Applebloome",
-          "Franz Rudnick"
-        ],
-        [
-          "Mary",
-          "Edith Hancke"
-        ],
-        [
-          "Elizabeth",
-          "Marianne Kehlau"
-        ],
-        [
-          "John Smith",
-          "Dirk Anton"
-        ],
-        [
-          "Jenkins",
-          "Douglas Welbat"
-        ],
-        [
-          "Thomas",
-          "Stephan Chrzescinski"
-        ],
-        [
-          "Andrew",
-          "Michael von Rospatt"
-        ],
-        [
-          "Mrs. Rodriguez",
-          "Katja Brügger"
-        ],
-        [
-          "Hoteldirektor",
-          "Hans Sievers"
-        ],
-        [
-          "Blondine",
-          "Veronika Neugebauer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Alex Burlington",
+          "sprecher" : "Klaus Sonnenschein"
+        },
+        {
+          "rolle" : "Richard Applebloome",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Robert Applebloome",
+          "sprecher" : "Franz Rudnick"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Edith Hancke"
+        },
+        {
+          "rolle" : "Elizabeth",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "John Smith",
+          "sprecher" : "Dirk Anton"
+        },
+        {
+          "rolle" : "Jenkins",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Thomas",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Andrew",
+          "sprecher" : "Michael von Rospatt"
+        },
+        {
+          "rolle" : "Mrs. Rodriguez",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Hoteldirektor",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Blondine",
+          "sprecher" : "Veronika Neugebauer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/065/metadata.json",
@@ -7375,55 +7440,55 @@
           "end" : 3555013
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Alberto Bergamelli, Fotograf",
-          "Holger Mahlich"
-        ],
-        [
-          "Alexandra",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Ignazio, Pensionswirt",
-          "Leonardo Cusenza"
-        ],
-        [
-          "Sofia, Pensionswirtin",
-          "Maria Chirivi"
-        ],
-        [
-          "Franca",
-          "Samira Chanfir"
-        ],
-        [
-          "Italienerin",
-          "Francesca Chiavon"
-        ],
-        [
-          "Italiener 1",
-          "Marcello Grassi"
-        ],
-        [
-          "Italiener 2",
-          "Luigi Pane"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Alberto Bergamelli, Fotograf",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Alexandra",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Ignazio, Pensionswirt",
+          "sprecher" : "Leonardo Cusenza"
+        },
+        {
+          "rolle" : "Sofia, Pensionswirtin",
+          "sprecher" : "Maria Chirivi"
+        },
+        {
+          "rolle" : "Franca",
+          "sprecher" : "Samira Chanfir"
+        },
+        {
+          "rolle" : "Italienerin",
+          "sprecher" : "Francesca Chiavon"
+        },
+        {
+          "rolle" : "Italiener 1",
+          "sprecher" : "Marcello Grassi"
+        },
+        {
+          "rolle" : "Italiener 2",
+          "sprecher" : "Luigi Pane"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/066/metadata.json",
@@ -7483,59 +7548,59 @@
           "end" : 3799320
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Babette Eberle",
-          "Michael von Rospatt"
-        ],
-        [
-          "Bruder Benedikt",
-          "Tassilo Jelde"
-        ],
-        [
-          "Mylná",
-          "Utz Richter"
-        ],
-        [
-          "Alexandra",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Wirt",
-          "Hans Paetsch"
-        ],
-        [
-          "Wirtin",
-          "Ingeborg Ottmann"
-        ],
-        [
-          "Max",
-          "Lutz Schnell"
-        ],
-        [
-          "Polizist 1",
-          "Boris von Sychowski"
-        ],
-        [
-          "Polizist 2",
-          "Frank Meyer-Brockmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Babette Eberle",
+          "sprecher" : "Michael von Rospatt"
+        },
+        {
+          "rolle" : "Bruder Benedikt",
+          "sprecher" : "Tassilo Jelde"
+        },
+        {
+          "rolle" : "Mylná",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Alexandra",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Wirt",
+          "sprecher" : "Hans Paetsch"
+        },
+        {
+          "rolle" : "Wirtin",
+          "sprecher" : "Ingeborg Ottmann"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Lutz Schnell"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Boris von Sychowski"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Frank Meyer-Brockmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/067/metadata.json",
@@ -7595,39 +7660,39 @@
           "end" : 3581227
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jerzy",
-          "Michael Bideller"
-        ],
-        [
-          "Mariana",
-          "Antje Roosch"
-        ],
-        [
-          "Mann 1",
-          "Nicolas König"
-        ],
-        [
-          "Mann 2",
-          "Lutz Schnell"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jerzy",
+          "sprecher" : "Michael Bideller"
+        },
+        {
+          "rolle" : "Mariana",
+          "sprecher" : "Antje Roosch"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Lutz Schnell"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/068/metadata.json",
@@ -7687,71 +7752,72 @@
           "end" : 3942387
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Erna Fiedler",
-          "Ursula Gompf"
-        ],
-        [
-          "Dr. Ferguson",
-          "Antje Cornelius"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "John Brady",
-          "Dirk Anton"
-        ],
-        [
-          "Matt Brady",
-          "Volker Bogdan"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Mr. Shaw",
-          "Eberhard Haar"
-        ],
-        [
-          "Mrs. Shaw",
-          "Heikedine Körting"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Erna Fiedler",
+          "sprecher" : "Ursula Gompf"
+        },
+        {
+          "rolle" : "Dr. Ferguson",
+          "sprecher" : "Antje Cornelius"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "John Brady",
+          "sprecher" : "Dirk Anton"
+        },
+        {
+          "rolle" : "Matt Brady",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/069/metadata.json",
@@ -7811,63 +7877,63 @@
           "end" : 3784293
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Alan",
-          "Oliver Reinhard"
-        ],
-        [
-          "Sally Samson",
-          "Cornelia Meinhardt"
-        ],
-        [
-          "Sofie Samson",
-          "Samira Chanfir"
-        ],
-        [
-          "Dr. Harris",
-          "Hansi Jochmann"
-        ],
-        [
-          "John Davis",
-          "Tim Wieck"
-        ],
-        [
-          "Homer Washington",
-          "Hans Sievers"
-        ],
-        [
-          "Fahrer",
-          "Klaus-Peter Kaehler"
-        ],
-        [
-          "Brenda",
-          "Micaëla Kreißler"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Junge",
-          "Jona Mues"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Alan",
+          "sprecher" : "Oliver Reinhard"
+        },
+        {
+          "rolle" : "Sally Samson",
+          "sprecher" : "Cornelia Meinhardt"
+        },
+        {
+          "rolle" : "Sofie Samson",
+          "sprecher" : "Samira Chanfir"
+        },
+        {
+          "rolle" : "Dr. Harris",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "John Davis",
+          "sprecher" : "Tim Wieck"
+        },
+        {
+          "rolle" : "Homer Washington",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Fahrer",
+          "sprecher" : "Klaus-Peter Kaehler"
+        },
+        {
+          "rolle" : "Brenda",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Jona Mues"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/070/metadata.json",
@@ -7927,75 +7993,76 @@
           "end" : 3994440
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Lu Kwan",
-          "Susanne von Loessl"
-        ],
-        [
-          "Jefferson",
-          "Christian Redl"
-        ],
-        [
-          "Dimitrios, Bankdirektor",
-          "Wilhelm Wieben"
-        ],
-        [
-          "Dan Jordan, Reporter",
-          "Michael Lott"
-        ],
-        [
-          "Olivia",
-          "Eva Weissmann"
-        ],
-        [
-          "Santoria",
-          "Dieter Ohlendiek"
-        ],
-        [
-          "Pertier",
-          "Johann Herstermann"
-        ],
-        [
-          "Sergeant",
-          "Ingvar Jensen"
-        ],
-        [
-          "Irma",
-          "Konstanze Ullmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Lu Kwan",
+          "sprecher" : "Susanne von Loessl"
+        },
+        {
+          "rolle" : "Jefferson",
+          "sprecher" : "Christian Redl"
+        },
+        {
+          "rolle" : "Dimitrios, Bankdirektor",
+          "sprecher" : "Wilhelm Wieben"
+        },
+        {
+          "rolle" : "Dan Jordan, Reporter",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Olivia",
+          "sprecher" : "Eva Weissmann"
+        },
+        {
+          "rolle" : "Santoria",
+          "sprecher" : "Dieter Ohlendiek"
+        },
+        {
+          "rolle" : "Pertier",
+          "sprecher" : "Johann Herstermann"
+        },
+        {
+          "rolle" : "Sergeant",
+          "sprecher" : "Ingvar Jensen"
+        },
+        {
+          "rolle" : "Irma",
+          "sprecher" : "Konstanze Ullmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/071/metadata.json",
@@ -8055,71 +8122,71 @@
           "end" : 3477893
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Laura McLaughin",
-          "Marianne Kehlau"
-        ],
-        [
-          "Malcolm King",
-          "Jörg Gillner"
-        ],
-        [
-          "Lansana King",
-          "Sabine Hahn"
-        ],
-        [
-          "Hester Dalton",
-          "Marianne Bernhardt"
-        ],
-        [
-          "Billie",
-          "Stefan Conradi"
-        ],
-        [
-          "Polizist",
-          "Oliver Reinhard"
-        ],
-        [
-          "Wachmann",
-          "Dieter Ohlendiek"
-        ],
-        [
-          "Wächter 2",
-          "Michael Lott"
-        ],
-        [
-          "Polizist 1",
-          "Torben Liebrecht"
-        ],
-        [
-          "Polizist 2",
-          "Rene Spiegelberger"
-        ],
-        [
-          "Kellnerin",
-          "Doris Jahn"
-        ],
-        [
-          "Kundin",
-          "Susan Jarling"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Laura McLaughin",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Malcolm King",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Lansana King",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Hester Dalton",
+          "sprecher" : "Marianne Bernhardt"
+        },
+        {
+          "rolle" : "Billie",
+          "sprecher" : "Stefan Conradi"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Oliver Reinhard"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Dieter Ohlendiek"
+        },
+        {
+          "rolle" : "Wächter 2",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Torben Liebrecht"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Rene Spiegelberger"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Doris Jahn"
+        },
+        {
+          "rolle" : "Kundin",
+          "sprecher" : "Susan Jarling"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/072/metadata.json",
@@ -8179,55 +8246,55 @@
           "end" : 3997320
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Madigan",
-          "Annemarie Marks-Rocke"
-        ],
-        [
-          "Eathon Easton, ihr Untermieter",
-          "Helgo Liebig"
-        ],
-        [
-          "Mrs. Lydia Cartier",
-          "Gerda Gmelin"
-        ],
-        [
-          "Sigourney, ihr Dienstmädchen",
-          "Susanne Beck"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Inspektor Kershaw",
-          "Frank Felicetti"
-        ],
-        [
-          "Hugenay",
-          "Hans Irle"
-        ],
-        [
-          "Museumswärterin",
-          "Marianne Kehlau"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Madigan",
+          "sprecher" : "Annemarie Marks-Rocke"
+        },
+        {
+          "rolle" : "Eathon Easton, ihr Untermieter",
+          "sprecher" : "Helgo Liebig"
+        },
+        {
+          "rolle" : "Mrs. Lydia Cartier",
+          "sprecher" : "Gerda Gmelin"
+        },
+        {
+          "rolle" : "Sigourney, ihr Dienstmädchen",
+          "sprecher" : "Susanne Beck"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Inspektor Kershaw",
+          "sprecher" : "Frank Felicetti"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Hans Irle"
+        },
+        {
+          "rolle" : "Museumswärterin",
+          "sprecher" : "Marianne Kehlau"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/073/metadata.json",
@@ -8287,71 +8354,72 @@
           "end" : 4442107
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Whitehead",
-          "Uwe Friedrichsen"
-        ],
-        [
-          "Steven Robinshaw, Anwalt",
-          "Helgo Liebig"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mary",
-          "Victoria Voncampe"
-        ],
-        [
-          "Stan",
-          "Georg Tryphon"
-        ],
-        [
-          "Jeffrey",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "John",
-          "Andreas Martens"
-        ],
-        [
-          "Dr. Wright",
-          "Dietmar Mues"
-        ],
-        [
-          "Carrie Hanson",
-          "Hella von der Osten-Sacken"
-        ],
-        [
-          "Tim Conrad",
-          "Moritz Gentsch"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Whitehead",
+          "sprecher" : "Uwe Friedrichsen"
+        },
+        {
+          "rolle" : "Steven Robinshaw, Anwalt",
+          "sprecher" : "Helgo Liebig"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Victoria Voncampe"
+        },
+        {
+          "rolle" : "Stan",
+          "sprecher" : "Georg Tryphon"
+        },
+        {
+          "rolle" : "Jeffrey",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "John",
+          "sprecher" : "Andreas Martens"
+        },
+        {
+          "rolle" : "Dr. Wright",
+          "sprecher" : "Dietmar Mues"
+        },
+        {
+          "rolle" : "Carrie Hanson",
+          "sprecher" : "Hella von der Osten-Sacken"
+        },
+        {
+          "rolle" : "Tim Conrad",
+          "sprecher" : "Moritz Gentsch"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/074/metadata.json",
@@ -8411,51 +8479,51 @@
           "end" : 3339600
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Shaw",
-          "Heikedine Körting"
-        ],
-        [
-          "Amanda Black",
-          "Beate Hasenau"
-        ],
-        [
-          "Detective Gregston",
-          "Wolf-Dietrich Berg"
-        ],
-        [
-          "Nora Sethons",
-          "Ursula Sieg"
-        ],
-        [
-          "Mrs. Aston",
-          "Joyceline Schmidt"
-        ],
-        [
-          "Mr. Krieger",
-          "Jörg Gillner"
-        ],
-        [
-          "Lisa Manninger",
-          "Katja Stichel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Amanda Black",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Detective Gregston",
+          "sprecher" : "Wolf-Dietrich Berg"
+        },
+        {
+          "rolle" : "Nora Sethons",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Mrs. Aston",
+          "sprecher" : "Joyceline Schmidt"
+        },
+        {
+          "rolle" : "Mr. Krieger",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Lisa Manninger",
+          "sprecher" : "Katja Stichel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/075/metadata.json",
@@ -8515,59 +8583,59 @@
           "end" : 4184827
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Abigail Holligan",
-          "Katharina Brauren"
-        ],
-        [
-          "Metzla Holligan",
-          "Beate Hasenau"
-        ],
-        [
-          "Clarissa Franklin",
-          "Judy Winter"
-        ],
-        [
-          "Dr. Miller",
-          "Marianne Kehlau"
-        ],
-        [
-          "Mrs. Petersen",
-          "Victoria Voncampe"
-        ],
-        [
-          "Sekretariat",
-          "\"Fettes Brot\""
-        ],
-        [
-          "Mr. Brian",
-          "Peter Schubert"
-        ],
-        [
-          "Mrs. Dream",
-          "Petra Ehlers"
-        ],
-        [
-          "Jack Cliffwater",
-          "Thomas Schüler"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Abigail Holligan",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Metzla Holligan",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Clarissa Franklin",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Dr. Miller",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Mrs. Petersen",
+          "sprecher" : "Victoria Voncampe"
+        },
+        {
+          "rolle" : "Sekretariat",
+          "sprecher" : "\"Fettes Brot\""
+        },
+        {
+          "rolle" : "Mr. Brian",
+          "sprecher" : "Peter Schubert"
+        },
+        {
+          "rolle" : "Mrs. Dream",
+          "sprecher" : "Petra Ehlers"
+        },
+        {
+          "rolle" : "Jack Cliffwater",
+          "sprecher" : "Thomas Schüler"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/076/metadata.json",
@@ -8617,67 +8685,68 @@
           "end" : 3559333
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Karen Sulzenberger",
-          "Kristina von Weltzien"
-        ],
-        [
-          "Nicola",
-          "Maria Fuchs"
-        ],
-        [
-          "McMannoman",
-          "Wolfgang Noack"
-        ],
-        [
-          "Tony",
-          "Martin Lohmann"
-        ],
-        [
-          "Mrs. Seven",
-          "Eva Gelb"
-        ],
-        [
-          "Trainer",
-          "Hans Sievers"
-        ],
-        [
-          "Roger",
-          "Klaus-Peter Kaehler"
-        ],
-        [
-          "Mann 1",
-          "Helmut Ahner"
-        ],
-        [
-          "Mann 2",
-          "Richard Ems"
-        ],
-        [
-          "Kellnerin",
-          "Micaëla Kreißler"
-        ],
-        [
-          "Uli",
-          "Norman Messer [André Minninger]"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Karen Sulzenberger",
+          "sprecher" : "Kristina von Weltzien"
+        },
+        {
+          "rolle" : "Nicola",
+          "sprecher" : "Maria Fuchs"
+        },
+        {
+          "rolle" : "McMannoman",
+          "sprecher" : "Wolfgang Noack"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Martin Lohmann"
+        },
+        {
+          "rolle" : "Mrs. Seven",
+          "sprecher" : "Eva Gelb"
+        },
+        {
+          "rolle" : "Trainer",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Roger",
+          "sprecher" : "Klaus-Peter Kaehler"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Richard Ems"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Uli",
+          "sprecher" : "André Minninger",
+          "pseudonym" : "Norman Messer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/077/metadata.json",
@@ -8727,63 +8796,64 @@
           "end" : 3448987
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Albert Hitfield",
-          "Manfred Steffen"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Lys",
-          "Kerstin Draeger"
-        ],
-        [
-          "J.J.",
-          "Gregor Reisch"
-        ],
-        [
-          "Julius Jonas",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Catherine Jonas",
-          "Anne Moll"
-        ],
-        [
-          "Arturo",
-          "Carlos Goiach"
-        ],
-        [
-          "Autovermieter",
-          "Richard Ems"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Albert Hitfield",
+          "sprecher" : "Manfred Steffen"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "J.J.",
+          "sprecher" : "Gregor Reisch"
+        },
+        {
+          "rolle" : "Julius Jonas",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Catherine Jonas",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Arturo",
+          "sprecher" : "Carlos Goiach"
+        },
+        {
+          "rolle" : "Autovermieter",
+          "sprecher" : "Richard Ems"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/078/metadata.json",
@@ -8843,67 +8913,70 @@
           "end" : 4612307
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Al Parker, Musikproduzent",
-          "Lennardt Krüger"
-        ],
-        [
-          "William Needle",
-          "Nicolas König"
-        ],
-        [
-          "Stevens",
-          "Lothar Behrendt"
-        ],
-        [
-          "Bart",
-          "Dokter Renz [Martin Vandreier]"
-        ],
-        [
-          "Luke",
-          "Schiffmeister [Björn Warns]"
-        ],
-        [
-          "Frank",
-          "König Boris [Boris Lauterbach]"
-        ],
-        [
-          "Joan, Visagistin",
-          "Alida Gundlach"
-        ],
-        [
-          "Jeffrey",
-          "Niko Minninger"
-        ],
-        [
-          "Hank",
-          "Harvey Draeger"
-        ],
-        [
-          "Billy",
-          "Sven Stricker"
-        ],
-        [
-          "Angestellter",
-          "Jens Herrndorff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Al Parker, Musikproduzent",
+          "sprecher" : "Lennardt Krüger"
+        },
+        {
+          "rolle" : "William Needle",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Stevens",
+          "sprecher" : "Lothar Behrendt"
+        },
+        {
+          "rolle" : "Bart",
+          "sprecher" : "Martin Vandreier",
+          "pseudonym" : "Dokter Renz"
+        },
+        {
+          "rolle" : "Luke",
+          "sprecher" : "Björn Warns",
+          "pseudonym" : "Schiffmeister"
+        },
+        {
+          "rolle" : "Frank",
+          "sprecher" : "Boris Lauterbach",
+          "pseudonym" : "König Boris"
+        },
+        {
+          "rolle" : "Joan, Visagistin",
+          "sprecher" : "Alida Gundlach"
+        },
+        {
+          "rolle" : "Jeffrey",
+          "sprecher" : "Niko Minninger"
+        },
+        {
+          "rolle" : "Hank",
+          "sprecher" : "Harvey Draeger"
+        },
+        {
+          "rolle" : "Billy",
+          "sprecher" : "Sven Stricker"
+        },
+        {
+          "rolle" : "Angestellter",
+          "sprecher" : "Jens Herrndorff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/079/metadata.json",
@@ -8953,35 +9026,36 @@
           "end" : 3560667
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Cosma",
-          "Elke Reissert"
-        ],
-        [
-          "Vladimir Contreras",
-          "Gerhart Hinze"
-        ],
-        [
-          "Roger Carpenter",
-          "Igmar Frenzen [Gustav-Adolph Artz]"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Cosma",
+          "sprecher" : "Elke Reissert"
+        },
+        {
+          "rolle" : "Vladimir Contreras",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Roger Carpenter",
+          "sprecher" : "Gustav-Adolph Artz",
+          "pseudonym" : "Igmar Frenzen"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/080/metadata.json",
@@ -9031,59 +9105,59 @@
           "end" : 2983827
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly Madigan",
-          "Juliane Szalay"
-        ],
-        [
-          "DaElba",
-          "Ozanan Rocha"
-        ],
-        [
-          "Alberto",
-          "Antonio Luz"
-        ],
-        [
-          "Mr. Toll",
-          "Balduin Baas"
-        ],
-        [
-          "Franke",
-          "Wolfgang Noack"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Mr. Burt",
-          "Gerd Baltus"
-        ],
-        [
-          "Boris",
-          "Carlos Goiach"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly Madigan",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "DaElba",
+          "sprecher" : "Ozanan Rocha"
+        },
+        {
+          "rolle" : "Alberto",
+          "sprecher" : "Antonio Luz"
+        },
+        {
+          "rolle" : "Mr. Toll",
+          "sprecher" : "Balduin Baas"
+        },
+        {
+          "rolle" : "Franke",
+          "sprecher" : "Wolfgang Noack"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Mr. Burt",
+          "sprecher" : "Gerd Baltus"
+        },
+        {
+          "rolle" : "Boris",
+          "sprecher" : "Carlos Goiach"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/081/metadata.json",
@@ -9133,43 +9207,43 @@
           "end" : 4199867
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Milva Summer, Astrologin",
-          "Elisabeth Volkmann"
-        ],
-        [
-          "Professor Steed, Tiermediziner",
-          "Henning Schlüter"
-        ],
-        [
-          "Daniel Art, Bodyguard",
-          "Monty Arnold"
-        ],
-        [
-          "Mike Hanson, Reporter",
-          "Corny Littmann"
-        ],
-        [
-          "Nachrichtensprecher",
-          "Werner Pohlenz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Milva Summer, Astrologin",
+          "sprecher" : "Elisabeth Volkmann"
+        },
+        {
+          "rolle" : "Professor Steed, Tiermediziner",
+          "sprecher" : "Henning Schlüter"
+        },
+        {
+          "rolle" : "Daniel Art, Bodyguard",
+          "sprecher" : "Monty Arnold"
+        },
+        {
+          "rolle" : "Mike Hanson, Reporter",
+          "sprecher" : "Corny Littmann"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "Werner Pohlenz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/082/metadata.json",
@@ -9219,51 +9293,51 @@
           "end" : 3558427
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Käptn Jason",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "Professor Clark",
-          "Erich Krieg"
-        ],
-        [
-          "Carol Ford, Fernsehjournalistin",
-          "Claudia Schermutzki"
-        ],
-        [
-          "Dr. Helprin, Wissenschaftler",
-          "Rudolf H. Herget"
-        ],
-        [
-          "Mr. Evans",
-          "Peter Groß"
-        ],
-        [
-          "Enrique Serra",
-          "Jörg Gillner"
-        ],
-        [
-          "Mr. Andrews",
-          "Roland Becker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Käptn Jason",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Professor Clark",
+          "sprecher" : "Erich Krieg"
+        },
+        {
+          "rolle" : "Carol Ford, Fernsehjournalistin",
+          "sprecher" : "Claudia Schermutzki"
+        },
+        {
+          "rolle" : "Dr. Helprin, Wissenschaftler",
+          "sprecher" : "Rudolf H. Herget"
+        },
+        {
+          "rolle" : "Mr. Evans",
+          "sprecher" : "Peter Groß"
+        },
+        {
+          "rolle" : "Enrique Serra",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Roland Becker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/083/metadata.json",
@@ -9313,43 +9387,43 @@
           "end" : 3603107
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jelena Charkova",
-          "Alexandra Doerk"
-        ],
-        [
-          "Mr. Charkov",
-          "Klaus Dittmann"
-        ],
-        [
-          "Vanderhell, Teufelsgeiger",
-          "Lutz Mackensy"
-        ],
-        [
-          "Mr. Andrews",
-          "Roland Becker"
-        ],
-        [
-          "Mrs. Andrews",
-          "Carola Lange"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Mr. Charkov",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Vanderhell, Teufelsgeiger",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Roland Becker"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Carola Lange"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/084/metadata.json",
@@ -9399,51 +9473,51 @@
           "end" : 3562000
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Walker",
-          "Lothar Grützner"
-        ],
-        [
-          "Monica",
-          "Hansi Jochmann"
-        ],
-        [
-          "Lady MacWeiden",
-          "Renate Pichler"
-        ],
-        [
-          "Mac George",
-          "Johann Schibli"
-        ],
-        [
-          "Chris",
-          "Daniel Kruth"
-        ],
-        [
-          "Campingwart",
-          "Helmut Ahner"
-        ],
-        [
-          "Frau des Campingwarts",
-          "Ingrid Weiß"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Walker",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Monica",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Lady MacWeiden",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Mac George",
+          "sprecher" : "Johann Schibli"
+        },
+        {
+          "rolle" : "Chris",
+          "sprecher" : "Daniel Kruth"
+        },
+        {
+          "rolle" : "Campingwart",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Frau des Campingwarts",
+          "sprecher" : "Ingrid Weiß"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/085/metadata.json",
@@ -9493,51 +9567,51 @@
           "end" : 3457213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mr. Peacock, Museumsdirektor",
-          "Helmut Ahner"
-        ],
-        [
-          "Alpha",
-          "Achim Schülke"
-        ],
-        [
-          "Beth",
-          "Katja Brügger"
-        ],
-        [
-          "Ernie",
-          "Wolfgang Hartmann"
-        ],
-        [
-          "Dog",
-          "Niko Minninger"
-        ],
-        [
-          "Ceewee",
-          "Michael Quiatkowsky"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mr. Peacock, Museumsdirektor",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Alpha",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Beth",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Ernie",
+          "sprecher" : "Wolfgang Hartmann"
+        },
+        {
+          "rolle" : "Dog",
+          "sprecher" : "Niko Minninger"
+        },
+        {
+          "rolle" : "Ceewee",
+          "sprecher" : "Michael Quiatkowsky"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/086/metadata.json",
@@ -9587,59 +9661,59 @@
           "end" : 3294627
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Harding, Polizeipsychologin",
-          "Katrin Wasow"
-        ],
-        [
-          "Mr. Ambler, Assistent",
-          "Rainer Schmitt"
-        ],
-        [
-          "Rodder, das Wolfsgesicht",
-          "Andreas Martens"
-        ],
-        [
-          "Mr. Laurent, Ladenbesitzer",
-          "Lutz Lukasz"
-        ],
-        [
-          "Mr. Stepelton, Ladenbesitzer",
-          "Harald Pages"
-        ],
-        [
-          "Ray, Praktikant",
-          "Marcel Rinkenauer"
-        ],
-        [
-          "Sandy, Verkäuferin",
-          "Cornelia Meinhardt"
-        ],
-        [
-          "Kundin",
-          "Kathi Robens"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Harding, Polizeipsychologin",
+          "sprecher" : "Katrin Wasow"
+        },
+        {
+          "rolle" : "Mr. Ambler, Assistent",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Rodder, das Wolfsgesicht",
+          "sprecher" : "Andreas Martens"
+        },
+        {
+          "rolle" : "Mr. Laurent, Ladenbesitzer",
+          "sprecher" : "Lutz Lukasz"
+        },
+        {
+          "rolle" : "Mr. Stepelton, Ladenbesitzer",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Ray, Praktikant",
+          "sprecher" : "Marcel Rinkenauer"
+        },
+        {
+          "rolle" : "Sandy, Verkäuferin",
+          "sprecher" : "Cornelia Meinhardt"
+        },
+        {
+          "rolle" : "Kundin",
+          "sprecher" : "Kathi Robens"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/087/metadata.json",
@@ -9689,79 +9763,79 @@
           "end" : 4496507
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Doe Dungeon, Programmierer",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Lili Buschfort",
-          "Christina Holsten"
-        ],
-        [
-          "Tom Beker",
-          "Wolfgang Hartmann"
-        ],
-        [
-          "Märchenerzähler",
-          "Hans Paetsch"
-        ],
-        [
-          "Königin Trulie",
-          "Hanna Reisch"
-        ],
-        [
-          "Vinton",
-          "Nils Noller"
-        ],
-        [
-          "Amme",
-          "Katharina Brauren"
-        ],
-        [
-          "Medusa",
-          "Marianne Kehlau"
-        ],
-        [
-          "Oinki Hinki",
-          "Niko Minninger"
-        ],
-        [
-          "Vampir-Frau",
-          "Julia von Spieß"
-        ],
-        [
-          "Hexe",
-          "Micaëla Kreißler"
-        ],
-        [
-          "Oma",
-          "Beate Hasenau"
-        ],
-        [
-          "Wache",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "Computerstimme",
-          "Sascha Gutzeit"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Doe Dungeon, Programmierer",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Lili Buschfort",
+          "sprecher" : "Christina Holsten"
+        },
+        {
+          "rolle" : "Tom Beker",
+          "sprecher" : "Wolfgang Hartmann"
+        },
+        {
+          "rolle" : "Märchenerzähler",
+          "sprecher" : "Hans Paetsch"
+        },
+        {
+          "rolle" : "Königin Trulie",
+          "sprecher" : "Hanna Reisch"
+        },
+        {
+          "rolle" : "Vinton",
+          "sprecher" : "Nils Noller"
+        },
+        {
+          "rolle" : "Amme",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Medusa",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Oinki Hinki",
+          "sprecher" : "Niko Minninger"
+        },
+        {
+          "rolle" : "Vampir-Frau",
+          "sprecher" : "Julia von Spieß"
+        },
+        {
+          "rolle" : "Hexe",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Oma",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Wache",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "Computerstimme",
+          "sprecher" : "Sascha Gutzeit"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/088/metadata.json",
@@ -9811,51 +9885,51 @@
           "end" : 3586347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Gilbert",
-          "Manfred Reddemann"
-        ],
-        [
-          "Mrs. Grayson",
-          "Beate Hasenau"
-        ],
-        [
-          "Mr. Perkins",
-          "Marco Kröger"
-        ],
-        [
-          "Mac Dunno",
-          "Gerhard Marcel"
-        ],
-        [
-          "Wachmann",
-          "Uli Pleßmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Gilbert",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Mrs. Grayson",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Mr. Perkins",
+          "sprecher" : "Marco Kröger"
+        },
+        {
+          "rolle" : "Mac Dunno",
+          "sprecher" : "Gerhard Marcel"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Uli Pleßmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/089/metadata.json",
@@ -9905,35 +9979,35 @@
           "end" : 3532947
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Aaron Moore",
-          "Reent Reins"
-        ],
-        [
-          "Roxanne",
-          "Regine Lamster"
-        ],
-        [
-          "Bruce Black",
-          "Till Demtrøder"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Aaron Moore",
+          "sprecher" : "Reent Reins"
+        },
+        {
+          "rolle" : "Roxanne",
+          "sprecher" : "Regine Lamster"
+        },
+        {
+          "rolle" : "Bruce Black",
+          "sprecher" : "Till Demtrøder"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/090/metadata.json",
@@ -9983,39 +10057,39 @@
           "end" : 3597147
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Stanley Truman",
-          "Horst Stark"
-        ],
-        [
-          "Mr. Shaw",
-          "Eberhard Haar"
-        ],
-        [
-          "Mrs. Jones",
-          "Gisela Trowe"
-        ],
-        [
-          "Mrs. Shoemaker",
-          "Barbara Schipper"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Stanley Truman",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Mrs. Jones",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Mrs. Shoemaker",
+          "sprecher" : "Barbara Schipper"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/091/metadata.json",
@@ -10065,39 +10139,39 @@
           "end" : 3569347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Gregstone",
-          "Wolf Rahtjen"
-        ],
-        [
-          "Butch",
-          "Frank Felicetti"
-        ],
-        [
-          "Ramirez",
-          "Tobias Schmidt"
-        ],
-        [
-          "Radiosprecher",
-          "Hubertus Borck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Gregstone",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Butch",
+          "sprecher" : "Frank Felicetti"
+        },
+        {
+          "rolle" : "Ramirez",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Radiosprecher",
+          "sprecher" : "Hubertus Borck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/092/metadata.json",
@@ -10147,43 +10221,44 @@
           "end" : 3592133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Quin",
-          "Rasmus Borowski"
-        ],
-        [
-          "Mr. Conrad Farnham",
-          "Lothar Grützner"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Deborah Snell",
-          "Anja Topf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Quin",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Mr. Conrad Farnham",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Deborah Snell",
+          "sprecher" : "Anja Topf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/093/metadata.json",
@@ -10233,59 +10308,60 @@
           "end" : 3262720
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Alois Copper",
-          "Werner Cartano"
-        ],
-        [
-          "Mr. Carter",
-          "Marius Berthold"
-        ],
-        [
-          "Miss Lilly",
-          "Jocelyne Boisseau"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Frau des Bürgermeisters",
-          "Wanda Osten [Hella von der Osten-Sacken]"
-        ],
-        [
-          "Reporter",
-          "Jacky Nonnon"
-        ],
-        [
-          "Stewart",
-          "Tilman Madaus"
-        ],
-        [
-          "Pico, Clown",
-          "Hubertus Borck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Alois Copper",
+          "sprecher" : "Werner Cartano"
+        },
+        {
+          "rolle" : "Mr. Carter",
+          "sprecher" : "Marius Berthold"
+        },
+        {
+          "rolle" : "Miss Lilly",
+          "sprecher" : "Jocelyne Boisseau"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Frau des Bürgermeisters",
+          "sprecher" : "Hella von der Osten-Sacken",
+          "pseudonym" : "Wanda Osten"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Jacky Nonnon"
+        },
+        {
+          "rolle" : "Stewart",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Pico, Clown",
+          "sprecher" : "Hubertus Borck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/094/metadata.json",
@@ -10335,47 +10411,47 @@
           "end" : 3603800
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jelena Charkova",
-          "Alexandra Doerk"
-        ],
-        [
-          "Mr. Charkov",
-          "Klaus Dittmann"
-        ],
-        [
-          "Dr. Arroway",
-          "Soňa Červená"
-        ],
-        [
-          "Janet, ihre Assistentin",
-          "Ute Rohrbeck"
-        ],
-        [
-          "Tom Gordon",
-          "Philip Hoier"
-        ],
-        [
-          "Dixon",
-          "Utz Richter"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Mr. Charkov",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Dr. Arroway",
+          "sprecher" : "Soňa Červená"
+        },
+        {
+          "rolle" : "Janet, ihre Assistentin",
+          "sprecher" : "Ute Rohrbeck"
+        },
+        {
+          "rolle" : "Tom Gordon",
+          "sprecher" : "Philip Hoier"
+        },
+        {
+          "rolle" : "Dixon",
+          "sprecher" : "Utz Richter"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/095/metadata.json",
@@ -10435,55 +10511,55 @@
           "end" : 3191000
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Detective Frank",
-          "Wolf Frass"
-        ],
-        [
-          "Dave Rawling",
-          "Helmut Gentsch"
-        ],
-        [
-          "Praktikantin Lesley",
-          "Ann Montenbruck"
-        ],
-        [
-          "Mrs. Shaw",
-          "Heikedine Körting"
-        ],
-        [
-          "Mr. Smith",
-          "Douglas Welbat"
-        ],
-        [
-          "Sheppard",
-          "Marius Kreissler"
-        ],
-        [
-          "Feuerwehrmann",
-          "Wolfgang Kaven"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Detective Frank",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Dave Rawling",
+          "sprecher" : "Helmut Gentsch"
+        },
+        {
+          "rolle" : "Praktikantin Lesley",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Mr. Smith",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Sheppard",
+          "sprecher" : "Marius Kreissler"
+        },
+        {
+          "rolle" : "Feuerwehrmann",
+          "sprecher" : "Wolfgang Kaven"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/096/metadata.json",
@@ -10543,43 +10619,44 @@
           "end" : 4066453
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Janet Hazelwood",
-          "Marianne Kehlau"
-        ],
-        [
-          "Laura Stryker",
-          "Regina Lemnitz"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Mrs. White",
-          "Brigitte Böttrich"
-        ],
-        [
-          "Mr. Collins",
-          "Daniel Eggers"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Janet Hazelwood",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Laura Stryker",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Mrs. White",
+          "sprecher" : "Brigitte Böttrich"
+        },
+        {
+          "rolle" : "Mr. Collins",
+          "sprecher" : "Daniel Eggers"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/097/metadata.json",
@@ -10639,63 +10716,64 @@
           "end" : 3772307
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ann Sullivan",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Mr. Martin",
-          "Christian Mey"
-        ],
-        [
-          "Mr. Caddy",
-          "Helmut Gentsch"
-        ],
-        [
-          "Kellnerin",
-          "Anna Carlsson"
-        ],
-        [
-          "Lady Day",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Henry",
-          "Wilhelm Wieben"
-        ],
-        [
-          "Mann aus der Wüste",
-          "Wilhelm Hornbostel"
-        ],
-        [
-          "Miller",
-          "Lutz Mackensy"
-        ],
-        [
-          "Debby",
-          "Roswitha Benda"
-        ],
-        [
-          "Joe",
-          "Jakob Lichtblau [Fabian Harloff]"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ann Sullivan",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Mr. Martin",
+          "sprecher" : "Christian Mey"
+        },
+        {
+          "rolle" : "Mr. Caddy",
+          "sprecher" : "Helmut Gentsch"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Lady Day",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Henry",
+          "sprecher" : "Wilhelm Wieben"
+        },
+        {
+          "rolle" : "Mann aus der Wüste",
+          "sprecher" : "Wilhelm Hornbostel"
+        },
+        {
+          "rolle" : "Miller",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Debby",
+          "sprecher" : "Roswitha Benda"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Fabian Harloff",
+          "pseudonym" : "Jakob Lichtblau"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/098/metadata.json",
@@ -10755,67 +10833,67 @@
           "end" : 4573053
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Kevin Anderson",
-          "Thomas Bug"
-        ],
-        [
-          "Clarissa Franklin",
-          "Judy Winter"
-        ],
-        [
-          "Dr. Freeman",
-          "Jürgen Thormann"
-        ],
-        [
-          "Mrs. Brighton",
-          "Monika Werner"
-        ],
-        [
-          "Mrs. Wheel",
-          "Ines Sawatzki"
-        ],
-        [
-          "Schwester Whitney",
-          "Andrea Lange"
-        ],
-        [
-          "Besucher",
-          "Eckart Dux"
-        ],
-        [
-          "Bote",
-          "Stefan Rüter"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kevin Anderson",
+          "sprecher" : "Thomas Bug"
+        },
+        {
+          "rolle" : "Clarissa Franklin",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Dr. Freeman",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Mrs. Brighton",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Mrs. Wheel",
+          "sprecher" : "Ines Sawatzki"
+        },
+        {
+          "rolle" : "Schwester Whitney",
+          "sprecher" : "Andrea Lange"
+        },
+        {
+          "rolle" : "Besucher",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Bote",
+          "sprecher" : "Stefan Rüter"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/099/metadata.json",
@@ -10866,47 +10944,47 @@
               "end" : 3204573
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Matthias Fuchs"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Skinny Norris",
-              "Andreas von der Meden"
-            ],
-            [
-              "Jelena Charkova",
-              "Alexandra Doerk"
-            ],
-            [
-              "Dr. Svenson",
-              "Antje Roosch"
-            ],
-            [
-              "Mr. Schwarz",
-              "Erik Schäffler"
-            ],
-            [
-              "Mr. Olin",
-              "Uli Krohm"
-            ],
-            [
-              "Juan",
-              "Oliver Böttcher"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Matthias Fuchs"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Skinny Norris",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Jelena Charkova",
+              "sprecher" : "Alexandra Doerk"
+            },
+            {
+              "rolle" : "Dr. Svenson",
+              "sprecher" : "Antje Roosch"
+            },
+            {
+              "rolle" : "Mr. Schwarz",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Mr. Olin",
+              "sprecher" : "Uli Krohm"
+            },
+            {
+              "rolle" : "Juan",
+              "sprecher" : "Oliver Böttcher"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/1/metadata.json",
@@ -10951,67 +11029,67 @@
               "end" : 3376800
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Matthias Fuchs"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Skinny Norris",
-              "Andreas von der Meden"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Jelena Charkova",
-              "Alexandra Doerk"
-            ],
-            [
-              "Professor Phoenix",
-              "Winfried Glatzeder"
-            ],
-            [
-              "Dr. Svenson",
-              "Antje Roosch"
-            ],
-            [
-              "Mr. Schwarz",
-              "Erik Schäffler"
-            ],
-            [
-              "Mr. Olin",
-              "Uli Krohm"
-            ],
-            [
-              "Juan",
-              "Oliver Böttcher"
-            ],
-            [
-              "Rachel Hadden",
-              "Anna Carlsson"
-            ],
-            [
-              "Al",
-              "Nicolas König"
-            ],
-            [
-              "Anne",
-              "Corinna Wodrich"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Matthias Fuchs"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Skinny Norris",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Jelena Charkova",
+              "sprecher" : "Alexandra Doerk"
+            },
+            {
+              "rolle" : "Professor Phoenix",
+              "sprecher" : "Winfried Glatzeder"
+            },
+            {
+              "rolle" : "Dr. Svenson",
+              "sprecher" : "Antje Roosch"
+            },
+            {
+              "rolle" : "Mr. Schwarz",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Mr. Olin",
+              "sprecher" : "Uli Krohm"
+            },
+            {
+              "rolle" : "Juan",
+              "sprecher" : "Oliver Böttcher"
+            },
+            {
+              "rolle" : "Rachel Hadden",
+              "sprecher" : "Anna Carlsson"
+            },
+            {
+              "rolle" : "Al",
+              "sprecher" : "Nicolas König"
+            },
+            {
+              "rolle" : "Anne",
+              "sprecher" : "Corinna Wodrich"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/2/metadata.json",
@@ -11056,55 +11134,55 @@
               "end" : 3410493
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Matthias Fuchs"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Jelena Charkova",
-              "Alexandra Doerk"
-            ],
-            [
-              "Professor Phoenix",
-              "Winfried Glatzeder"
-            ],
-            [
-              "Dr. Svenson",
-              "Antje Roosch"
-            ],
-            [
-              "Mr. Schwarz",
-              "Erik Schäffler"
-            ],
-            [
-              "Mr. Olin",
-              "Uli Krohm"
-            ],
-            [
-              "Juan",
-              "Oliver Böttcher"
-            ],
-            [
-              "Al",
-              "Nicolas König"
-            ],
-            [
-              "Anne",
-              "Corinna Wodrich"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Matthias Fuchs"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Jelena Charkova",
+              "sprecher" : "Alexandra Doerk"
+            },
+            {
+              "rolle" : "Professor Phoenix",
+              "sprecher" : "Winfried Glatzeder"
+            },
+            {
+              "rolle" : "Dr. Svenson",
+              "sprecher" : "Antje Roosch"
+            },
+            {
+              "rolle" : "Mr. Schwarz",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Mr. Olin",
+              "sprecher" : "Uli Krohm"
+            },
+            {
+              "rolle" : "Juan",
+              "sprecher" : "Oliver Böttcher"
+            },
+            {
+              "rolle" : "Al",
+              "sprecher" : "Nicolas König"
+            },
+            {
+              "rolle" : "Anne",
+              "sprecher" : "Corinna Wodrich"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/3/metadata.json",
@@ -11118,67 +11196,67 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Die drei ??? übernehmen ihren 100sten Fall Fall! In drei spannenden Folgen sind sie dem Geheimnis der Toteninsel auf der Spur.\nEine große Herausforderung für die Detektive. Weswegen sie gut beraten sind, die Hilfe alter Wegbegleiter anzunehmen, um Das Rätsel der Sphinx (Teil 1) zu lösen. Doch plötzlich ist Peter verschwunden und auch Das vergessene Volk (Teil 2) kann Justus und Bob bei ihrer Suche nicht weiterhelfen. Erst Der Fluch der Gräber (Teil 3) führt die drei ??? auf eine heiße Spur.",
       "veröffentlichungsdatum" : "2001-10-15",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Jelena Charkova",
-          "Alexandra Doerk"
-        ],
-        [
-          "Dr. Svenson",
-          "Antje Roosch"
-        ],
-        [
-          "Mr. Schwarz",
-          "Erik Schäffler"
-        ],
-        [
-          "Mr. Olin",
-          "Uli Krohm"
-        ],
-        [
-          "Juan",
-          "Oliver Böttcher"
-        ],
-        [
-          "Professor Phoenix",
-          "Winfried Glatzeder"
-        ],
-        [
-          "Rachel Hadden",
-          "Anna Carlsson"
-        ],
-        [
-          "Al",
-          "Nicolas König"
-        ],
-        [
-          "Anne",
-          "Corinna Wodrich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Dr. Svenson",
+          "sprecher" : "Antje Roosch"
+        },
+        {
+          "rolle" : "Mr. Schwarz",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Mr. Olin",
+          "sprecher" : "Uli Krohm"
+        },
+        {
+          "rolle" : "Juan",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Professor Phoenix",
+          "sprecher" : "Winfried Glatzeder"
+        },
+        {
+          "rolle" : "Rachel Hadden",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Al",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Anne",
+          "sprecher" : "Corinna Wodrich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/100/metadata.json",
@@ -11236,55 +11314,55 @@
           "end" : 4313453
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Giorgio Cade",
-          "Bastian Pastewka"
-        ],
-        [
-          "Monique Carrera",
-          "Amanda Lear"
-        ],
-        [
-          "Mrs. Jones",
-          "Marianne Kehlau"
-        ],
-        [
-          "Jenny Collins",
-          "Anja Topf"
-        ],
-        [
-          "Jeremy Scott",
-          "Woody Mues"
-        ],
-        [
-          "Mrs. Scott",
-          "Hansi Jochmann"
-        ],
-        [
-          "Oma Scott",
-          "Apollonia Jepsen"
-        ],
-        [
-          "Acer",
-          "Thomas Schüler"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Giorgio Cade",
+          "sprecher" : "Bastian Pastewka"
+        },
+        {
+          "rolle" : "Monique Carrera",
+          "sprecher" : "Amanda Lear"
+        },
+        {
+          "rolle" : "Mrs. Jones",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Jenny Collins",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Jeremy Scott",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Mrs. Scott",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Oma Scott",
+          "sprecher" : "Apollonia Jepsen"
+        },
+        {
+          "rolle" : "Acer",
+          "sprecher" : "Thomas Schüler"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/101/metadata.json",
@@ -11344,43 +11422,43 @@
           "end" : 3560680
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "King",
-          "Wolfgang Condrus"
-        ],
-        [
-          "Jenny Collins",
-          "Anja Topf"
-        ],
-        [
-          "Tricia Wilson",
-          "Ursula Vogel"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "King",
+          "sprecher" : "Wolfgang Condrus"
+        },
+        {
+          "rolle" : "Jenny Collins",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Tricia Wilson",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/102/metadata.json",
@@ -11440,51 +11518,52 @@
           "end" : 3810187
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brittany",
-          "Dorette Hugo"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro [Wolfgang Kubach]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Wilbur Graham",
-          "Thomas Bammer"
-        ],
-        [
-          "Bruder Raphael",
-          "Siegfried W. Kernen"
-        ],
-        [
-          "Inspektor Berger",
-          "Jan Buchwald"
-        ],
-        [
-          "Baldwin",
-          "Gerhart Hinze"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brittany",
+          "sprecher" : "Dorette Hugo"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Wilbur Graham",
+          "sprecher" : "Thomas Bammer"
+        },
+        {
+          "rolle" : "Bruder Raphael",
+          "sprecher" : "Siegfried W. Kernen"
+        },
+        {
+          "rolle" : "Inspektor Berger",
+          "sprecher" : "Jan Buchwald"
+        },
+        {
+          "rolle" : "Baldwin",
+          "sprecher" : "Gerhart Hinze"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/103/metadata.json",
@@ -11544,51 +11623,51 @@
           "end" : 4138120
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dick Perry",
-          "Ernst H. Hilbich"
-        ],
-        [
-          "Mrs. Meg Baker",
-          "Lotti Krekel"
-        ],
-        [
-          "Mrs. Wood",
-          "Elga Schütz"
-        ],
-        [
-          "Jack Sharky",
-          "Stefan Babic"
-        ],
-        [
-          "Betty Shutton",
-          "Regina Pressler"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dick Perry",
+          "sprecher" : "Ernst H. Hilbich"
+        },
+        {
+          "rolle" : "Mrs. Meg Baker",
+          "sprecher" : "Lotti Krekel"
+        },
+        {
+          "rolle" : "Mrs. Wood",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "Jack Sharky",
+          "sprecher" : "Stefan Babic"
+        },
+        {
+          "rolle" : "Betty Shutton",
+          "sprecher" : "Regina Pressler"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/104/metadata.json",
@@ -11648,47 +11727,47 @@
           "end" : 4545293
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Joanna Masterson",
-          "Barbara Marcks"
-        ],
-        [
-          "Jack Masterson",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Sarah Masterson",
-          "Nadja Reichardt"
-        ],
-        [
-          "Mr. Harry Falkner",
-          "Wolfgang Hartmann"
-        ],
-        [
-          "Harvey Ashford",
-          "Rolf E. Schenker"
-        ],
-        [
-          "Marc",
-          "Hartmut Kollakowsky"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Joanna Masterson",
+          "sprecher" : "Barbara Marcks"
+        },
+        {
+          "rolle" : "Jack Masterson",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Sarah Masterson",
+          "sprecher" : "Nadja Reichardt"
+        },
+        {
+          "rolle" : "Mr. Harry Falkner",
+          "sprecher" : "Wolfgang Hartmann"
+        },
+        {
+          "rolle" : "Harvey Ashford",
+          "sprecher" : "Rolf E. Schenker"
+        },
+        {
+          "rolle" : "Marc",
+          "sprecher" : "Hartmut Kollakowsky"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/105/metadata.json",
@@ -11748,75 +11827,77 @@
           "end" : 4255213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Amy Scream",
-          "Marianne Kehlau"
-        ],
-        [
-          "Monique Carrera",
-          "Amanda Lear"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Ellen",
-          "Celine Fontanges"
-        ],
-        [
-          "Pam",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Jim Cowley",
-          "Cäsar [Marcus Kaiser]"
-        ],
-        [
-          "Jeffrey",
-          "Kim Frank"
-        ],
-        [
-          "Mandy Robin",
-          "Manuela Dahm"
-        ],
-        [
-          "Sanitäter 1",
-          "Robert Missler"
-        ],
-        [
-          "Sanitäter 2",
-          "Hartmut Kollakowsky"
-        ],
-        [
-          "Bardame",
-          "Monique Carrera [Amanda Lear]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Diskothekenbesucher",
-          "Echt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Amy Scream",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Monique Carrera",
+          "sprecher" : "Amanda Lear"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Ellen",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Pam",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Jim Cowley",
+          "sprecher" : "Marcus Kaiser",
+          "pseudonym" : "Cäsar"
+        },
+        {
+          "rolle" : "Jeffrey",
+          "sprecher" : "Kim Frank"
+        },
+        {
+          "rolle" : "Mandy Robin",
+          "sprecher" : "Manuela Dahm"
+        },
+        {
+          "rolle" : "Sanitäter 1",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Sanitäter 2",
+          "sprecher" : "Hartmut Kollakowsky"
+        },
+        {
+          "rolle" : "Bardame",
+          "sprecher" : "Amanda Lear",
+          "pseudonym" : "Monique Carrera"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Diskothekenbesucher",
+          "sprecher" : "Echt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/106/metadata.json",
@@ -11876,55 +11957,55 @@
           "end" : 3850840
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Lama Geshe",
-          "Rolf Nagel"
-        ],
-        [
-          "Tai Sutsi",
-          "Dr. Boo Young-Shin"
-        ],
-        [
-          "Chuck",
-          "Yan Kimsang"
-        ],
-        [
-          "Vinaya",
-          "Prof. Dr. Zhu"
-        ],
-        [
-          "Mr. Zhang",
-          "Ingo Feder"
-        ],
-        [
-          "Lesley Dimple",
-          "Ann Montenbruck"
-        ],
-        [
-          "Mrs. Wilbur",
-          "Ingeburg Kanstein"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Lama Geshe",
+          "sprecher" : "Rolf Nagel"
+        },
+        {
+          "rolle" : "Tai Sutsi",
+          "sprecher" : "Dr. Boo Young-Shin"
+        },
+        {
+          "rolle" : "Chuck",
+          "sprecher" : "Yan Kimsang"
+        },
+        {
+          "rolle" : "Vinaya",
+          "sprecher" : "Prof. Dr. Zhu"
+        },
+        {
+          "rolle" : "Mr. Zhang",
+          "sprecher" : "Ingo Feder"
+        },
+        {
+          "rolle" : "Lesley Dimple",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Mrs. Wilbur",
+          "sprecher" : "Ingeburg Kanstein"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/107/metadata.json",
@@ -11989,39 +12070,39 @@
           "end" : 4004480
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Caspar Carter",
-          "Claus Wilcke"
-        ],
-        [
-          "Enid",
-          "Janina Richter"
-        ],
-        [
-          "Albert",
-          "Wolf Rahtjen"
-        ],
-        [
-          "Montgomery",
-          "Hans Sievers"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Caspar Carter",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Enid",
+          "sprecher" : "Janina Richter"
+        },
+        {
+          "rolle" : "Albert",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Montgomery",
+          "sprecher" : "Hans Sievers"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/108/metadata.json",
@@ -12081,59 +12162,59 @@
           "end" : 4027533
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Nick Nobel",
-          "Ilja Richter"
-        ],
-        [
-          "Sandy",
-          "Micaëla Kreißler"
-        ],
-        [
-          "Bill",
-          "Achim Schülke"
-        ],
-        [
-          "Mike Pherson",
-          "Wolf-Dietrich Berg"
-        ],
-        [
-          "Assistent",
-          "Martin Meyer"
-        ],
-        [
-          "Clarissa",
-          "Theresa Underberg"
-        ],
-        [
-          "Veronica",
-          "Saskia Weckler"
-        ],
-        [
-          "Joe",
-          "Jan-David Rönfeldt"
-        ],
-        [
-          "Sekretärin",
-          "Traudel Sperber"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Nick Nobel",
+          "sprecher" : "Ilja Richter"
+        },
+        {
+          "rolle" : "Sandy",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Bill",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Mike Pherson",
+          "sprecher" : "Wolf-Dietrich Berg"
+        },
+        {
+          "rolle" : "Assistent",
+          "sprecher" : "Martin Meyer"
+        },
+        {
+          "rolle" : "Clarissa",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Veronica",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Jan-David Rönfeldt"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Traudel Sperber"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/109/metadata.json",
@@ -12193,63 +12274,63 @@
           "end" : 3310573
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Pablo",
-          "Kai Henrik Möller"
-        ],
-        [
-          "Dr. Brolin",
-          "Karl-Friedrich Gerster"
-        ],
-        [
-          "Jenkins",
-          "Gustav-Adolph Artz"
-        ],
-        [
-          "Professor Clark",
-          "Thor W. Müller"
-        ],
-        [
-          "Bürgermeister Hoover",
-          "Michael Griem"
-        ],
-        [
-          "Margie",
-          "Susanna Leu"
-        ],
-        [
-          "Mike",
-          "Achim Schülke"
-        ],
-        [
-          "Clark",
-          "Wolf Rahtjen"
-        ],
-        [
-          "Wachmann",
-          "Kristian Kretschmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Pablo",
+          "sprecher" : "Kai Henrik Möller"
+        },
+        {
+          "rolle" : "Dr. Brolin",
+          "sprecher" : "Karl-Friedrich Gerster"
+        },
+        {
+          "rolle" : "Jenkins",
+          "sprecher" : "Gustav-Adolph Artz"
+        },
+        {
+          "rolle" : "Professor Clark",
+          "sprecher" : "Thor W. Müller"
+        },
+        {
+          "rolle" : "Bürgermeister Hoover",
+          "sprecher" : "Michael Griem"
+        },
+        {
+          "rolle" : "Margie",
+          "sprecher" : "Susanna Leu"
+        },
+        {
+          "rolle" : "Mike",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Clark",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Kristian Kretschmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/110/metadata.json",
@@ -12339,71 +12420,71 @@
           "end" : 3906600
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Maggie Jones",
-          "Ulrike Johannson"
-        ],
-        [
-          "Lythia Waterstone",
-          "Barbara Focke"
-        ],
-        [
-          "Elisabeth Waterstone",
-          "Linde Fulda"
-        ],
-        [
-          "John Stanley",
-          "Kai Böger"
-        ],
-        [
-          "Jack Donelly",
-          "Andreas Mattau"
-        ],
-        [
-          "Althena",
-          "Michaela Boland"
-        ],
-        [
-          "Corona",
-          "Stephanie Damare"
-        ],
-        [
-          "Fahrer Ken",
-          "Wolf Frass"
-        ],
-        [
-          "John Fairbanks",
-          "Christian Rudolf"
-        ],
-        [
-          "Hal Fairbanks",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Walt",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Blackeye",
-          "Georg Marquard"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Maggie Jones",
+          "sprecher" : "Ulrike Johannson"
+        },
+        {
+          "rolle" : "Lythia Waterstone",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Elisabeth Waterstone",
+          "sprecher" : "Linde Fulda"
+        },
+        {
+          "rolle" : "John Stanley",
+          "sprecher" : "Kai Böger"
+        },
+        {
+          "rolle" : "Jack Donelly",
+          "sprecher" : "Andreas Mattau"
+        },
+        {
+          "rolle" : "Althena",
+          "sprecher" : "Michaela Boland"
+        },
+        {
+          "rolle" : "Corona",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Fahrer Ken",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "John Fairbanks",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Hal Fairbanks",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Walt",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Blackeye",
+          "sprecher" : "Georg Marquard"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/111/metadata.json",
@@ -12488,47 +12569,47 @@
           "end" : 3529667
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Donovan",
-          "Joachim Richert"
-        ],
-        [
-          "Pit",
-          "Wolfgang Wagner"
-        ],
-        [
-          "Max",
-          "Johannes Rothenstein"
-        ],
-        [
-          "Cowboy",
-          "Christian Niehues"
-        ],
-        [
-          "Creeklong",
-          "Nobi Schatka"
-        ],
-        [
-          "Brad Fleming",
-          "Dennis Jensen"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Donovan",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Pit",
+          "sprecher" : "Wolfgang Wagner"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Johannes Rothenstein"
+        },
+        {
+          "rolle" : "Cowboy",
+          "sprecher" : "Christian Niehues"
+        },
+        {
+          "rolle" : "Creeklong",
+          "sprecher" : "Nobi Schatka"
+        },
+        {
+          "rolle" : "Brad Fleming",
+          "sprecher" : "Dennis Jensen"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/112/metadata.json",
@@ -12618,47 +12699,47 @@
           "end" : 3607400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Emily",
-          "Madeleine Weingart"
-        ],
-        [
-          "Mrs. Silverstone",
-          "Katrin Wasow"
-        ],
-        [
-          "Dr. Wakefield",
-          "Hans Daniel"
-        ],
-        [
-          "Alruna",
-          "Gisela Trowe"
-        ],
-        [
-          "Marcus Lake",
-          "Thomas Karallus"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Emily",
+          "sprecher" : "Madeleine Weingart"
+        },
+        {
+          "rolle" : "Mrs. Silverstone",
+          "sprecher" : "Katrin Wasow"
+        },
+        {
+          "rolle" : "Dr. Wakefield",
+          "sprecher" : "Hans Daniel"
+        },
+        {
+          "rolle" : "Alruna",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Marcus Lake",
+          "sprecher" : "Thomas Karallus"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/113/metadata.json",
@@ -12738,51 +12819,51 @@
           "end" : 4150480
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Bernadette O'Donnell",
-          "Eva Maria Bauer"
-        ],
-        [
-          "Cecilia Jones",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Elouise Adams",
-          "Hannelore Wüst"
-        ],
-        [
-          "Mrs. Willow",
-          "Elga Schütz"
-        ],
-        [
-          "Möbelpacker",
-          "Christian Niehues"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Bernadette O'Donnell",
+          "sprecher" : "Eva Maria Bauer"
+        },
+        {
+          "rolle" : "Cecilia Jones",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Elouise Adams",
+          "sprecher" : "Hannelore Wüst"
+        },
+        {
+          "rolle" : "Mrs. Willow",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "Möbelpacker",
+          "sprecher" : "Christian Niehues"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/114/metadata.json",
@@ -12877,63 +12958,64 @@
           "end" : 4200627
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Escovedo",
-          "Ignacio Descalzo"
-        ],
-        [
-          "Anita Caballero",
-          "Isabel Navarro"
-        ],
-        [
-          "Lesley Dimple",
-          "Rica Blunck"
-        ],
-        [
-          "Regina Pearson",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Mr. Horowitz",
-          "Rolf Jülich"
-        ],
-        [
-          "Mr. Rothman",
-          "Peter Weis"
-        ],
-        [
-          "Mrs. O'Rien",
-          "Victoria Trauttmansdorff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Escovedo",
+          "sprecher" : "Ignacio Descalzo"
+        },
+        {
+          "rolle" : "Anita Caballero",
+          "sprecher" : "Isabel Navarro"
+        },
+        {
+          "rolle" : "Lesley Dimple",
+          "sprecher" : "Rica Blunck"
+        },
+        {
+          "rolle" : "Regina Pearson",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Mr. Horowitz",
+          "sprecher" : "Rolf Jülich"
+        },
+        {
+          "rolle" : "Mr. Rothman",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Mrs. O'Rien",
+          "sprecher" : "Victoria Trauttmansdorff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/115/metadata.json",
@@ -12998,51 +13080,51 @@
           "end" : 3724893
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Applegate",
-          "Stephan Benson"
-        ],
-        [
-          "Julia Applegate",
-          "Sophie Lechtenbrink"
-        ],
-        [
-          "Teddy Applegate",
-          "Jona Mues"
-        ],
-        [
-          "Rafter",
-          "Volker Bogdan"
-        ],
-        [
-          "Archie",
-          "Bertram Hiese"
-        ],
-        [
-          "Jenny Collins",
-          "Anja Topf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Applegate",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Julia Applegate",
+          "sprecher" : "Sophie Lechtenbrink"
+        },
+        {
+          "rolle" : "Teddy Applegate",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Rafter",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Archie",
+          "sprecher" : "Bertram Hiese"
+        },
+        {
+          "rolle" : "Jenny Collins",
+          "sprecher" : "Anja Topf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/116/metadata.json",
@@ -13117,59 +13199,60 @@
           "end" : 3640027
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Wagner",
-          "Jürgen Thormann"
-        ],
-        [
-          "Beaumont",
-          "Douglas Welbat"
-        ],
-        [
-          "Calhoon",
-          "Bernd Stephan"
-        ],
-        [
-          "Mike",
-          "Arndt Schmöle"
-        ],
-        [
-          "Zia",
-          "Brigitte Böttrich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Wagner",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Beaumont",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Calhoon",
+          "sprecher" : "Bernd Stephan"
+        },
+        {
+          "rolle" : "Mike",
+          "sprecher" : "Arndt Schmöle"
+        },
+        {
+          "rolle" : "Zia",
+          "sprecher" : "Brigitte Böttrich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/117/metadata.json",
@@ -13254,67 +13337,67 @@
           "end" : 3996413
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Ralph",
-          "Jan-David Rönfeldt"
-        ],
-        [
-          "Robbie",
-          "Manfred Reddemann"
-        ],
-        [
-          "Jack",
-          "Daniel Brühl"
-        ],
-        [
-          "Dennis",
-          "Stefan Brönneke"
-        ],
-        [
-          "Gina",
-          "Chiara Ferraú"
-        ],
-        [
-          "Charly",
-          "Aaron Lee Ullmer"
-        ],
-        [
-          "Sheriff",
-          "Harry Rowohlt"
-        ],
-        [
-          "Turnbull",
-          "Detlef Bierstedt"
-        ],
-        [
-          "Jenny Collins",
-          "Anja Topf"
-        ],
-        [
-          "Dizzy",
-          "Marion Klaus"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Ralph",
+          "sprecher" : "Jan-David Rönfeldt"
+        },
+        {
+          "rolle" : "Robbie",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Daniel Brühl"
+        },
+        {
+          "rolle" : "Dennis",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Gina",
+          "sprecher" : "Chiara Ferraú"
+        },
+        {
+          "rolle" : "Charly",
+          "sprecher" : "Aaron Lee Ullmer"
+        },
+        {
+          "rolle" : "Sheriff",
+          "sprecher" : "Harry Rowohlt"
+        },
+        {
+          "rolle" : "Turnbull",
+          "sprecher" : "Detlef Bierstedt"
+        },
+        {
+          "rolle" : "Jenny Collins",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Dizzy",
+          "sprecher" : "Marion Klaus"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/118/metadata.json",
@@ -13404,59 +13487,60 @@
           "end" : 4063440
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Caitlin Kopperschmidt",
-          "Marion Martienzen"
-        ],
-        [
-          "Jeremy Kopperschmidt",
-          "Lutz Herkenrath"
-        ],
-        [
-          "Graig Kopperschmidt",
-          "Mario Grete"
-        ],
-        [
-          "George",
-          "Henry König"
-        ],
-        [
-          "Anthony Quinn",
-          "Franz-Josef Steffens"
-        ],
-        [
-          "Martha",
-          "Sabine Falkenberg"
-        ],
-        [
-          "Felix Kopperschmidt",
-          "Hermann Otto"
-        ],
-        [
-          "Mann",
-          "Frank Felicetti"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Caitlin Kopperschmidt",
+          "sprecher" : "Marion Martienzen"
+        },
+        {
+          "rolle" : "Jeremy Kopperschmidt",
+          "sprecher" : "Lutz Herkenrath"
+        },
+        {
+          "rolle" : "Graig Kopperschmidt",
+          "sprecher" : "Mario Grete"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Anthony Quinn",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Martha",
+          "sprecher" : "Sabine Falkenberg"
+        },
+        {
+          "rolle" : "Felix Kopperschmidt",
+          "sprecher" : "Hermann Otto"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Frank Felicetti"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/119/metadata.json",
@@ -13531,43 +13615,43 @@
           "end" : 3528253
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ken Parker, Beachball-Spieler",
-          "Jürgen Holdorf"
-        ],
-        [
-          "Dr. Robinson",
-          "Heinz Lieven"
-        ],
-        [
-          "Mickey McQuire",
-          "Marco Sand"
-        ],
-        [
-          "Mrs. Bancroft",
-          "Ilka Kirsch"
-        ],
-        [
-          "Zuschauer",
-          "Alexander Müller"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ken Parker, Beachball-Spieler",
+          "sprecher" : "Jürgen Holdorf"
+        },
+        {
+          "rolle" : "Dr. Robinson",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Mickey McQuire",
+          "sprecher" : "Marco Sand"
+        },
+        {
+          "rolle" : "Mrs. Bancroft",
+          "sprecher" : "Ilka Kirsch"
+        },
+        {
+          "rolle" : "Zuschauer",
+          "sprecher" : "Alexander Müller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/120/metadata.json",
@@ -13652,55 +13736,55 @@
           "end" : 3762347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Shawn",
-          "Robin Brosch"
-        ],
-        [
-          "Jolene",
-          "Marion Elskis"
-        ],
-        [
-          "Leah",
-          "Susanne Sternberg"
-        ],
-        [
-          "Jelena Charkova",
-          "Alexandra Doerk"
-        ],
-        [
-          "Sue",
-          "Kerstin Hilbig"
-        ],
-        [
-          "Kimberly Lloyd",
-          "Ingeborg Christiansen"
-        ],
-        [
-          "William Boyd",
-          "Olaf Kreutzenbeck"
-        ],
-        [
-          "Thorndike",
-          "Michael Lott"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Shawn",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Jolene",
+          "sprecher" : "Marion Elskis"
+        },
+        {
+          "rolle" : "Leah",
+          "sprecher" : "Susanne Sternberg"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Sue",
+          "sprecher" : "Kerstin Hilbig"
+        },
+        {
+          "rolle" : "Kimberly Lloyd",
+          "sprecher" : "Ingeborg Christiansen"
+        },
+        {
+          "rolle" : "William Boyd",
+          "sprecher" : "Olaf Kreutzenbeck"
+        },
+        {
+          "rolle" : "Thorndike",
+          "sprecher" : "Michael Lott"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/121/metadata.json",
@@ -13765,59 +13849,59 @@
           "end" : 3494760
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Fred Jenkins",
-          "Nick Seidensticker"
-        ],
-        [
-          "Mr. Campbell",
-          "Gerhart Hinze"
-        ],
-        [
-          "Sam Reilly",
-          "Jürgen Strube"
-        ],
-        [
-          "Carl Sheehan",
-          "Michael Weckler"
-        ],
-        [
-          "Collins",
-          "Thorsten Weber"
-        ],
-        [
-          "Mr. Kingsley",
-          "Herbert Tennigkeit"
-        ],
-        [
-          "Mrs. Kingsley",
-          "Tina Rehfeld-Wildmann"
-        ],
-        [
-          "Devlin Reno",
-          "Jörg Pleva"
-        ],
-        [
-          "Dr. Long",
-          "Lou Wong"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Fred Jenkins",
+          "sprecher" : "Nick Seidensticker"
+        },
+        {
+          "rolle" : "Mr. Campbell",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Sam Reilly",
+          "sprecher" : "Jürgen Strube"
+        },
+        {
+          "rolle" : "Carl Sheehan",
+          "sprecher" : "Michael Weckler"
+        },
+        {
+          "rolle" : "Collins",
+          "sprecher" : "Thorsten Weber"
+        },
+        {
+          "rolle" : "Mr. Kingsley",
+          "sprecher" : "Herbert Tennigkeit"
+        },
+        {
+          "rolle" : "Mrs. Kingsley",
+          "sprecher" : "Tina Rehfeld-Wildmann"
+        },
+        {
+          "rolle" : "Devlin Reno",
+          "sprecher" : "Jörg Pleva"
+        },
+        {
+          "rolle" : "Dr. Long",
+          "sprecher" : "Lou Wong"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/122/metadata.json",
@@ -13892,43 +13976,43 @@
           "end" : 3677213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Emiliano",
-          "Tobias Schmidt"
-        ],
-        [
-          "Pancho",
-          "Ben Hecker"
-        ],
-        [
-          "Esperanza",
-          "Ingeborg Christiansen"
-        ],
-        [
-          "Pedro",
-          "Anton Sprick"
-        ],
-        [
-          "Abelardo",
-          "Peter Heinrich Brix"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Emiliano",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Pancho",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Esperanza",
+          "sprecher" : "Ingeborg Christiansen"
+        },
+        {
+          "rolle" : "Pedro",
+          "sprecher" : "Anton Sprick"
+        },
+        {
+          "rolle" : "Abelardo",
+          "sprecher" : "Peter Heinrich Brix"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/123/metadata.json",
@@ -14023,43 +14107,43 @@
           "end" : 3990920
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. O'Sullivan",
-          "Eckart Dux"
-        ],
-        [
-          "Butler Paul",
-          "Volker Bogdan"
-        ],
-        [
-          "Dick Perry",
-          "Ernst H. Hilbich"
-        ],
-        [
-          "Polizist",
-          "Frank Thannhäuser"
-        ],
-        [
-          "Aufsicht",
-          "Patrick Bach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. O'Sullivan",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Butler Paul",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Dick Perry",
+          "sprecher" : "Ernst H. Hilbich"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Frank Thannhäuser"
+        },
+        {
+          "rolle" : "Aufsicht",
+          "sprecher" : "Patrick Bach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/124/metadata.json",
@@ -14140,55 +14224,56 @@
               "end" : 4488347
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Brittany",
-              "Dorette Hugo"
-            ],
-            [
-              "Hugenay",
-              "Albert Giro [Wolfgang Kubach]"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Jaccard (Off-Stimme)",
-              "Douglas Welbat"
-            ],
-            [
-              "Andy Miller",
-              "Jannik Endemann"
-            ],
-            [
-              "Sharon Lockwood",
-              "Nova Meierhenrich"
-            ],
-            [
-              "Moderator",
-              "Holger Wemhoff"
-            ],
-            [
-              "Rubbish George",
-              "Utz Richter"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Brittany",
+              "sprecher" : "Dorette Hugo"
+            },
+            {
+              "rolle" : "Hugenay",
+              "sprecher" : "Wolfgang Kubach",
+              "pseudonym" : "Albert Giro"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Jaccard (Off-Stimme)",
+              "sprecher" : "Douglas Welbat"
+            },
+            {
+              "rolle" : "Andy Miller",
+              "sprecher" : "Jannik Endemann"
+            },
+            {
+              "rolle" : "Sharon Lockwood",
+              "sprecher" : "Nova Meierhenrich"
+            },
+            {
+              "rolle" : "Moderator",
+              "sprecher" : "Holger Wemhoff"
+            },
+            {
+              "rolle" : "Rubbish George",
+              "sprecher" : "Utz Richter"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/1/metadata.json",
@@ -14273,75 +14358,77 @@
               "end" : 4166213
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Brittany",
-              "Dorette Hugo"
-            ],
-            [
-              "Hugenay",
-              "Albert Giro [Wolfgang Kubach]"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Graham, Reporter",
-              "Thomas Bammer"
-            ],
-            [
-              "Julianne Wallace",
-              "Marlen Diekhoff"
-            ],
-            [
-              "Sharon Lockwood",
-              "Nova Meierhenrich"
-            ],
-            [
-              "Moderator",
-              "Holger Wemhoff"
-            ],
-            [
-              "Polizist 1",
-              "Fabian Harloff"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Mrs. Albright",
-              "Lotti Krekel"
-            ],
-            [
-              "Mr. Myers",
-              "Eberhard Haar"
-            ],
-            [
-              "LKW-Fahrer",
-              "Nick Heidfeld"
-            ],
-            [
-              "Onkel Titus",
-              "Hans Meinhardt [Andreas E. Beurmann]"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Brittany",
+              "sprecher" : "Dorette Hugo"
+            },
+            {
+              "rolle" : "Hugenay",
+              "sprecher" : "Wolfgang Kubach",
+              "pseudonym" : "Albert Giro"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Graham, Reporter",
+              "sprecher" : "Thomas Bammer"
+            },
+            {
+              "rolle" : "Julianne Wallace",
+              "sprecher" : "Marlen Diekhoff"
+            },
+            {
+              "rolle" : "Sharon Lockwood",
+              "sprecher" : "Nova Meierhenrich"
+            },
+            {
+              "rolle" : "Moderator",
+              "sprecher" : "Holger Wemhoff"
+            },
+            {
+              "rolle" : "Polizist 1",
+              "sprecher" : "Fabian Harloff"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Mrs. Albright",
+              "sprecher" : "Lotti Krekel"
+            },
+            {
+              "rolle" : "Mr. Myers",
+              "sprecher" : "Eberhard Haar"
+            },
+            {
+              "rolle" : "LKW-Fahrer",
+              "sprecher" : "Nick Heidfeld"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/2/metadata.json",
@@ -14436,75 +14523,77 @@
               "end" : 4464547
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Brittany",
-              "Dorette Hugo"
-            ],
-            [
-              "Hugenay",
-              "Albert Giro [Wolfgang Kubach]"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Julianne Wallace",
-              "Marlen Diekhoff"
-            ],
-            [
-              "Charles Knox",
-              "Dirk Bach"
-            ],
-            [
-              "Moderator",
-              "Holger Wemhoff"
-            ],
-            [
-              "Polizist 2",
-              "Erik Schäffler"
-            ],
-            [
-              "Ansager",
-              "Bertram Hiese"
-            ],
-            [
-              "Mr. Myers",
-              "Eberhard Haar"
-            ],
-            [
-              "Nachtschatten",
-              "Frank Thannhäuser"
-            ],
-            [
-              "Onkel Titus",
-              "Hans Meinhardt [Andreas E. Beurmann]"
-            ],
-            [
-              "Tante Mathilda",
-              "Karin Lieneweg"
-            ],
-            [
-              "Mr. Baker",
-              "Wolf Pahlke"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Brittany",
+              "sprecher" : "Dorette Hugo"
+            },
+            {
+              "rolle" : "Hugenay",
+              "sprecher" : "Wolfgang Kubach",
+              "pseudonym" : "Albert Giro"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Julianne Wallace",
+              "sprecher" : "Marlen Diekhoff"
+            },
+            {
+              "rolle" : "Charles Knox",
+              "sprecher" : "Dirk Bach"
+            },
+            {
+              "rolle" : "Moderator",
+              "sprecher" : "Holger Wemhoff"
+            },
+            {
+              "rolle" : "Polizist 2",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Ansager",
+              "sprecher" : "Bertram Hiese"
+            },
+            {
+              "rolle" : "Mr. Myers",
+              "sprecher" : "Eberhard Haar"
+            },
+            {
+              "rolle" : "Nachtschatten",
+              "sprecher" : "Frank Thannhäuser"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Mr. Baker",
+              "sprecher" : "Wolf Pahlke"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/3/metadata.json",
@@ -14518,111 +14607,113 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Rätselhafte Briefe eines verstorbenen Malers bringen die drei ??? auf die Spur eines verschollenes Gemäldes … Und der Gegenspieler der Detektive aus Rocky Beach ist kein Geringerer als der französische Meisterdieb Victor Hugenay! Wem wird es gelingen, Feuermond zu finden und das in dem Gemälde verborgene große Geheimnis zu lüften?",
       "veröffentlichungsdatum" : "2008-10-10",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Andy Miller",
-          "Jannik Endemann"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Ansager",
-          "Bertram Hiese"
-        ],
-        [
-          "Graham, Reporter",
-          "Thomas Bammer"
-        ],
-        [
-          "Julianne Wallace",
-          "Marlen Diekhoff"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro [Wolfgang Kubach]"
-        ],
-        [
-          "Moderator",
-          "Holger Wemhoff"
-        ],
-        [
-          "Charles Knox",
-          "Dirk Bach"
-        ],
-        [
-          "Mr. Myers",
-          "Eberhard Haar"
-        ],
-        [
-          "Nachtschatten",
-          "Frank Thannhäuser"
-        ],
-        [
-          "Brittany",
-          "Dorette Hugo"
-        ],
-        [
-          "Sharon Lockwood",
-          "Nova Meierhenrich"
-        ],
-        [
-          "Mrs. Albright",
-          "Lotti Krekel"
-        ],
-        [
-          "Jaccard (Off-Stimme)",
-          "Douglas Welbat"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Polizist 1",
-          "Fabian Harloff"
-        ],
-        [
-          "Polizist 2",
-          "Erik Schäffler"
-        ],
-        [
-          "LKW-Fahrer",
-          "Nick Heidfeld"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Rubbish George",
-          "Utz Richter"
-        ],
-        [
-          "Mr. Baker",
-          "Wolf Pahlke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Andy Miller",
+          "sprecher" : "Jannik Endemann"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Ansager",
+          "sprecher" : "Bertram Hiese"
+        },
+        {
+          "rolle" : "Graham, Reporter",
+          "sprecher" : "Thomas Bammer"
+        },
+        {
+          "rolle" : "Julianne Wallace",
+          "sprecher" : "Marlen Diekhoff"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Moderator",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Charles Knox",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "Mr. Myers",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Nachtschatten",
+          "sprecher" : "Frank Thannhäuser"
+        },
+        {
+          "rolle" : "Brittany",
+          "sprecher" : "Dorette Hugo"
+        },
+        {
+          "rolle" : "Sharon Lockwood",
+          "sprecher" : "Nova Meierhenrich"
+        },
+        {
+          "rolle" : "Mrs. Albright",
+          "sprecher" : "Lotti Krekel"
+        },
+        {
+          "rolle" : "Jaccard (Off-Stimme)",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "LKW-Fahrer",
+          "sprecher" : "Nick Heidfeld"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Mr. Baker",
+          "sprecher" : "Wolf Pahlke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/125/metadata.json",
@@ -14695,51 +14786,51 @@
           "end" : 3992933
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dr. Chandler",
-          "Wolf Pahlke"
-        ],
-        [
-          "Max",
-          "Sven Dahlem"
-        ],
-        [
-          "Austin",
-          "Patrick Bach"
-        ],
-        [
-          "Dwain",
-          "Tim Knauer"
-        ],
-        [
-          "Mr. Monroe",
-          "Joachim Regelien"
-        ],
-        [
-          "Professor Rosenberg",
-          "Lothar Grützner"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dr. Chandler",
+          "sprecher" : "Wolf Pahlke"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Austin",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Dwain",
+          "sprecher" : "Tim Knauer"
+        },
+        {
+          "rolle" : "Mr. Monroe",
+          "sprecher" : "Joachim Regelien"
+        },
+        {
+          "rolle" : "Professor Rosenberg",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/126/metadata.json",
@@ -14819,63 +14910,63 @@
           "end" : 4390653
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "José",
-          "Patrick Bach"
-        ],
-        [
-          "Steve Bright",
-          "Marek Erhardt"
-        ],
-        [
-          "Brian Smith",
-          "Christian Rode"
-        ],
-        [
-          "Martin",
-          "Jesse Grimm"
-        ],
-        [
-          "Wächter",
-          "Sven Dahlem"
-        ],
-        [
-          "Mrs. Osborne",
-          "Anja Nejarri"
-        ],
-        [
-          "Mr. Pentecost",
-          "Wolf Frass"
-        ],
-        [
-          "Senora Gonzalez",
-          "Susanne von Loessl"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "José",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Steve Bright",
+          "sprecher" : "Marek Erhardt"
+        },
+        {
+          "rolle" : "Brian Smith",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Martin",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Wächter",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Mrs. Osborne",
+          "sprecher" : "Anja Nejarri"
+        },
+        {
+          "rolle" : "Mr. Pentecost",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Senora Gonzalez",
+          "sprecher" : "Susanne von Loessl"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/127/metadata.json",
@@ -14955,51 +15046,51 @@
           "end" : 4412907
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Bennett",
-          "Renate Pichler"
-        ],
-        [
-          "Wächter",
-          "Marek Erhardt"
-        ],
-        [
-          "Crowle",
-          "Christian Rudolf"
-        ],
-        [
-          "Casey Wye",
-          "Gisela Trowe"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Oliver Taper",
-          "Gosta Liptow"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Bennett",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Wächter",
+          "sprecher" : "Marek Erhardt"
+        },
+        {
+          "rolle" : "Crowle",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Casey Wye",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Oliver Taper",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/128/metadata.json",
@@ -15104,79 +15195,79 @@
           "end" : 4734387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Layla",
-          "Saskia Weckler"
-        ],
-        [
-          "Alaa Edine",
-          "Abdul Kader-Diab"
-        ],
-        [
-          "Abazza",
-          "Robert Missler"
-        ],
-        [
-          "Kamelhändler",
-          "Wolf Frass"
-        ],
-        [
-          "Kamelführer",
-          "Fathi Farnazmatis"
-        ],
-        [
-          "Wärter",
-          "Gosta Liptow"
-        ],
-        [
-          "Ägypter",
-          "Lothar Grützner"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Rubbish George",
-          "Utz Richter"
-        ],
-        [
-          "Kommissar",
-          "Klaus Dittmann"
-        ],
-        [
-          "Aisha",
-          "Susanne von Loessl"
-        ],
-        [
-          "Verkäufer",
-          "Farhat Al Yhi"
-        ],
-        [
-          "Dick Vincent",
-          "Holger Löwenberg"
-        ],
-        [
-          "Taxifahrer",
-          "Wolf Pahlke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Layla",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Alaa Edine",
+          "sprecher" : "Abdul Kader-Diab"
+        },
+        {
+          "rolle" : "Abazza",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Kamelhändler",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Kamelführer",
+          "sprecher" : "Fathi Farnazmatis"
+        },
+        {
+          "rolle" : "Wärter",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Ägypter",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Kommissar",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Aisha",
+          "sprecher" : "Susanne von Loessl"
+        },
+        {
+          "rolle" : "Verkäufer",
+          "sprecher" : "Farhat Al Yhi"
+        },
+        {
+          "rolle" : "Dick Vincent",
+          "sprecher" : "Holger Löwenberg"
+        },
+        {
+          "rolle" : "Taxifahrer",
+          "sprecher" : "Wolf Pahlke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/129/metadata.json",
@@ -15276,63 +15367,64 @@
           "end" : 4112560
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Beverly Leung",
-          "Susanne Stangl"
-        ],
-        [
-          "Thomas Johnson",
-          "Lutz Herkenrath"
-        ],
-        [
-          "Polizist 1",
-          "Robert Missler"
-        ],
-        [
-          "Polizist 2",
-          "Edgar Hoppe"
-        ],
-        [
-          "James",
-          "Sönke Städtler"
-        ],
-        [
-          "Daniel Baker",
-          "Sascha Rotermund"
-        ],
-        [
-          "Mr. Grogan",
-          "Günther Flesch"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Beverly Leung",
+          "sprecher" : "Susanne Stangl"
+        },
+        {
+          "rolle" : "Thomas Johnson",
+          "sprecher" : "Lutz Herkenrath"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Edgar Hoppe"
+        },
+        {
+          "rolle" : "James",
+          "sprecher" : "Sönke Städtler"
+        },
+        {
+          "rolle" : "Daniel Baker",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Mr. Grogan",
+          "sprecher" : "Günther Flesch"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/130/metadata.json",
@@ -15397,59 +15489,59 @@
           "end" : 4242960
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Lloyd Scavenger",
-          "Stephan Benson"
-        ],
-        [
-          "Jack Lowell",
-          "Siegfried W. Kernen"
-        ],
-        [
-          "Alexander Nolan",
-          "Wilfried Hochholdinger"
-        ],
-        [
-          "Jaqueline Williams",
-          "Henrike Fehrs"
-        ],
-        [
-          "Ian Parsley",
-          "Jörg Gillner"
-        ],
-        [
-          "Mary Parsley",
-          "Carin Abicht"
-        ],
-        [
-          "Jasper Kittle",
-          "Peter Weis"
-        ],
-        [
-          "Shawne Davison",
-          "Susanne Lothar"
-        ],
-        [
-          "Officer Wood",
-          "Roman Kretschmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Lloyd Scavenger",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Jack Lowell",
+          "sprecher" : "Siegfried W. Kernen"
+        },
+        {
+          "rolle" : "Alexander Nolan",
+          "sprecher" : "Wilfried Hochholdinger"
+        },
+        {
+          "rolle" : "Jaqueline Williams",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Ian Parsley",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Mary Parsley",
+          "sprecher" : "Carin Abicht"
+        },
+        {
+          "rolle" : "Jasper Kittle",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Shawne Davison",
+          "sprecher" : "Susanne Lothar"
+        },
+        {
+          "rolle" : "Officer Wood",
+          "sprecher" : "Roman Kretschmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/131/metadata.json",
@@ -15514,71 +15606,71 @@
           "end" : 3799387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Miss Bennett",
-          "Renate Pichler"
-        ],
-        [
-          "Karen",
-          "Celine Fontanges"
-        ],
-        [
-          "Becky",
-          "Katharina von Keller"
-        ],
-        [
-          "Felicia Sparing",
-          "Rhea Harder-Vennewald"
-        ],
-        [
-          "Mrs. Amelia Sparing",
-          "Karin Buchholz"
-        ],
-        [
-          "Mr. Sparing",
-          "Sky du Mont"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Professor Alkurah",
-          "Ben Hecker"
-        ],
-        [
-          "Eroll",
-          "Bertram Hiese"
-        ],
-        [
-          "Mrs. Featherstone",
-          "Sabine Hahn"
-        ],
-        [
-          "Wärter",
-          "Jürgen Holdorf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Miss Bennett",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Karen",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Becky",
+          "sprecher" : "Katharina von Keller"
+        },
+        {
+          "rolle" : "Felicia Sparing",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Mrs. Amelia Sparing",
+          "sprecher" : "Karin Buchholz"
+        },
+        {
+          "rolle" : "Mr. Sparing",
+          "sprecher" : "Sky du Mont"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Professor Alkurah",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Eroll",
+          "sprecher" : "Bertram Hiese"
+        },
+        {
+          "rolle" : "Mrs. Featherstone",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Wärter",
+          "sprecher" : "Jürgen Holdorf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/132/metadata.json",
@@ -15643,59 +15735,59 @@
           "end" : 3473893
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sergeant Ludlow",
-          "Dietmar Mues"
-        ],
-        [
-          "Banden-Chef",
-          "Eberhard Haar"
-        ],
-        [
-          "Eddy Reardon",
-          "Lukas T. Sperber"
-        ],
-        [
-          "Spanier",
-          "Erik Schäffler"
-        ],
-        [
-          "Jack",
-          "Fabian Harloff"
-        ],
-        [
-          "Italiener",
-          "Lutz Harder"
-        ],
-        [
-          "Gauner",
-          "Sven Dahlem"
-        ],
-        [
-          "Gehilfe",
-          "Gerhart Hinze"
-        ],
-        [
-          "Polizist",
-          "Bertram Hiese"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sergeant Ludlow",
+          "sprecher" : "Dietmar Mues"
+        },
+        {
+          "rolle" : "Banden-Chef",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Eddy Reardon",
+          "sprecher" : "Lukas T. Sperber"
+        },
+        {
+          "rolle" : "Spanier",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Italiener",
+          "sprecher" : "Lutz Harder"
+        },
+        {
+          "rolle" : "Gauner",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Gehilfe",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Bertram Hiese"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/133/metadata.json",
@@ -15780,51 +15872,51 @@
           "end" : 4029587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Christine",
-          "Inken Sommer"
-        ],
-        [
-          "Mr. Bambridge",
-          "Gustav-Adolph Artz"
-        ],
-        [
-          "Lo Wang",
-          "Dae Joon Yoo"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Anthony Hearst",
-          "Wolfgang Pampel"
-        ],
-        [
-          "Truck-Fahrer",
-          "Konstantin Graudus"
-        ],
-        [
-          "Avercromby",
-          "Nicolas König"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Christine",
+          "sprecher" : "Inken Sommer"
+        },
+        {
+          "rolle" : "Mr. Bambridge",
+          "sprecher" : "Gustav-Adolph Artz"
+        },
+        {
+          "rolle" : "Lo Wang",
+          "sprecher" : "Dae Joon Yoo"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Anthony Hearst",
+          "sprecher" : "Wolfgang Pampel"
+        },
+        {
+          "rolle" : "Truck-Fahrer",
+          "sprecher" : "Konstantin Graudus"
+        },
+        {
+          "rolle" : "Avercromby",
+          "sprecher" : "Nicolas König"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/134/metadata.json",
@@ -15929,47 +16021,47 @@
           "end" : 4271013
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Pilot",
-          "Gerhart Hinze"
-        ],
-        [
-          "Max",
-          "Traudel Sperber"
-        ],
-        [
-          "Liolotta",
-          "Peter Striebeck"
-        ],
-        [
-          "Althena",
-          "Stephanie Damare"
-        ],
-        [
-          "Sarah Livingston",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Elvira Zuckerman",
-          "Konstanze Ullmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Pilot",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Liolotta",
+          "sprecher" : "Peter Striebeck"
+        },
+        {
+          "rolle" : "Althena",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Sarah Livingston",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Elvira Zuckerman",
+          "sprecher" : "Konstanze Ullmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/135/metadata.json",
@@ -16054,63 +16146,63 @@
           "end" : 4117027
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Darren Duff",
-          "Jesse Grimm"
-        ],
-        [
-          "Taucher Carl",
-          "Oliver Böttcher"
-        ],
-        [
-          "Taucherin Joan",
-          "Christine Pappert"
-        ],
-        [
-          "Paul Brooks",
-          "Heinz Lieven"
-        ],
-        [
-          "Joe Wilcox",
-          "Rolf Becker"
-        ],
-        [
-          "Cassandra Wilcox",
-          "Elke Reissert"
-        ],
-        [
-          "Daniel",
-          "Jochen Baumert"
-        ],
-        [
-          "Henry",
-          "Frank Felicetti"
-        ],
-        [
-          "Doktor Holloway",
-          "Barbara Focke"
-        ],
-        [
-          "Cedric Duff",
-          "Rolf E. Schenker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Darren Duff",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Taucher Carl",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Taucherin Joan",
+          "sprecher" : "Christine Pappert"
+        },
+        {
+          "rolle" : "Paul Brooks",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Joe Wilcox",
+          "sprecher" : "Rolf Becker"
+        },
+        {
+          "rolle" : "Cassandra Wilcox",
+          "sprecher" : "Elke Reissert"
+        },
+        {
+          "rolle" : "Daniel",
+          "sprecher" : "Jochen Baumert"
+        },
+        {
+          "rolle" : "Henry",
+          "sprecher" : "Frank Felicetti"
+        },
+        {
+          "rolle" : "Doktor Holloway",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Cedric Duff",
+          "sprecher" : "Rolf E. Schenker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/136/metadata.json",
@@ -16195,47 +16287,47 @@
           "end" : 4653507
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Winston Granville",
-          "Christian Rode"
-        ],
-        [
-          "Matthew Granville",
-          "Uwe Friedrichsen"
-        ],
-        [
-          "Smithy",
-          "Konstantin Graudus"
-        ],
-        [
-          "Mr. Jackmore",
-          "Michael Brennicke"
-        ],
-        [
-          "Professor Frazier",
-          "Wilhelm Wieben"
-        ],
-        [
-          "Polizist",
-          "Tetje Mierendorf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Winston Granville",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Matthew Granville",
+          "sprecher" : "Uwe Friedrichsen"
+        },
+        {
+          "rolle" : "Smithy",
+          "sprecher" : "Konstantin Graudus"
+        },
+        {
+          "rolle" : "Mr. Jackmore",
+          "sprecher" : "Michael Brennicke"
+        },
+        {
+          "rolle" : "Professor Frazier",
+          "sprecher" : "Wilhelm Wieben"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Tetje Mierendorf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/137/metadata.json",
@@ -16320,39 +16412,39 @@
           "end" : 3987133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Davy Swann",
-          "Torsten Sense"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Craig Holden",
-          "Gerhard Olschewski"
-        ],
-        [
-          "Löwenritter",
-          "Burghart Klaußner"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Davy Swann",
+          "sprecher" : "Torsten Sense"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Craig Holden",
+          "sprecher" : "Gerhard Olschewski"
+        },
+        {
+          "rolle" : "Löwenritter",
+          "sprecher" : "Burghart Klaußner"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/138/metadata.json",
@@ -16432,79 +16524,80 @@
           "end" : 3860747
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Helena Darraz",
-          "Ingrid Andree"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Pritchard",
-          "Sascha Rotermund"
-        ],
-        [
-          "Sid",
-          "Tilman Madaus"
-        ],
-        [
-          "Caroline",
-          "Celine Fontanges"
-        ],
-        [
-          "Sandy",
-          "Simona Pahl"
-        ],
-        [
-          "Steven",
-          "René Dawn-Claude"
-        ],
-        [
-          "Ernest",
-          "Tim Kreuer"
-        ],
-        [
-          "Radioansagerin",
-          "Susanne Wulkow"
-        ],
-        [
-          "Harvey Griscom",
-          "Christian Rudolf"
-        ],
-        [
-          "John Dellcourt",
-          "Gustav Adolph Artz"
-        ],
-        [
-          "Miss Darraz",
-          "Sabine Hahn"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Helena Darraz",
+          "sprecher" : "Ingrid Andree"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Pritchard",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Sid",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Caroline",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Sandy",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Steven",
+          "sprecher" : "René Dawn-Claude"
+        },
+        {
+          "rolle" : "Ernest",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Radioansagerin",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Harvey Griscom",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "John Dellcourt",
+          "sprecher" : "Gustav Adolph Artz"
+        },
+        {
+          "rolle" : "Miss Darraz",
+          "sprecher" : "Sabine Hahn"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/139/metadata.json",
@@ -16579,59 +16672,59 @@
           "end" : 4658533
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Josy McDonaghough",
-          "Lili Draeger"
-        ],
-        [
-          "Homer Diesel",
-          "Christian Senger"
-        ],
-        [
-          "Mary Stamper",
-          "Annabelle Krieg"
-        ],
-        [
-          "Otis Stamper",
-          "Klaus Dittmann"
-        ],
-        [
-          "Jonathan Black",
-          "Eckart Dux"
-        ],
-        [
-          "Miles Black",
-          "Sascha Rotermund"
-        ],
-        [
-          "Klara Kowalski",
-          "Stephanie Damare"
-        ],
-        [
-          "Silvester Proud",
-          "Gustav Adolph Artz"
-        ],
-        [
-          "Pfarrer Clark",
-          "Gerd Baltus"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Josy McDonaghough",
+          "sprecher" : "Lili Draeger"
+        },
+        {
+          "rolle" : "Homer Diesel",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Mary Stamper",
+          "sprecher" : "Annabelle Krieg"
+        },
+        {
+          "rolle" : "Otis Stamper",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Jonathan Black",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Miles Black",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Klara Kowalski",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Silvester Proud",
+          "sprecher" : "Gustav Adolph Artz"
+        },
+        {
+          "rolle" : "Pfarrer Clark",
+          "sprecher" : "Gerd Baltus"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/140/metadata.json",
@@ -16716,71 +16809,72 @@
           "end" : 3562347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Jeffrey Seaman",
-          "Daniel Welbat"
-        ],
-        [
-          "Steven",
-          "Oliver Böttcher"
-        ],
-        [
-          "Eric",
-          "Patrick Bach"
-        ],
-        [
-          "Mr. Settler",
-          "Christian Senger"
-        ],
-        [
-          "Auktionator",
-          "Achim Schülke"
-        ],
-        [
-          "Frau",
-          "Hilla Fitzen"
-        ],
-        [
-          "Patrick O'Brian",
-          "Wolfgang Riehm"
-        ],
-        [
-          "William de Haas",
-          "Jörg Gillner"
-        ],
-        [
-          "Theodor Brewster",
-          "Tobias Meister"
-        ],
-        [
-          "Butler",
-          "Olaf Kreutzenbeck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Jeffrey Seaman",
+          "sprecher" : "Daniel Welbat"
+        },
+        {
+          "rolle" : "Steven",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Eric",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Mr. Settler",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Auktionator",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Hilla Fitzen"
+        },
+        {
+          "rolle" : "Patrick O'Brian",
+          "sprecher" : "Wolfgang Riehm"
+        },
+        {
+          "rolle" : "William de Haas",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Theodor Brewster",
+          "sprecher" : "Tobias Meister"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Olaf Kreutzenbeck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/141/metadata.json",
@@ -16865,79 +16959,79 @@
           "end" : 3437227
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Carol Ford",
-          "Claudia Schermutzki"
-        ],
-        [
-          "Francis Studstill",
-          "Elena Wilms"
-        ],
-        [
-          "Baxter Norsworthy",
-          "Udo Schenk"
-        ],
-        [
-          "Gordon Hoke",
-          "Holger Löwenberg"
-        ],
-        [
-          "Jared Fox",
-          "Meik Spallek"
-        ],
-        [
-          "Candace Duskin",
-          "Andrea Lienau"
-        ],
-        [
-          "George Bennet",
-          "Urs Affolter"
-        ],
-        [
-          "Greg Harper",
-          "Robert Missler"
-        ],
-        [
-          "Woodland",
-          "Jürgen Thormann"
-        ],
-        [
-          "Reporterin",
-          "Jamie Leaves"
-        ],
-        [
-          "Reporter",
-          "Glenn Goltz"
-        ],
-        [
-          "Wellford",
-          "Oliver Geilhardt"
-        ],
-        [
-          "Pilot",
-          "Achim Schülke"
-        ],
-        [
-          "Lautsprecherstimme",
-          "Sascha Draeger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Carol Ford",
+          "sprecher" : "Claudia Schermutzki"
+        },
+        {
+          "rolle" : "Francis Studstill",
+          "sprecher" : "Elena Wilms"
+        },
+        {
+          "rolle" : "Baxter Norsworthy",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Gordon Hoke",
+          "sprecher" : "Holger Löwenberg"
+        },
+        {
+          "rolle" : "Jared Fox",
+          "sprecher" : "Meik Spallek"
+        },
+        {
+          "rolle" : "Candace Duskin",
+          "sprecher" : "Andrea Lienau"
+        },
+        {
+          "rolle" : "George Bennet",
+          "sprecher" : "Urs Affolter"
+        },
+        {
+          "rolle" : "Greg Harper",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Woodland",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Reporterin",
+          "sprecher" : "Jamie Leaves"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Glenn Goltz"
+        },
+        {
+          "rolle" : "Wellford",
+          "sprecher" : "Oliver Geilhardt"
+        },
+        {
+          "rolle" : "Pilot",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Lautsprecherstimme",
+          "sprecher" : "Sascha Draeger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/142/metadata.json",
@@ -17012,55 +17106,55 @@
           "end" : 3621920
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Richie Hanson",
-          "Dennis Schmidt-Foß"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Benni",
-          "Ivo Möller"
-        ],
-        [
-          "Jacki Jin",
-          "Robert Missler"
-        ],
-        [
-          "Kellnerin",
-          "Corinna Wodrich"
-        ],
-        [
-          "Croupier",
-          "Dirk Bach"
-        ],
-        [
-          "Mann",
-          "Arndt Schmöle"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Richie Hanson",
+          "sprecher" : "Dennis Schmidt-Foß"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Benni",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Jacki Jin",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Croupier",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Arndt Schmöle"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/143/metadata.json",
@@ -17145,55 +17239,56 @@
           "end" : 4256000
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Arthur Sinclair",
-          "Joachim Pukaß"
-        ],
-        [
-          "Mr. Peastone",
-          "Eberhard Haar"
-        ],
-        [
-          "Jeremy Witherspoon",
-          "Martin Semmelrogge"
-        ],
-        [
-          "Barnaby Witherspoon",
-          "Achim Schülke"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Mann",
-          "Holger Löwenberg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Arthur Sinclair",
+          "sprecher" : "Joachim Pukaß"
+        },
+        {
+          "rolle" : "Mr. Peastone",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Jeremy Witherspoon",
+          "sprecher" : "Martin Semmelrogge"
+        },
+        {
+          "rolle" : "Barnaby Witherspoon",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Holger Löwenberg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/144/metadata.json",
@@ -17273,55 +17368,55 @@
           "end" : 3722547
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Takasi Yukawa",
-          "Wilfried Dziallas"
-        ],
-        [
-          "Frank Hektor",
-          "Michael Lott"
-        ],
-        [
-          "Sean Doherty",
-          "Leonhard Mahlich"
-        ],
-        [
-          "Mandy",
-          "Jasmin Wagner"
-        ],
-        [
-          "Zeno Daniels",
-          "Philipp Baltus"
-        ],
-        [
-          "Percy",
-          "Jesse Grimm"
-        ],
-        [
-          "Keko",
-          "Jens Wendland"
-        ],
-        [
-          "Anthony Fender",
-          "Peter Buchholz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Takasi Yukawa",
+          "sprecher" : "Wilfried Dziallas"
+        },
+        {
+          "rolle" : "Frank Hektor",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Sean Doherty",
+          "sprecher" : "Leonhard Mahlich"
+        },
+        {
+          "rolle" : "Mandy",
+          "sprecher" : "Jasmin Wagner"
+        },
+        {
+          "rolle" : "Zeno Daniels",
+          "sprecher" : "Philipp Baltus"
+        },
+        {
+          "rolle" : "Percy",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Keko",
+          "sprecher" : "Jens Wendland"
+        },
+        {
+          "rolle" : "Anthony Fender",
+          "sprecher" : "Peter Buchholz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/145/metadata.json",
@@ -17421,79 +17516,80 @@
           "end" : 3430360
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Quentin Wadleigh",
-          "Christian Rudolf"
-        ],
-        [
-          "Dr. Winston Wadleigh",
-          "Mathias Münster"
-        ],
-        [
-          "Dr. John Frears",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Jamie",
-          "Philipp Draeger"
-        ],
-        [
-          "Sammy",
-          "Jacob Mayerhoff"
-        ],
-        [
-          "Mrs. Pitkätossu",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Jackall Madson",
-          "Ingo Nommsen"
-        ],
-        [
-          "Tiger Madson",
-          "Dieter Dücker"
-        ],
-        [
-          "Vivian",
-          "Saskia Mayerhoff"
-        ],
-        [
-          "Fitzwilliam Waterfield",
-          "Wolfgang Völz"
-        ],
-        [
-          "Sanitäter",
-          "Robin Brosch"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Quentin Wadleigh",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Dr. Winston Wadleigh",
+          "sprecher" : "Mathias Münster"
+        },
+        {
+          "rolle" : "Dr. John Frears",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Jamie",
+          "sprecher" : "Philipp Draeger"
+        },
+        {
+          "rolle" : "Sammy",
+          "sprecher" : "Jacob Mayerhoff"
+        },
+        {
+          "rolle" : "Mrs. Pitkätossu",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Jackall Madson",
+          "sprecher" : "Ingo Nommsen"
+        },
+        {
+          "rolle" : "Tiger Madson",
+          "sprecher" : "Dieter Dücker"
+        },
+        {
+          "rolle" : "Vivian",
+          "sprecher" : "Saskia Mayerhoff"
+        },
+        {
+          "rolle" : "Fitzwilliam Waterfield",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Robin Brosch"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/146/metadata.json",
@@ -17558,71 +17654,71 @@
           "end" : 3770533
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Adam Campbell",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Henry Campbell",
-          "Christian Rudolf"
-        ],
-        [
-          "John Taylor",
-          "Holger Umbreit"
-        ],
-        [
-          "Edward Crockett",
-          "Ben Hecker"
-        ],
-        [
-          "Mrs. Harkort",
-          "Katja Brügger"
-        ],
-        [
-          "Mr. Prescott",
-          "Stefan Kaminski"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Jack Leech",
-          "Volker Bogdan"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Einbrecher",
-          "Patrick Bach"
-        ],
-        [
-          "Max",
-          "Tommaso Cacciapuoti"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Adam Campbell",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Henry Campbell",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "John Taylor",
+          "sprecher" : "Holger Umbreit"
+        },
+        {
+          "rolle" : "Edward Crockett",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Mrs. Harkort",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Mr. Prescott",
+          "sprecher" : "Stefan Kaminski"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Jack Leech",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Einbrecher",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Tommaso Cacciapuoti"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/147/metadata.json",
@@ -17687,55 +17783,55 @@
           "end" : 4011933
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Allie Jamison",
-          "Katrin Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Ursula Burns",
-          "Birke Bruck"
-        ],
-        [
-          "Emerald Pendragon",
-          "Monty Arnold"
-        ],
-        [
-          "Carl Parsley",
-          "Peter Weis"
-        ],
-        [
-          "Sunshine",
-          "Dagmar Dreke"
-        ],
-        [
-          "Mann 1",
-          "Tetje Mierendorf"
-        ],
-        [
-          "Mann 2",
-          "Gosta Liptow"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Allie Jamison",
+          "sprecher" : "Katrin Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Ursula Burns",
+          "sprecher" : "Birke Bruck"
+        },
+        {
+          "rolle" : "Emerald Pendragon",
+          "sprecher" : "Monty Arnold"
+        },
+        {
+          "rolle" : "Carl Parsley",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Sunshine",
+          "sprecher" : "Dagmar Dreke"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Tetje Mierendorf"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Gosta Liptow"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/148/metadata.json",
@@ -17825,71 +17921,71 @@
           "end" : 3717773
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Cynthia McGowan",
-          "Luise Lunow"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Mrs. Andrews",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mina Parker",
-          "Annabelle Krieg"
-        ],
-        [
-          "Brandon Fraser",
-          "Tim Grobe"
-        ],
-        [
-          "Beatrix Fraser",
-          "Sophie Lechtenbrink"
-        ],
-        [
-          "Roxy",
-          "Julia Fölster"
-        ],
-        [
-          "Josh",
-          "Volker Hanisch"
-        ],
-        [
-          "Paul",
-          "Tim Kreuer"
-        ],
-        [
-          "Davis",
-          "Frank Meyer-Brockmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Cynthia McGowan",
+          "sprecher" : "Luise Lunow"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mina Parker",
+          "sprecher" : "Annabelle Krieg"
+        },
+        {
+          "rolle" : "Brandon Fraser",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Beatrix Fraser",
+          "sprecher" : "Sophie Lechtenbrink"
+        },
+        {
+          "rolle" : "Roxy",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Josh",
+          "sprecher" : "Volker Hanisch"
+        },
+        {
+          "rolle" : "Paul",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Davis",
+          "sprecher" : "Frank Meyer-Brockmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/149/metadata.json",
@@ -17980,79 +18076,79 @@
               "end" : 4055093
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Frank Mason",
-              "Wolfgang Condrus"
-            ],
-            [
-              "Miles Dempster",
-              "Stephan Benson"
-            ],
-            [
-              "Mr. Sapchevsky",
-              "Andreas Schmidt-Schaller"
-            ],
-            [
-              "Gerry",
-              "Kostja Ullmann"
-            ],
-            [
-              "Ismael",
-              "Stephan Schad"
-            ],
-            [
-              "Carla Fenton",
-              "Natalie O'Hara"
-            ],
-            [
-              "Mrs. Maruthers",
-              "Ulrike Johannson"
-            ],
-            [
-              "Inspektor Havilland",
-              "Oliver Kalkofe"
-            ],
-            [
-              "Taylor",
-              "Bernhard Hoëcker"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Angelica",
-              "Anna Thalbach"
-            ],
-            [
-              "Schwester 1",
-              "Manuela Becker"
-            ],
-            [
-              "Schwester 2",
-              "Traudel Sperber"
-            ],
-            [
-              "Pfleger",
-              "Sven Dahlem"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Frank Mason",
+              "sprecher" : "Wolfgang Condrus"
+            },
+            {
+              "rolle" : "Miles Dempster",
+              "sprecher" : "Stephan Benson"
+            },
+            {
+              "rolle" : "Mr. Sapchevsky",
+              "sprecher" : "Andreas Schmidt-Schaller"
+            },
+            {
+              "rolle" : "Gerry",
+              "sprecher" : "Kostja Ullmann"
+            },
+            {
+              "rolle" : "Ismael",
+              "sprecher" : "Stephan Schad"
+            },
+            {
+              "rolle" : "Carla Fenton",
+              "sprecher" : "Natalie O'Hara"
+            },
+            {
+              "rolle" : "Mrs. Maruthers",
+              "sprecher" : "Ulrike Johannson"
+            },
+            {
+              "rolle" : "Inspektor Havilland",
+              "sprecher" : "Oliver Kalkofe"
+            },
+            {
+              "rolle" : "Taylor",
+              "sprecher" : "Bernhard Hoëcker"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Angelica",
+              "sprecher" : "Anna Thalbach"
+            },
+            {
+              "rolle" : "Schwester 1",
+              "sprecher" : "Manuela Becker"
+            },
+            {
+              "rolle" : "Schwester 2",
+              "sprecher" : "Traudel Sperber"
+            },
+            {
+              "rolle" : "Pfleger",
+              "sprecher" : "Sven Dahlem"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/1/metadata.json",
@@ -18147,83 +18243,83 @@
               "end" : 4100240
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Taylor",
-              "Bernhard Hoëcker"
-            ],
-            [
-              "Mr. Smith",
-              "Tim Grobe"
-            ],
-            [
-              "Curtis Fisher",
-              "Tobias Schmidt"
-            ],
-            [
-              "Amrita Chakyar",
-              "Angela Stresemann"
-            ],
-            [
-              "Inspektor Havilland",
-              "Oliver Kalkofe"
-            ],
-            [
-              "Ismael",
-              "Stephan Schad"
-            ],
-            [
-              "Angelica",
-              "Anna Thalbach"
-            ],
-            [
-              "Sergeant Madhu",
-              "Olli Dittrich"
-            ],
-            [
-              "Mr. Andrews",
-              "Henry König"
-            ],
-            [
-              "Mrs. Andrews",
-              "Konstanze Ullmer"
-            ],
-            [
-              "Frank Mason",
-              "Wolfgang Condrus"
-            ],
-            [
-              "Mr. Raffer",
-              "Harald Dietl"
-            ],
-            [
-              "Feuerwehrmann",
-              "Kai Henrik Möller"
-            ],
-            [
-              "Kapitän",
-              "Sky du Mont"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Taylor",
+              "sprecher" : "Bernhard Hoëcker"
+            },
+            {
+              "rolle" : "Mr. Smith",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Curtis Fisher",
+              "sprecher" : "Tobias Schmidt"
+            },
+            {
+              "rolle" : "Amrita Chakyar",
+              "sprecher" : "Angela Stresemann"
+            },
+            {
+              "rolle" : "Inspektor Havilland",
+              "sprecher" : "Oliver Kalkofe"
+            },
+            {
+              "rolle" : "Ismael",
+              "sprecher" : "Stephan Schad"
+            },
+            {
+              "rolle" : "Angelica",
+              "sprecher" : "Anna Thalbach"
+            },
+            {
+              "rolle" : "Sergeant Madhu",
+              "sprecher" : "Olli Dittrich"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Mrs. Andrews",
+              "sprecher" : "Konstanze Ullmer"
+            },
+            {
+              "rolle" : "Frank Mason",
+              "sprecher" : "Wolfgang Condrus"
+            },
+            {
+              "rolle" : "Mr. Raffer",
+              "sprecher" : "Harald Dietl"
+            },
+            {
+              "rolle" : "Feuerwehrmann",
+              "sprecher" : "Kai Henrik Möller"
+            },
+            {
+              "rolle" : "Kapitän",
+              "sprecher" : "Sky du Mont"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/2/metadata.json",
@@ -18293,83 +18389,83 @@
               "end" : 3763400
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Frank Mason",
-              "Wolfgang Condrus"
-            ],
-            [
-              "Taylor",
-              "Bernhard Hoëcker"
-            ],
-            [
-              "Curtis Fisher",
-              "Tobias Schmidt"
-            ],
-            [
-              "John Fisher",
-              "Dirk Bach"
-            ],
-            [
-              "Gerry",
-              "Kostja Ullmann"
-            ],
-            [
-              "Ismael",
-              "Stephan Schad"
-            ],
-            [
-              "Mr. Smith",
-              "Tim Grobe"
-            ],
-            [
-              "Mrs. Maruthers",
-              "Ulrike Johannson"
-            ],
-            [
-              "Angelica",
-              "Anna Thalbach"
-            ],
-            [
-              "Sergeant Madhu",
-              "Olli Dittrich"
-            ],
-            [
-              "Mr. Castro",
-              "Jörg Gillner"
-            ],
-            [
-              "Sanitäter",
-              "Robert Kotulla"
-            ],
-            [
-              "Anudhara",
-              "Rosakutty Hemsing"
-            ],
-            [
-              "Ruth",
-              "Gabriele Libbach"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Frank Mason",
+              "sprecher" : "Wolfgang Condrus"
+            },
+            {
+              "rolle" : "Taylor",
+              "sprecher" : "Bernhard Hoëcker"
+            },
+            {
+              "rolle" : "Curtis Fisher",
+              "sprecher" : "Tobias Schmidt"
+            },
+            {
+              "rolle" : "John Fisher",
+              "sprecher" : "Dirk Bach"
+            },
+            {
+              "rolle" : "Gerry",
+              "sprecher" : "Kostja Ullmann"
+            },
+            {
+              "rolle" : "Ismael",
+              "sprecher" : "Stephan Schad"
+            },
+            {
+              "rolle" : "Mr. Smith",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Mrs. Maruthers",
+              "sprecher" : "Ulrike Johannson"
+            },
+            {
+              "rolle" : "Angelica",
+              "sprecher" : "Anna Thalbach"
+            },
+            {
+              "rolle" : "Sergeant Madhu",
+              "sprecher" : "Olli Dittrich"
+            },
+            {
+              "rolle" : "Mr. Castro",
+              "sprecher" : "Jörg Gillner"
+            },
+            {
+              "rolle" : "Sanitäter",
+              "sprecher" : "Robert Kotulla"
+            },
+            {
+              "rolle" : "Anudhara",
+              "sprecher" : "Rosakutty Hemsing"
+            },
+            {
+              "rolle" : "Ruth",
+              "sprecher" : "Gabriele Libbach"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/3/metadata.json",
@@ -18383,139 +18479,139 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Die drei ??? übernehmen und lösen (hoffentlich!) ihren 150sten Fall! In drei atemberaubenden Folgen sind sie dem Rätsel der Geisterbucht auf der Spur! Welches Geheimnis verbirgt sich hinter dem Testament, dass der exzentrische Harry Shreber kurz vor seinem Tod verfasst hat? Führen die verschlüsselten Verse tatsächlich zu Rashuras Schatz? (Teil A) Den drei Detektiven wird nichts anderes übrig bleiben: Sie müssen in Flammendes Wasser (Teil B) hinab tauchen, denn nur in der Tiefe des Meeres kann geklärt werden, warum Der brennende Kristall (Teil C) so viel Unglück über eine große Anzahl Menschen bringen konnte …",
       "veröffentlichungsdatum" : "2011-11-11",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Frank Mason",
-          "Wolfgang Condrus"
-        ],
-        [
-          "Miles Dempster",
-          "Stephan Benson"
-        ],
-        [
-          "Mr. Sapchevsky",
-          "Andreas Schmidt-Schaller"
-        ],
-        [
-          "Gerry",
-          "Kostja Ullmann"
-        ],
-        [
-          "Ismael",
-          "Stephan Schad"
-        ],
-        [
-          "Carla Fenton",
-          "Natalie O'Hara"
-        ],
-        [
-          "Mrs. Maruthers",
-          "Ulrike Johannson"
-        ],
-        [
-          "Inspektor Havilland",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Taylor",
-          "Bernhard Hoëcker"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Angelica",
-          "Anna Thalbach"
-        ],
-        [
-          "Schwester 1",
-          "Manuela Becker"
-        ],
-        [
-          "Schwester 2",
-          "Traudel Sperber"
-        ],
-        [
-          "Pfleger",
-          "Sven Dahlem"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mr. Smith",
-          "Tim Grobe"
-        ],
-        [
-          "Curtis Fisher",
-          "Tobias Schmidt"
-        ],
-        [
-          "Amrita Chakyar",
-          "Angela Stresemann"
-        ],
-        [
-          "Sergeant Madhu",
-          "Olli Dittrich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Mrs. Andrews",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Mr. Raffer",
-          "Harald Dietl"
-        ],
-        [
-          "Feuerwehrmann",
-          "Kai Henrik Möller"
-        ],
-        [
-          "Kapitän",
-          "Sky du Mont"
-        ],
-        [
-          "John Fisher",
-          "Dirk Bach"
-        ],
-        [
-          "Mr. Castro",
-          "Jörg Gillner"
-        ],
-        [
-          "Sanitäter",
-          "Robert Kotulla"
-        ],
-        [
-          "Anudhara",
-          "Rosakutty Hemsing"
-        ],
-        [
-          "Ruth",
-          "Gabriele Libbach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Frank Mason",
+          "sprecher" : "Wolfgang Condrus"
+        },
+        {
+          "rolle" : "Miles Dempster",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Mr. Sapchevsky",
+          "sprecher" : "Andreas Schmidt-Schaller"
+        },
+        {
+          "rolle" : "Gerry",
+          "sprecher" : "Kostja Ullmann"
+        },
+        {
+          "rolle" : "Ismael",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Carla Fenton",
+          "sprecher" : "Natalie O'Hara"
+        },
+        {
+          "rolle" : "Mrs. Maruthers",
+          "sprecher" : "Ulrike Johannson"
+        },
+        {
+          "rolle" : "Inspektor Havilland",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Taylor",
+          "sprecher" : "Bernhard Hoëcker"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Angelica",
+          "sprecher" : "Anna Thalbach"
+        },
+        {
+          "rolle" : "Schwester 1",
+          "sprecher" : "Manuela Becker"
+        },
+        {
+          "rolle" : "Schwester 2",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Pfleger",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mr. Smith",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Curtis Fisher",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Amrita Chakyar",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Sergeant Madhu",
+          "sprecher" : "Olli Dittrich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Mr. Raffer",
+          "sprecher" : "Harald Dietl"
+        },
+        {
+          "rolle" : "Feuerwehrmann",
+          "sprecher" : "Kai Henrik Möller"
+        },
+        {
+          "rolle" : "Kapitän",
+          "sprecher" : "Sky du Mont"
+        },
+        {
+          "rolle" : "John Fisher",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "Mr. Castro",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Robert Kotulla"
+        },
+        {
+          "rolle" : "Anudhara",
+          "sprecher" : "Rosakutty Hemsing"
+        },
+        {
+          "rolle" : "Ruth",
+          "sprecher" : "Gabriele Libbach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/150/metadata.json",
@@ -18613,87 +18709,87 @@
           "end" : 3943307
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Laurence Seinfeld",
-          "Wolf Frass"
-        ],
-        [
-          "Denzel Hopkins",
-          "Tilo Schmitz"
-        ],
-        [
-          "Goldie Hopkins",
-          "Madeleine Weingart"
-        ],
-        [
-          "Neil Rockwell",
-          "Wanja Mues"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Summer Hopkins",
-          "Regina Lemnitz"
-        ],
-        [
-          "Brooks, Galerist",
-          "Martin May"
-        ],
-        [
-          "Mr. Elroy Follister",
-          "Stephan Schwartz"
-        ],
-        [
-          "Martha",
-          "Hanna Reisch"
-        ],
-        [
-          "Dillon",
-          "Gregor Reisch"
-        ],
-        [
-          "Wayne",
-          "Woody Mues"
-        ],
-        [
-          "Gefängniswärter",
-          "Gosta Liptow"
-        ],
-        [
-          "Wirt",
-          "Klaus Dittmann"
-        ],
-        [
-          "Greis",
-          "Jürgen Thormann"
-        ],
-        [
-          "Beamter",
-          "Monty Arnold"
-        ],
-        [
-          "Taxifahrer",
-          "Harald Dietl"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Laurence Seinfeld",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Denzel Hopkins",
+          "sprecher" : "Tilo Schmitz"
+        },
+        {
+          "rolle" : "Goldie Hopkins",
+          "sprecher" : "Madeleine Weingart"
+        },
+        {
+          "rolle" : "Neil Rockwell",
+          "sprecher" : "Wanja Mues"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Summer Hopkins",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Brooks, Galerist",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Mr. Elroy Follister",
+          "sprecher" : "Stephan Schwartz"
+        },
+        {
+          "rolle" : "Martha",
+          "sprecher" : "Hanna Reisch"
+        },
+        {
+          "rolle" : "Dillon",
+          "sprecher" : "Gregor Reisch"
+        },
+        {
+          "rolle" : "Wayne",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Gefängniswärter",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Wirt",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Greis",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Beamter",
+          "sprecher" : "Monty Arnold"
+        },
+        {
+          "rolle" : "Taxifahrer",
+          "sprecher" : "Harald Dietl"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/151/metadata.json",
@@ -18773,83 +18869,83 @@
           "end" : 3374867
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Bert Young",
-          "Horst Stark"
-        ],
-        [
-          "Mrs. Johnson",
-          "Gabriele Libbach"
-        ],
-        [
-          "Chapman",
-          "Sascha Rotermund"
-        ],
-        [
-          "Tony",
-          "Reent Reins"
-        ],
-        [
-          "Blake",
-          "Wolfgang Rositzka"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Rubbish George",
-          "Utz Richter"
-        ],
-        [
-          "Mann 1",
-          "Rasmus Borowski"
-        ],
-        [
-          "Mann 2",
-          "Joachim Kappl"
-        ],
-        [
-          "Verkäufer",
-          "Marcus Schönhoff"
-        ],
-        [
-          "Sunny",
-          "Rainer Schmitt"
-        ],
-        [
-          "Fernsehe-Sprecher",
-          "Jannik Schümann"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ],
-        [
-          "Francesco",
-          "Anton Sprick"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Bert Young",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Mrs. Johnson",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Chapman",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Reent Reins"
+        },
+        {
+          "rolle" : "Blake",
+          "sprecher" : "Wolfgang Rositzka"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Joachim Kappl"
+        },
+        {
+          "rolle" : "Verkäufer",
+          "sprecher" : "Marcus Schönhoff"
+        },
+        {
+          "rolle" : "Sunny",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Fernsehe-Sprecher",
+          "sprecher" : "Jannik Schümann"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Francesco",
+          "sprecher" : "Anton Sprick"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/152/metadata.json",
@@ -18924,79 +19020,79 @@
           "end" : 3243960
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sean O'Donnell",
-          "Till Demtrøder"
-        ],
-        [
-          "Alexander Chilton",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Mann im Stadion",
-          "Eric Förster"
-        ],
-        [
-          "Ordner",
-          "Matthias Treder"
-        ],
-        [
-          "Frau im Police Department",
-          "Corinna Wodrich"
-        ],
-        [
-          "Mrs. Gardiner",
-          "Elisa Linnemann"
-        ],
-        [
-          "Sekretärin",
-          "Susan Jarling"
-        ],
-        [
-          "Inspektor Craig",
-          "Gustav-Adolph Artz"
-        ],
-        [
-          "Tom Chilton",
-          "Christopher Arndt"
-        ],
-        [
-          "Junger Mann auf der Pier",
-          "Christian Senger"
-        ],
-        [
-          "Junge im Stadion",
-          "Johann Gutjahr"
-        ],
-        [
-          "Live-Kommentator",
-          "Ulrich Potofski"
-        ],
-        [
-          "Ansager",
-          "Frank Wintjen"
-        ],
-        [
-          "Frau auf dem Pier",
-          "Katinka Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sean O'Donnell",
+          "sprecher" : "Till Demtrøder"
+        },
+        {
+          "rolle" : "Alexander Chilton",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Mann im Stadion",
+          "sprecher" : "Eric Förster"
+        },
+        {
+          "rolle" : "Ordner",
+          "sprecher" : "Matthias Treder"
+        },
+        {
+          "rolle" : "Frau im Police Department",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Mrs. Gardiner",
+          "sprecher" : "Elisa Linnemann"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Inspektor Craig",
+          "sprecher" : "Gustav-Adolph Artz"
+        },
+        {
+          "rolle" : "Tom Chilton",
+          "sprecher" : "Christopher Arndt"
+        },
+        {
+          "rolle" : "Junger Mann auf der Pier",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Junge im Stadion",
+          "sprecher" : "Johann Gutjahr"
+        },
+        {
+          "rolle" : "Live-Kommentator",
+          "sprecher" : "Ulrich Potofski"
+        },
+        {
+          "rolle" : "Ansager",
+          "sprecher" : "Frank Wintjen"
+        },
+        {
+          "rolle" : "Frau auf dem Pier",
+          "sprecher" : "Katinka Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/153/metadata.json",
@@ -19081,95 +19177,96 @@
           "end" : 4238587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Prof. Jane Heathcliff",
-          "Victoria Trauttmansdorff"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mr. Grey",
-          "Urs Affolter"
-        ],
-        [
-          "Lester Price",
-          "Fabian Harloff"
-        ],
-        [
-          "Cinelly",
-          "Bernd Stephan"
-        ],
-        [
-          "Mr. Monroe",
-          "Achim Schülke"
-        ],
-        [
-          "Miss Deborah Cassidy",
-          "Barbara Focke"
-        ],
-        [
-          "Mr. Burke",
-          "Kai Henrik Möller"
-        ],
-        [
-          "Miss Trimble",
-          "Christine Pappert"
-        ],
-        [
-          "Mr. Weston",
-          "Joachim Lautenbach"
-        ],
-        [
-          "Nachbarin",
-          "Doris Maria Kaiser"
-        ],
-        [
-          "Butler",
-          "Erik Schäffler"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Michael Kowalski",
-          "Tobias Schmidt"
-        ],
-        [
-          "Jack",
-          "Leonhard Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Prof. Jane Heathcliff",
+          "sprecher" : "Victoria Trauttmansdorff"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mr. Grey",
+          "sprecher" : "Urs Affolter"
+        },
+        {
+          "rolle" : "Lester Price",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Cinelly",
+          "sprecher" : "Bernd Stephan"
+        },
+        {
+          "rolle" : "Mr. Monroe",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Miss Deborah Cassidy",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Mr. Burke",
+          "sprecher" : "Kai Henrik Möller"
+        },
+        {
+          "rolle" : "Miss Trimble",
+          "sprecher" : "Christine Pappert"
+        },
+        {
+          "rolle" : "Mr. Weston",
+          "sprecher" : "Joachim Lautenbach"
+        },
+        {
+          "rolle" : "Nachbarin",
+          "sprecher" : "Doris Maria Kaiser"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Michael Kowalski",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Leonhard Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/154/metadata.json",
@@ -19269,63 +19366,63 @@
           "end" : 4055280
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Zack Martin",
-          "Christian Stark"
-        ],
-        [
-          "Mary-Ann Leigh",
-          "Manuela Eifrig"
-        ],
-        [
-          "Latona Johnson",
-          "Julia Hummer"
-        ],
-        [
-          "Frank Norman",
-          "Till Huster"
-        ],
-        [
-          "Mrs. Robinson",
-          "Heidi Berndt"
-        ],
-        [
-          "Angela Sciutto",
-          "Gisela Fritsch"
-        ],
-        [
-          "Federico Sciutto",
-          "Rainer Fritzsche"
-        ],
-        [
-          "Mr. Torrance",
-          "Ingo Feder"
-        ],
-        [
-          "Frau",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Kind",
-          "Undine Ullmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Zack Martin",
+          "sprecher" : "Christian Stark"
+        },
+        {
+          "rolle" : "Mary-Ann Leigh",
+          "sprecher" : "Manuela Eifrig"
+        },
+        {
+          "rolle" : "Latona Johnson",
+          "sprecher" : "Julia Hummer"
+        },
+        {
+          "rolle" : "Frank Norman",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Mrs. Robinson",
+          "sprecher" : "Heidi Berndt"
+        },
+        {
+          "rolle" : "Angela Sciutto",
+          "sprecher" : "Gisela Fritsch"
+        },
+        {
+          "rolle" : "Federico Sciutto",
+          "sprecher" : "Rainer Fritzsche"
+        },
+        {
+          "rolle" : "Mr. Torrance",
+          "sprecher" : "Ingo Feder"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Kind",
+          "sprecher" : "Undine Ullmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/155/metadata.json",
@@ -19420,63 +19517,63 @@
           "end" : 4331240
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ryan Holbrooke",
-          "Manfred Reddemann"
-        ],
-        [
-          "Sheriff Pickett",
-          "Gerhart Hinze"
-        ],
-        [
-          "Stephen Baron",
-          "Patrick Elias"
-        ],
-        [
-          "Zyklon",
-          "Wolfgang Berger"
-        ],
-        [
-          "Al Dahab",
-          "Neil Malik Abdullah"
-        ],
-        [
-          "Frau",
-          "Regine Lamster"
-        ],
-        [
-          "Matthew",
-          "Mike Olsowski"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Zabriski",
-          "Volker Bogdan"
-        ],
-        [
-          "Fred",
-          "Oliver Mink"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ryan Holbrooke",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Sheriff Pickett",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Stephen Baron",
+          "sprecher" : "Patrick Elias"
+        },
+        {
+          "rolle" : "Zyklon",
+          "sprecher" : "Wolfgang Berger"
+        },
+        {
+          "rolle" : "Al Dahab",
+          "sprecher" : "Neil Malik Abdullah"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Regine Lamster"
+        },
+        {
+          "rolle" : "Matthew",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Zabriski",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Fred",
+          "sprecher" : "Oliver Mink"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/156/metadata.json",
@@ -19556,63 +19653,64 @@
           "end" : 4461093
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Riese",
-          "Tilo Schmitz"
-        ],
-        [
-          "Hunnicutt",
-          "Heinz Lieven"
-        ],
-        [
-          "Sheila",
-          "Melanie Pukaß"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Felicity",
-          "Kari Erlhoff"
-        ],
-        [
-          "Chester",
-          "Mike Olsowski"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Gizmo",
-          "Michael von Rospatt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Riese",
+          "sprecher" : "Tilo Schmitz"
+        },
+        {
+          "rolle" : "Hunnicutt",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Sheila",
+          "sprecher" : "Melanie Pukaß"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Felicity",
+          "sprecher" : "Kari Erlhoff"
+        },
+        {
+          "rolle" : "Chester",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Gizmo",
+          "sprecher" : "Michael von Rospatt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/157/metadata.json",
@@ -19697,75 +19795,75 @@
           "end" : 3396520
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Michelle",
-          "Ulrike Stürzbecher"
-        ],
-        [
-          "Ronald Pounder",
-          "Jürgen Kluckert"
-        ],
-        [
-          "Maurice Blight",
-          "Oliver Böttcher"
-        ],
-        [
-          "Betsy",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Isabella",
-          "Isabel Navarro"
-        ],
-        [
-          "Vladas Abakulow",
-          "Erik Schäffler"
-        ],
-        [
-          "Moody Firthway",
-          "Peter Striebeck"
-        ],
-        [
-          "Polizist",
-          "Mike Olsowski"
-        ],
-        [
-          "Jenna",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Mann 1",
-          "Olaf Kreutzenbeck"
-        ],
-        [
-          "Mann 2",
-          "Rainer Fritzsche"
-        ],
-        [
-          "Mann 3",
-          "Claus Fuchs"
-        ],
-        [
-          "Mann 4",
-          "Jannik Endemann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Michelle",
+          "sprecher" : "Ulrike Stürzbecher"
+        },
+        {
+          "rolle" : "Ronald Pounder",
+          "sprecher" : "Jürgen Kluckert"
+        },
+        {
+          "rolle" : "Maurice Blight",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Betsy",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Isabella",
+          "sprecher" : "Isabel Navarro"
+        },
+        {
+          "rolle" : "Vladas Abakulow",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Moody Firthway",
+          "sprecher" : "Peter Striebeck"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Jenna",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Olaf Kreutzenbeck"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Rainer Fritzsche"
+        },
+        {
+          "rolle" : "Mann 3",
+          "sprecher" : "Claus Fuchs"
+        },
+        {
+          "rolle" : "Mann 4",
+          "sprecher" : "Jannik Endemann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/158/metadata.json",
@@ -19840,55 +19938,56 @@
           "end" : 3931427
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Caroline Cotta",
-          "Micaëla Kreißler"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Sergeant Donatelli",
-          "Peter Weis"
-        ],
-        [
-          "Mann 1",
-          "Robin Brosch"
-        ],
-        [
-          "Mann 2",
-          "Gerhart Hinze"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Caroline Cotta",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Sergeant Donatelli",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Gerhart Hinze"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/159/metadata.json",
@@ -19953,67 +20052,67 @@
           "end" : 3820387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Barbara",
-          "Tanja Geke"
-        ],
-        [
-          "Professor Mathewson",
-          "Stephan Schwartz"
-        ],
-        [
-          "Arthur",
-          "Stephan Benson"
-        ],
-        [
-          "Alan Jones",
-          "Wolfgang Pampel"
-        ],
-        [
-          "Shu Liin",
-          "Monika Freisfeld-Pampel"
-        ],
-        [
-          "Kellner",
-          "Sven Dahlem"
-        ],
-        [
-          "Frank",
-          "Simon Jäger"
-        ],
-        [
-          "Stadtverwalter",
-          "Achim Schülke"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Feuerschlucker",
-          "Bertram Hiese"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Barbara",
+          "sprecher" : "Tanja Geke"
+        },
+        {
+          "rolle" : "Professor Mathewson",
+          "sprecher" : "Stephan Schwartz"
+        },
+        {
+          "rolle" : "Arthur",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Alan Jones",
+          "sprecher" : "Wolfgang Pampel"
+        },
+        {
+          "rolle" : "Shu Liin",
+          "sprecher" : "Monika Freisfeld-Pampel"
+        },
+        {
+          "rolle" : "Kellner",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Frank",
+          "sprecher" : "Simon Jäger"
+        },
+        {
+          "rolle" : "Stadtverwalter",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Feuerschlucker",
+          "sprecher" : "Bertram Hiese"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/160/metadata.json",
@@ -20103,63 +20202,63 @@
           "end" : 4238493
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Greenwalt",
-          "Harald Dietl"
-        ],
-        [
-          "Brock",
-          "Guido A. Schick"
-        ],
-        [
-          "Deforge",
-          "Bruno F. Apitz"
-        ],
-        [
-          "Mrs. Kretchmer",
-          "Monika Werner"
-        ],
-        [
-          "Mrs. Espenson",
-          "Karin Eckhold"
-        ],
-        [
-          "Mrs. Wondratschek",
-          "Ela Nitzsche"
-        ],
-        [
-          "Mrs. Field",
-          "Celine Fontanges"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Harris",
-          "Lutz Harder"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Greenwalt",
+          "sprecher" : "Harald Dietl"
+        },
+        {
+          "rolle" : "Brock",
+          "sprecher" : "Guido A. Schick"
+        },
+        {
+          "rolle" : "Deforge",
+          "sprecher" : "Bruno F. Apitz"
+        },
+        {
+          "rolle" : "Mrs. Kretchmer",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Mrs. Espenson",
+          "sprecher" : "Karin Eckhold"
+        },
+        {
+          "rolle" : "Mrs. Wondratschek",
+          "sprecher" : "Ela Nitzsche"
+        },
+        {
+          "rolle" : "Mrs. Field",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Harris",
+          "sprecher" : "Lutz Harder"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/161/metadata.json",
@@ -20234,59 +20333,59 @@
           "end" : 4365707
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Prof. Arnold Brewster",
-          "Horst Naumann"
-        ],
-        [
-          "Miss Daggett",
-          "Ingeborg Christiansen"
-        ],
-        [
-          "Hold",
-          "Christian Rode"
-        ],
-        [
-          "Hank Tornby",
-          "Edgar Hoppe"
-        ],
-        [
-          "Mike Cobble",
-          "Gordon Piedesack"
-        ],
-        [
-          "Martin Ishniak",
-          "Erkki Hopf"
-        ],
-        [
-          "Samuel Cobble",
-          "Eckart Dux"
-        ],
-        [
-          "William Prescott",
-          "Eberhard Haar"
-        ],
-        [
-          "Jim Sesto",
-          "Gustav-Adolph Artz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Prof. Arnold Brewster",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Miss Daggett",
+          "sprecher" : "Ingeborg Christiansen"
+        },
+        {
+          "rolle" : "Hold",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Hank Tornby",
+          "sprecher" : "Edgar Hoppe"
+        },
+        {
+          "rolle" : "Mike Cobble",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Martin Ishniak",
+          "sprecher" : "Erkki Hopf"
+        },
+        {
+          "rolle" : "Samuel Cobble",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "William Prescott",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Jim Sesto",
+          "sprecher" : "Gustav-Adolph Artz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/162/metadata.json",
@@ -20361,31 +20460,31 @@
           "end" : 4468413
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Fynch",
-          "Stephan Benson"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Fynch",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/163/metadata.json",
@@ -20455,63 +20554,65 @@
           "end" : 4125760
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Lenni",
-          "Tim Kreuer"
-        ],
-        [
-          "John Greyfox",
-          "Douglas Welbat"
-        ],
-        [
-          "Clay Carson",
-          "Krystian Martinek"
-        ],
-        [
-          "Walter",
-          "Achim Schülke"
-        ],
-        [
-          "Freddy Hays",
-          "Bruno F. Apitz"
-        ],
-        [
-          "Trainer",
-          "Woody Mues"
-        ],
-        [
-          "Mann",
-          "Wolfram Winfried [Wolfram Damerius]"
-        ],
-        [
-          "Junge",
-          "Francesco Nieheim [Frank Boldewin]"
-        ],
-        [
-          "Spieler",
-          "Carsten Kausse"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Lenni",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "John Greyfox",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Clay Carson",
+          "sprecher" : "Krystian Martinek"
+        },
+        {
+          "rolle" : "Walter",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Freddy Hays",
+          "sprecher" : "Bruno F. Apitz"
+        },
+        {
+          "rolle" : "Trainer",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Wolfram Damerius",
+          "pseudonym" : "Wolfram Winfried"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Frank Boldewin",
+          "pseudonym" : "Francesco Nieheim"
+        },
+        {
+          "rolle" : "Spieler",
+          "sprecher" : "Carsten Kausse"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/164/metadata.json",
@@ -20586,67 +20687,67 @@
           "end" : 4217360
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Randy",
-          "Marek Harloff"
-        ],
-        [
-          "Jeanne",
-          "Katja Brügger"
-        ],
-        [
-          "Ginette",
-          "Birte Kretschmer"
-        ],
-        [
-          "Tara",
-          "Angela Roy"
-        ],
-        [
-          "Steven",
-          "Robert Steudtner"
-        ],
-        [
-          "Ranger Thornton",
-          "Detlef Bierstedt"
-        ],
-        [
-          "Mr. Louis",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Busfahrer",
-          "Volker Bogdan"
-        ],
-        [
-          "Lindsey",
-          "Susan Jarling"
-        ],
-        [
-          "Reporter",
-          "Daniel Welbat"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Randy",
+          "sprecher" : "Marek Harloff"
+        },
+        {
+          "rolle" : "Jeanne",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Ginette",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Tara",
+          "sprecher" : "Angela Roy"
+        },
+        {
+          "rolle" : "Steven",
+          "sprecher" : "Robert Steudtner"
+        },
+        {
+          "rolle" : "Ranger Thornton",
+          "sprecher" : "Detlef Bierstedt"
+        },
+        {
+          "rolle" : "Mr. Louis",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Busfahrer",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Lindsey",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Daniel Welbat"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/165/metadata.json",
@@ -20711,43 +20812,43 @@
           "end" : 4063013
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mr. Bennet",
-          "Sven Dahlem"
-        ],
-        [
-          "Mrs. Dearing",
-          "Saskia Weckler"
-        ],
-        [
-          "Conrad Nash",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Frau",
-          "Elga Schütz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mr. Bennet",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Mrs. Dearing",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Conrad Nash",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Elga Schütz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/166/metadata.json",
@@ -20842,83 +20943,84 @@
           "end" : 4324213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Andy Carson",
-          "Stefan Schwade"
-        ],
-        [
-          "Mrs. Hampton",
-          "Celine Fontanges"
-        ],
-        [
-          "Nicky DeLores",
-          "Mogens von Gadow"
-        ],
-        [
-          "Mrs. Woodrow",
-          "Carin Abicht"
-        ],
-        [
-          "Judy Nigel",
-          "Angela Stresemann"
-        ],
-        [
-          "Direktor Grayston",
-          "Jörg Gillner"
-        ],
-        [
-          "Gregory Katic",
-          "Oliver Böttcher"
-        ],
-        [
-          "Mr. Clark",
-          "Stefan Brentle"
-        ],
-        [
-          "Tarzan",
-          "Sascha Draeger"
-        ],
-        [
-          "Mädchen 1",
-          "Julia Fölster"
-        ],
-        [
-          "Mädchen 2",
-          "Saskia Weckler"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Callister",
-          "Ingo Feder"
-        ],
-        [
-          "Lionel Pengrim",
-          "Robert Missler"
-        ],
-        [
-          "Ned",
-          "Bruno Ploeger [Charles Rettinghaus]"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Andy Carson",
+          "sprecher" : "Stefan Schwade"
+        },
+        {
+          "rolle" : "Mrs. Hampton",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Nicky DeLores",
+          "sprecher" : "Mogens von Gadow"
+        },
+        {
+          "rolle" : "Mrs. Woodrow",
+          "sprecher" : "Carin Abicht"
+        },
+        {
+          "rolle" : "Judy Nigel",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Direktor Grayston",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Gregory Katic",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Mr. Clark",
+          "sprecher" : "Stefan Brentle"
+        },
+        {
+          "rolle" : "Tarzan",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Mädchen 1",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Mädchen 2",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Callister",
+          "sprecher" : "Ingo Feder"
+        },
+        {
+          "rolle" : "Lionel Pengrim",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Ned",
+          "sprecher" : "Charles Rettinghaus",
+          "pseudonym" : "Bruno Ploeger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/167/metadata.json",
@@ -20988,83 +21090,83 @@
           "end" : 4675973
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Deborah",
-          "Gabriele Libbach"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Samuel Rodman",
-          "Christian Concilio"
-        ],
-        [
-          "Benjamin Rodman",
-          "Henning Karge"
-        ],
-        [
-          "Vallery Flockheart",
-          "Caroline Kiesewetter"
-        ],
-        [
-          "Nigel Tillerman",
-          "Lutz Mackensy"
-        ],
-        [
-          "Josh Reilly",
-          "Nicholas Müller"
-        ],
-        [
-          "Lexington",
-          "Sascha Eigner"
-        ],
-        [
-          "Reporter",
-          "Rasmus Borowski"
-        ],
-        [
-          "Journalistin",
-          "Nicolá Melissian"
-        ],
-        [
-          "Prescott",
-          "Rolf Becker"
-        ],
-        [
-          "Sergeant Morales",
-          "Peter Weis"
-        ],
-        [
-          "Mr. Arvidson",
-          "Gosta Liptow"
-        ],
-        [
-          "Mrs. Arvidson",
-          "Hedy Haase"
-        ],
-        [
-          "Mann",
-          "Andreas Becker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Deborah",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Samuel Rodman",
+          "sprecher" : "Christian Concilio"
+        },
+        {
+          "rolle" : "Benjamin Rodman",
+          "sprecher" : "Henning Karge"
+        },
+        {
+          "rolle" : "Vallery Flockheart",
+          "sprecher" : "Caroline Kiesewetter"
+        },
+        {
+          "rolle" : "Nigel Tillerman",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Josh Reilly",
+          "sprecher" : "Nicholas Müller"
+        },
+        {
+          "rolle" : "Lexington",
+          "sprecher" : "Sascha Eigner"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Journalistin",
+          "sprecher" : "Nicolá Melissian"
+        },
+        {
+          "rolle" : "Prescott",
+          "sprecher" : "Rolf Becker"
+        },
+        {
+          "rolle" : "Sergeant Morales",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Mr. Arvidson",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Mrs. Arvidson",
+          "sprecher" : "Hedy Haase"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Andreas Becker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/168/metadata.json",
@@ -21134,71 +21236,72 @@
           "end" : 4910587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Bradley",
-          "Nicolas König"
-        ],
-        [
-          "Bishop Blake",
-          "Wolf Frass"
-        ],
-        [
-          "Junge Frau",
-          "Heikedine Körting"
-        ],
-        [
-          "Derek",
-          "Tim Helssen"
-        ],
-        [
-          "Mrs. Kretschmer",
-          "Monika Werner"
-        ],
-        [
-          "Chastity",
-          "Undine Ullmer"
-        ],
-        [
-          "Charity",
-          "Kassandra Ullmer"
-        ],
-        [
-          "Sam Chiccarelli",
-          "Astrid Kollex"
-        ],
-        [
-          "Griffin Silverman",
-          "Stephan Schad"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Bradley",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Bishop Blake",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Junge Frau",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Derek",
+          "sprecher" : "Tim Helssen"
+        },
+        {
+          "rolle" : "Mrs. Kretschmer",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Chastity",
+          "sprecher" : "Undine Ullmer"
+        },
+        {
+          "rolle" : "Charity",
+          "sprecher" : "Kassandra Ullmer"
+        },
+        {
+          "rolle" : "Sam Chiccarelli",
+          "sprecher" : "Astrid Kollex"
+        },
+        {
+          "rolle" : "Griffin Silverman",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/169/metadata.json",
@@ -21273,87 +21376,87 @@
           "end" : 4816533
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mitch Palmer",
-          "Michael Lott"
-        ],
-        [
-          "Dimitri",
-          "Manou Lubowski"
-        ],
-        [
-          "Roy",
-          "Gosta Liptow"
-        ],
-        [
-          "Boss",
-          "Henry König"
-        ],
-        [
-          "Cindy",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Mike",
-          "Oliver Böttcher"
-        ],
-        [
-          "Wirt",
-          "Peter Lakenmacher"
-        ],
-        [
-          "Rockford",
-          "Christian Senger"
-        ],
-        [
-          "Casino-Besucher",
-          "Robin Brosch"
-        ],
-        [
-          "Casino-Besucherin",
-          "Brigitte Böttrich"
-        ],
-        [
-          "Rezeption 1",
-          "Dorothea Lott"
-        ],
-        [
-          "Rezeption 2",
-          "Marco Spina"
-        ],
-        [
-          "Fernfahrer",
-          "Tilman Madaus"
-        ],
-        [
-          "Putzfrau",
-          "Maria Baptista"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mitch Palmer",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Dimitri",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Roy",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Boss",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Cindy",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Mike",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Wirt",
+          "sprecher" : "Peter Lakenmacher"
+        },
+        {
+          "rolle" : "Rockford",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Casino-Besucher",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Casino-Besucherin",
+          "sprecher" : "Brigitte Böttrich"
+        },
+        {
+          "rolle" : "Rezeption 1",
+          "sprecher" : "Dorothea Lott"
+        },
+        {
+          "rolle" : "Rezeption 2",
+          "sprecher" : "Marco Spina"
+        },
+        {
+          "rolle" : "Fernfahrer",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Putzfrau",
+          "sprecher" : "Maria Baptista"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/170/metadata.json",
@@ -21423,91 +21526,91 @@
           "end" : 4040853
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Harry Salas",
-          "Pat Murphy"
-        ],
-        [
-          "Vanessa Goodstein",
-          "Simone Ritscher"
-        ],
-        [
-          "Eliah Cristobal",
-          "Stephan Schwartz"
-        ],
-        [
-          "Albert Goodstein",
-          "Manfred Reddemann"
-        ],
-        [
-          "Ben Kramer",
-          "Jan-Christof Kick"
-        ],
-        [
-          "Fiona Kramer",
-          "Lilian Körting"
-        ],
-        [
-          "Wirt",
-          "Harald Halgardt"
-        ],
-        [
-          "Jimmy Blue Eye",
-          "Ulrich Potofski"
-        ],
-        [
-          "Mann 1",
-          "Achim Schülke"
-        ],
-        [
-          "Mann 2",
-          "Fabian Harloff"
-        ],
-        [
-          "Frau",
-          "Saskia Weckler"
-        ],
-        [
-          "Rosaria",
-          "Gela del Este"
-        ],
-        [
-          "Silvie",
-          "Katharina von Keller"
-        ],
-        [
-          "Jessy",
-          "Manuela Eifrig"
-        ],
-        [
-          "Sergeant",
-          "Alexander Stamm"
-        ],
-        [
-          "Polizist",
-          "Gordon Piedesack"
-        ],
-        [
-          "Rikuo Yamamoto",
-          "Toru Takahashi"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Harry Salas",
+          "sprecher" : "Pat Murphy"
+        },
+        {
+          "rolle" : "Vanessa Goodstein",
+          "sprecher" : "Simone Ritscher"
+        },
+        {
+          "rolle" : "Eliah Cristobal",
+          "sprecher" : "Stephan Schwartz"
+        },
+        {
+          "rolle" : "Albert Goodstein",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Ben Kramer",
+          "sprecher" : "Jan-Christof Kick"
+        },
+        {
+          "rolle" : "Fiona Kramer",
+          "sprecher" : "Lilian Körting"
+        },
+        {
+          "rolle" : "Wirt",
+          "sprecher" : "Harald Halgardt"
+        },
+        {
+          "rolle" : "Jimmy Blue Eye",
+          "sprecher" : "Ulrich Potofski"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Rosaria",
+          "sprecher" : "Gela del Este"
+        },
+        {
+          "rolle" : "Silvie",
+          "sprecher" : "Katharina von Keller"
+        },
+        {
+          "rolle" : "Jessy",
+          "sprecher" : "Manuela Eifrig"
+        },
+        {
+          "rolle" : "Sergeant",
+          "sprecher" : "Alexander Stamm"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Rikuo Yamamoto",
+          "sprecher" : "Toru Takahashi"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/171/metadata.json",
@@ -21582,63 +21685,63 @@
           "end" : 4375213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Drago Martinez",
-          "Konstantin Graudus"
-        ],
-        [
-          "Fred Osborne",
-          "Erik Schäffler"
-        ],
-        [
-          "Cecile Jezero",
-          "Sandra Quadflieg"
-        ],
-        [
-          "Deborah",
-          "Kornelia Lüdorff"
-        ],
-        [
-          "Short",
-          "Manfred Liptow"
-        ],
-        [
-          "Anthony",
-          "Lutz Harder"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Heavy Metal",
-          "Iris Rufner"
-        ],
-        [
-          "Arthur Pepper",
-          "Frank Thannhäuser"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Drago Martinez",
+          "sprecher" : "Konstantin Graudus"
+        },
+        {
+          "rolle" : "Fred Osborne",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Cecile Jezero",
+          "sprecher" : "Sandra Quadflieg"
+        },
+        {
+          "rolle" : "Deborah",
+          "sprecher" : "Kornelia Lüdorff"
+        },
+        {
+          "rolle" : "Short",
+          "sprecher" : "Manfred Liptow"
+        },
+        {
+          "rolle" : "Anthony",
+          "sprecher" : "Lutz Harder"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Heavy Metal",
+          "sprecher" : "Iris Rufner"
+        },
+        {
+          "rolle" : "Arthur Pepper",
+          "sprecher" : "Frank Thannhäuser"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/172/metadata.json",
@@ -21708,59 +21811,59 @@
           "end" : 4225213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Rupert",
-          "Udo Schenk"
-        ],
-        [
-          "Luke",
-          "Daniel Kirchberger"
-        ],
-        [
-          "Gwendolyn Pembroke",
-          "Aranka Jaenke-Mamero"
-        ],
-        [
-          "Lance Vaughn",
-          "Rainer Schmitt"
-        ],
-        [
-          "'The Destroyer'",
-          "Stephan Schad"
-        ],
-        [
-          "Darby Farnham",
-          "Christine Jensen"
-        ],
-        [
-          "Earl Forrester",
-          "Tobias Schmidt"
-        ],
-        [
-          "Alvin Cray",
-          "Michael Bideller"
-        ],
-        [
-          "Mr. Lloyd",
-          "Lutz Mackensy"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Rupert",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Luke",
+          "sprecher" : "Daniel Kirchberger"
+        },
+        {
+          "rolle" : "Gwendolyn Pembroke",
+          "sprecher" : "Aranka Jaenke-Mamero"
+        },
+        {
+          "rolle" : "Lance Vaughn",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "'The Destroyer'",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Darby Farnham",
+          "sprecher" : "Christine Jensen"
+        },
+        {
+          "rolle" : "Earl Forrester",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Alvin Cray",
+          "sprecher" : "Michael Bideller"
+        },
+        {
+          "rolle" : "Mr. Lloyd",
+          "sprecher" : "Lutz Mackensy"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/173/metadata.json",
@@ -21825,55 +21928,55 @@
           "end" : 3800827
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Guillermo",
-          "Mario Ramos"
-        ],
-        [
-          "Stanley Morgan",
-          "Romanus Fuhrmann"
-        ],
-        [
-          "Grace Powell",
-          "Luise Lunow"
-        ],
-        [
-          "Angus",
-          "Till Demtrøder"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Baxter",
-          "Hans Kahlert"
-        ],
-        [
-          "Kranführer",
-          "Klaus Dittmann"
-        ],
-        [
-          "Steve",
-          "Martin Brücker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Guillermo",
+          "sprecher" : "Mario Ramos"
+        },
+        {
+          "rolle" : "Stanley Morgan",
+          "sprecher" : "Romanus Fuhrmann"
+        },
+        {
+          "rolle" : "Grace Powell",
+          "sprecher" : "Luise Lunow"
+        },
+        {
+          "rolle" : "Angus",
+          "sprecher" : "Till Demtrøder"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Baxter",
+          "sprecher" : "Hans Kahlert"
+        },
+        {
+          "rolle" : "Kranführer",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Steve",
+          "sprecher" : "Martin Brücker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/174/metadata.json",
@@ -21955,99 +22058,99 @@
               "end" : 3648933
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Mr. Andrews",
-              "Henry König"
-            ],
-            [
-              "Jeremy Bright",
-              "Stephan Schad"
-            ],
-            [
-              "Taylor-Jackson",
-              "Jona Mues"
-            ],
-            [
-              "Francine Breckenridge",
-              "Elga Schütz"
-            ],
-            [
-              "A.C. Berany",
-              "Hanni Vanhaiden"
-            ],
-            [
-              "Samantha",
-              "Henrike Fehrs"
-            ],
-            [
-              "Corvy",
-              "Karen Suender"
-            ],
-            [
-              "Lemuel Garvine",
-              "Tim Grobe"
-            ],
-            [
-              "Prof. Roalstad",
-              "Jürgen Thormann"
-            ],
-            [
-              "Chris",
-              "Soi Anifantis"
-            ],
-            [
-              "Gamma",
-              "Wolfram Grandezka"
-            ],
-            [
-              "Barfrau",
-              "Theresa Underberg"
-            ],
-            [
-              "John",
-              "Stephan Benson"
-            ],
-            [
-              "Walker",
-              "Rüdiger Schulzki"
-            ],
-            [
-              "Lederhose",
-              "Klaus Krückemeyer"
-            ],
-            [
-              "Polizist 1",
-              "Tim Kreuer"
-            ],
-            [
-              "Polizist 2",
-              "Jesse Grimm"
-            ],
-            [
-              "Telefonstimme",
-              "Wolfgang Völz"
-            ],
-            [
-              "Menge",
-              "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Jeremy Bright",
+              "sprecher" : "Stephan Schad"
+            },
+            {
+              "rolle" : "Taylor-Jackson",
+              "sprecher" : "Jona Mues"
+            },
+            {
+              "rolle" : "Francine Breckenridge",
+              "sprecher" : "Elga Schütz"
+            },
+            {
+              "rolle" : "A.C. Berany",
+              "sprecher" : "Hanni Vanhaiden"
+            },
+            {
+              "rolle" : "Samantha",
+              "sprecher" : "Henrike Fehrs"
+            },
+            {
+              "rolle" : "Corvy",
+              "sprecher" : "Karen Suender"
+            },
+            {
+              "rolle" : "Lemuel Garvine",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Prof. Roalstad",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Chris",
+              "sprecher" : "Soi Anifantis"
+            },
+            {
+              "rolle" : "Gamma",
+              "sprecher" : "Wolfram Grandezka"
+            },
+            {
+              "rolle" : "Barfrau",
+              "sprecher" : "Theresa Underberg"
+            },
+            {
+              "rolle" : "John",
+              "sprecher" : "Stephan Benson"
+            },
+            {
+              "rolle" : "Walker",
+              "sprecher" : "Rüdiger Schulzki"
+            },
+            {
+              "rolle" : "Lederhose",
+              "sprecher" : "Klaus Krückemeyer"
+            },
+            {
+              "rolle" : "Polizist 1",
+              "sprecher" : "Tim Kreuer"
+            },
+            {
+              "rolle" : "Polizist 2",
+              "sprecher" : "Jesse Grimm"
+            },
+            {
+              "rolle" : "Telefonstimme",
+              "sprecher" : "Wolfgang Völz"
+            },
+            {
+              "rolle" : "Menge",
+              "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/1/metadata.json",
@@ -22108,75 +22211,75 @@
               "end" : 3434200
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Taylor-Jackson",
-              "Jona Mues"
-            ],
-            [
-              "Samantha",
-              "Henrike Fehrs"
-            ],
-            [
-              "Jason",
-              "Woody Mues"
-            ],
-            [
-              "Mrs. Roalstad",
-              "Beate Rysopp"
-            ],
-            [
-              "Prof. Roalstad",
-              "Jürgen Thormann"
-            ],
-            [
-              "Corvy",
-              "Karen Suender"
-            ],
-            [
-              "Mrs. Fernandez",
-              "Anja Topf"
-            ],
-            [
-              "Lemuel Garvine",
-              "Tim Grobe"
-            ],
-            [
-              "Emery",
-              "Peter Weis"
-            ],
-            [
-              "Ginger",
-              "Heidi Schaffrath"
-            ],
-            [
-              "Sanitäter",
-              "Franzisko Löwe"
-            ],
-            [
-              "Schwester",
-              "Maike Nagel"
-            ],
-            [
-              "Menge",
-              "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Taylor-Jackson",
+              "sprecher" : "Jona Mues"
+            },
+            {
+              "rolle" : "Samantha",
+              "sprecher" : "Henrike Fehrs"
+            },
+            {
+              "rolle" : "Jason",
+              "sprecher" : "Woody Mues"
+            },
+            {
+              "rolle" : "Mrs. Roalstad",
+              "sprecher" : "Beate Rysopp"
+            },
+            {
+              "rolle" : "Prof. Roalstad",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Corvy",
+              "sprecher" : "Karen Suender"
+            },
+            {
+              "rolle" : "Mrs. Fernandez",
+              "sprecher" : "Anja Topf"
+            },
+            {
+              "rolle" : "Lemuel Garvine",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Emery",
+              "sprecher" : "Peter Weis"
+            },
+            {
+              "rolle" : "Ginger",
+              "sprecher" : "Heidi Schaffrath"
+            },
+            {
+              "rolle" : "Sanitäter",
+              "sprecher" : "Franzisko Löwe"
+            },
+            {
+              "rolle" : "Schwester",
+              "sprecher" : "Maike Nagel"
+            },
+            {
+              "rolle" : "Menge",
+              "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/2/metadata.json",
@@ -22232,67 +22335,67 @@
               "end" : 4166493
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Taylor-Jackson",
-              "Jona Mues"
-            ],
-            [
-              "Jason",
-              "Woody Mues"
-            ],
-            [
-              "Ivy",
-              "Leonie Landa"
-            ],
-            [
-              "Prof. Haynthorb",
-              "Wolfgang Draeger"
-            ],
-            [
-              "Mrs. Fernandez",
-              "Anja Topf"
-            ],
-            [
-              "Samantha",
-              "Henrike Fehrs"
-            ],
-            [
-              "Francine Breckenridge",
-              "Elga Schütz"
-            ],
-            [
-              "Dr. Wilcomb",
-              "Heinz Lieven"
-            ],
-            [
-              "Polizist 3",
-              "Wolfgang Kaven"
-            ],
-            [
-              "Mr. Andrews",
-              "Henry König"
-            ],
-            [
-              "Menge",
-              "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Taylor-Jackson",
+              "sprecher" : "Jona Mues"
+            },
+            {
+              "rolle" : "Jason",
+              "sprecher" : "Woody Mues"
+            },
+            {
+              "rolle" : "Ivy",
+              "sprecher" : "Leonie Landa"
+            },
+            {
+              "rolle" : "Prof. Haynthorb",
+              "sprecher" : "Wolfgang Draeger"
+            },
+            {
+              "rolle" : "Mrs. Fernandez",
+              "sprecher" : "Anja Topf"
+            },
+            {
+              "rolle" : "Samantha",
+              "sprecher" : "Henrike Fehrs"
+            },
+            {
+              "rolle" : "Francine Breckenridge",
+              "sprecher" : "Elga Schütz"
+            },
+            {
+              "rolle" : "Dr. Wilcomb",
+              "sprecher" : "Heinz Lieven"
+            },
+            {
+              "rolle" : "Polizist 3",
+              "sprecher" : "Wolfgang Kaven"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Menge",
+              "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/3/metadata.json",
@@ -22305,143 +22408,143 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Die drei Detektive bekommen eine einmalige Chance: Sie dürfen an der Universität Ruxton für ein paar Wochen das Studentenleben testen! Doch schnell wird klar, dass hier nicht nur Vorlesungen, Partys und Wohnheimzoff auf sie warten, sondern ein neuer Fall!",
       "veröffentlichungsdatum" : "2015-05-15",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Jeremy Bright",
-          "Stephan Schad"
-        ],
-        [
-          "Taylor-Jackson",
-          "Jona Mues"
-        ],
-        [
-          "Francine Breckenridge",
-          "Elga Schütz"
-        ],
-        [
-          "A.C. Berany",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Samantha",
-          "Henrike Fehrs"
-        ],
-        [
-          "Corvy",
-          "Karen Suender"
-        ],
-        [
-          "Lemuel Garvine",
-          "Tim Grobe"
-        ],
-        [
-          "Prof. Roalstad",
-          "Jürgen Thormann"
-        ],
-        [
-          "Chris",
-          "Soi Anifantis"
-        ],
-        [
-          "Gamma",
-          "Wolfram Grandezka"
-        ],
-        [
-          "Barfrau",
-          "Theresa Underberg"
-        ],
-        [
-          "John",
-          "Stephan Benson"
-        ],
-        [
-          "Walker",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Lederhose",
-          "Klaus Krückemeyer"
-        ],
-        [
-          "Polizist 1",
-          "Tim Kreuer"
-        ],
-        [
-          "Polizist 2",
-          "Jesse Grimm"
-        ],
-        [
-          "Telefonstimme",
-          "Wolfgang Völz"
-        ],
-        [
-          "Jason",
-          "Woody Mues"
-        ],
-        [
-          "Mrs. Roalstad",
-          "Beate Rysopp"
-        ],
-        [
-          "Mrs. Fernandez",
-          "Anja Topf"
-        ],
-        [
-          "Emery",
-          "Peter Weis"
-        ],
-        [
-          "Ginger",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Sanitäter",
-          "Franzisko Löwe"
-        ],
-        [
-          "Schwester",
-          "Maike Nagel"
-        ],
-        [
-          "Ivy",
-          "Leonie Landa"
-        ],
-        [
-          "Prof. Haynthorb",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Dr. Wilcomb",
-          "Heinz Lieven"
-        ],
-        [
-          "Polizist 3",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Menge",
-          "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Jeremy Bright",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Taylor-Jackson",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Francine Breckenridge",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "A.C. Berany",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Samantha",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Corvy",
+          "sprecher" : "Karen Suender"
+        },
+        {
+          "rolle" : "Lemuel Garvine",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Prof. Roalstad",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Chris",
+          "sprecher" : "Soi Anifantis"
+        },
+        {
+          "rolle" : "Gamma",
+          "sprecher" : "Wolfram Grandezka"
+        },
+        {
+          "rolle" : "Barfrau",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "John",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Walker",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Lederhose",
+          "sprecher" : "Klaus Krückemeyer"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Telefonstimme",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Jason",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Mrs. Roalstad",
+          "sprecher" : "Beate Rysopp"
+        },
+        {
+          "rolle" : "Mrs. Fernandez",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Emery",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Ginger",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Franzisko Löwe"
+        },
+        {
+          "rolle" : "Schwester",
+          "sprecher" : "Maike Nagel"
+        },
+        {
+          "rolle" : "Ivy",
+          "sprecher" : "Leonie Landa"
+        },
+        {
+          "rolle" : "Prof. Haynthorb",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Dr. Wilcomb",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Polizist 3",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Menge",
+          "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/175/metadata.json",
@@ -22518,59 +22621,59 @@
           "end" : 4064107
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sidney",
-          "Dorothee Sturz"
-        ],
-        [
-          "Tiffany",
-          "Maureen Havlena"
-        ],
-        [
-          "Salma Hutchinson",
-          "Tina Eschmann"
-        ],
-        [
-          "Trevor Pomery",
-          "Ben Hecker"
-        ],
-        [
-          "Beatrice",
-          "Ursula Sieg"
-        ],
-        [
-          "Claire",
-          "Karin Eckhold"
-        ],
-        [
-          "Pflegerin",
-          "Susanne Wulkow"
-        ],
-        [
-          "Roger Wolf",
-          "Stephan Schad"
-        ],
-        [
-          "Menge Fußballstadion",
-          "Die Gäste der Record-Release-Party am 22.02.2015 in Dortmund. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sidney",
+          "sprecher" : "Dorothee Sturz"
+        },
+        {
+          "rolle" : "Tiffany",
+          "sprecher" : "Maureen Havlena"
+        },
+        {
+          "rolle" : "Salma Hutchinson",
+          "sprecher" : "Tina Eschmann"
+        },
+        {
+          "rolle" : "Trevor Pomery",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Beatrice",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Claire",
+          "sprecher" : "Karin Eckhold"
+        },
+        {
+          "rolle" : "Pflegerin",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Roger Wolf",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Menge Fußballstadion",
+          "sprecher" : "Die Gäste der Record-Release-Party am 22.02.2015 in Dortmund. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/176/metadata.json",
@@ -22635,59 +22738,59 @@
           "end" : 4121080
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dusty Kirkpatrick",
-          "Hans Kahlert"
-        ],
-        [
-          "Miranda Kramer",
-          "Susanne Sternberg"
-        ],
-        [
-          "Barclay",
-          "Horst Stark"
-        ],
-        [
-          "Brian",
-          "Volker Hanisch"
-        ],
-        [
-          "Raven",
-          "Neda Rahmanian"
-        ],
-        [
-          "Dr. Hardwick",
-          "Till Huster"
-        ],
-        [
-          "Robert",
-          "Tim Kreuer"
-        ],
-        [
-          "Manolo",
-          "Wolfgang Berger"
-        ],
-        [
-          "Polizist",
-          "Kai Henrik Möller"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dusty Kirkpatrick",
+          "sprecher" : "Hans Kahlert"
+        },
+        {
+          "rolle" : "Miranda Kramer",
+          "sprecher" : "Susanne Sternberg"
+        },
+        {
+          "rolle" : "Barclay",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Brian",
+          "sprecher" : "Volker Hanisch"
+        },
+        {
+          "rolle" : "Raven",
+          "sprecher" : "Neda Rahmanian"
+        },
+        {
+          "rolle" : "Dr. Hardwick",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Robert",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Manolo",
+          "sprecher" : "Wolfgang Berger"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Kai Henrik Möller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/177/metadata.json",
@@ -22752,51 +22855,51 @@
           "end" : 3955933
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Barbara Mathewson",
-          "Tanja Geke"
-        ],
-        [
-          "Zacharias Faring",
-          "Olaf Reichmann"
-        ],
-        [
-          "Malone",
-          "Tilo Schmitz"
-        ],
-        [
-          "Ben Crane",
-          "Christian Rudolf"
-        ],
-        [
-          "Timothy Jackson",
-          "Nicolas König"
-        ],
-        [
-          "Reginald",
-          "Tobias Schmidt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Barbara Mathewson",
+          "sprecher" : "Tanja Geke"
+        },
+        {
+          "rolle" : "Zacharias Faring",
+          "sprecher" : "Olaf Reichmann"
+        },
+        {
+          "rolle" : "Malone",
+          "sprecher" : "Tilo Schmitz"
+        },
+        {
+          "rolle" : "Ben Crane",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Timothy Jackson",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Reginald",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/178/metadata.json",
@@ -22856,71 +22959,71 @@
           "end" : 4297960
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Evander Whiteside",
-          "Claus Wilcke"
-        ],
-        [
-          "Wendy Brown",
-          "Catrin Owerfeldt"
-        ],
-        [
-          "Christopher Barclay",
-          "Martin Paas"
-        ],
-        [
-          "Edgar Bristol",
-          "Sascha Gutzeit"
-        ],
-        [
-          "Carter Godfrey",
-          "Nicolas König"
-        ],
-        [
-          "Chuck Foster",
-          "Heiko Wohlgemuth"
-        ],
-        [
-          "Busfahrer Sam",
-          "Achim Schülke"
-        ],
-        [
-          "Officer Ossietzky",
-          "Romanus Fuhrmann"
-        ],
-        [
-          "Matt",
-          "Mike Olsowski"
-        ],
-        [
-          "Stephen",
-          "Alexander Mettin"
-        ],
-        [
-          "Billy",
-          "Tom Pidde"
-        ],
-        [
-          "Polizist Jerry",
-          "Stefan Weißenburger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Evander Whiteside",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Wendy Brown",
+          "sprecher" : "Catrin Owerfeldt"
+        },
+        {
+          "rolle" : "Christopher Barclay",
+          "sprecher" : "Martin Paas"
+        },
+        {
+          "rolle" : "Edgar Bristol",
+          "sprecher" : "Sascha Gutzeit"
+        },
+        {
+          "rolle" : "Carter Godfrey",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Chuck Foster",
+          "sprecher" : "Heiko Wohlgemuth"
+        },
+        {
+          "rolle" : "Busfahrer Sam",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Officer Ossietzky",
+          "sprecher" : "Romanus Fuhrmann"
+        },
+        {
+          "rolle" : "Matt",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Stephen",
+          "sprecher" : "Alexander Mettin"
+        },
+        {
+          "rolle" : "Billy",
+          "sprecher" : "Tom Pidde"
+        },
+        {
+          "rolle" : "Polizist Jerry",
+          "sprecher" : "Stefan Weißenburger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/179/metadata.json",
@@ -22980,59 +23083,59 @@
           "end" : 4667840
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Michael Rompa",
-          "Mario Ramos"
-        ],
-        [
-          "Afton",
-          "Julia Fölster"
-        ],
-        [
-          "Skinny Norris",
-          "Michael Harck"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Chef",
-          "Erik Schäffler"
-        ],
-        [
-          "Ron",
-          "Gordon Piedesack"
-        ],
-        [
-          "Ansage",
-          "Joachim Langer"
-        ],
-        [
-          "Oma",
-          "Renate Pichler"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Michael Rompa",
+          "sprecher" : "Mario Ramos"
+        },
+        {
+          "rolle" : "Afton",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Chef",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Ron",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Ansage",
+          "sprecher" : "Joachim Langer"
+        },
+        {
+          "rolle" : "Oma",
+          "sprecher" : "Renate Pichler"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/180/metadata.json",
@@ -23092,75 +23195,75 @@
           "end" : 4413560
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Quinn",
-          "Tobias Diakow"
-        ],
-        [
-          "Nightingale",
-          "Jürgen Thormann"
-        ],
-        [
-          "Pablo",
-          "Till Huster"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Thompson",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Mrs. Kato",
-          "Dorothea Hagena"
-        ],
-        [
-          "Sullivan",
-          "Jonas Hartmann"
-        ],
-        [
-          "Angelina",
-          "Norma Draeger"
-        ],
-        [
-          "Joshua",
-          "Hugo Richert"
-        ],
-        [
-          "Junge 1",
-          "Louis Körting"
-        ],
-        [
-          "Junge 2",
-          "Henrik Bichels"
-        ],
-        [
-          "Mädchen",
-          "Lilian Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Quinn",
+          "sprecher" : "Tobias Diakow"
+        },
+        {
+          "rolle" : "Nightingale",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Pablo",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Thompson",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Mrs. Kato",
+          "sprecher" : "Dorothea Hagena"
+        },
+        {
+          "rolle" : "Sullivan",
+          "sprecher" : "Jonas Hartmann"
+        },
+        {
+          "rolle" : "Angelina",
+          "sprecher" : "Norma Draeger"
+        },
+        {
+          "rolle" : "Joshua",
+          "sprecher" : "Hugo Richert"
+        },
+        {
+          "rolle" : "Junge 1",
+          "sprecher" : "Louis Körting"
+        },
+        {
+          "rolle" : "Junge 2",
+          "sprecher" : "Henrik Bichels"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Lilian Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/181/metadata.json",
@@ -23215,99 +23318,99 @@
           "end" : 4546493
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Shaw",
-          "Heikedine Körting"
-        ],
-        [
-          "Randy Carlisle",
-          "Johannes Semm"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Busfahrer",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Polizist",
-          "Christoph Meyer"
-        ],
-        [
-          "Mia",
-          "Elea Richert"
-        ],
-        [
-          "Mrs. Crouch",
-          "Pia Werfel"
-        ],
-        [
-          "Edna Shinefield",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "George",
-          "Gordon Piedesack"
-        ],
-        [
-          "Ronny",
-          "Anton Pleva"
-        ],
-        [
-          "Loreen",
-          "Barbara Schipper"
-        ],
-        [
-          "TV-Moderatorin",
-          "Dagmar Berghoff"
-        ],
-        [
-          "Daphne",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Kiera",
-          "Isabella Grothe"
-        ],
-        [
-          "Luther Litti",
-          "Wolf Frass"
-        ],
-        [
-          "Kyle Caldwell",
-          "Joachim Kretzer"
-        ],
-        [
-          "Hay",
-          "Tobias Diakow"
-        ],
-        [
-          "Junge",
-          "Hugo Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Randy Carlisle",
+          "sprecher" : "Johannes Semm"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Busfahrer",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Christoph Meyer"
+        },
+        {
+          "rolle" : "Mia",
+          "sprecher" : "Elea Richert"
+        },
+        {
+          "rolle" : "Mrs. Crouch",
+          "sprecher" : "Pia Werfel"
+        },
+        {
+          "rolle" : "Edna Shinefield",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Ronny",
+          "sprecher" : "Anton Pleva"
+        },
+        {
+          "rolle" : "Loreen",
+          "sprecher" : "Barbara Schipper"
+        },
+        {
+          "rolle" : "TV-Moderatorin",
+          "sprecher" : "Dagmar Berghoff"
+        },
+        {
+          "rolle" : "Daphne",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Kiera",
+          "sprecher" : "Isabella Grothe"
+        },
+        {
+          "rolle" : "Luther Litti",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Kyle Caldwell",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Hay",
+          "sprecher" : "Tobias Diakow"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Hugo Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/182/metadata.json",
@@ -23367,83 +23470,83 @@
           "end" : 4566333
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Lenny The Rock",
-          "Peter Kirchberger"
-        ],
-        [
-          "Sue Tamara",
-          "Maria Hartmann"
-        ],
-        [
-          "Sax Sandler",
-          "Christian Concilio"
-        ],
-        [
-          "Tim Durnell",
-          "Douglas Welbat"
-        ],
-        [
-          "Ron",
-          "Gosta Liptow"
-        ],
-        [
-          "Keith",
-          "Tobias Schmidt"
-        ],
-        [
-          "Debbie Peterson",
-          "Maud Ackermann"
-        ],
-        [
-          "Frank Wheeler",
-          "Timo Alexander Wenzel"
-        ],
-        [
-          "Joe",
-          "Stefan Brönneke"
-        ],
-        [
-          "Clayton",
-          "Gordon Piedesack"
-        ],
-        [
-          "Kellnerin",
-          "Simona Pahl"
-        ],
-        [
-          "Partygäste",
-          "Die Gäste der Record-Release-Party am 08.05.2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Lenny The Rock",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Sue Tamara",
+          "sprecher" : "Maria Hartmann"
+        },
+        {
+          "rolle" : "Sax Sandler",
+          "sprecher" : "Christian Concilio"
+        },
+        {
+          "rolle" : "Tim Durnell",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Ron",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Keith",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Debbie Peterson",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Frank Wheeler",
+          "sprecher" : "Timo Alexander Wenzel"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Clayton",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Partygäste",
+          "sprecher" : "Die Gäste der Record-Release-Party am 08.05.2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/183/metadata.json",
@@ -23493,79 +23596,79 @@
           "end" : 4139387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jesse",
-          "Jacob Weigert"
-        ],
-        [
-          "Trainer",
-          "Till Huster"
-        ],
-        [
-          "Jaden",
-          "Flemming Draeger"
-        ],
-        [
-          "Joshua",
-          "Louis Körting"
-        ],
-        [
-          "April",
-          "Lilli Körting"
-        ],
-        [
-          "Autumn",
-          "Sabrina Heuer-Diakow"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Charles Morland",
-          "Horst Stark"
-        ],
-        [
-          "Tanika Frost",
-          "Isabella Grothe"
-        ],
-        [
-          "Savannah Frost",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Dennis Frost",
-          "Sascha Oliver Bauer"
-        ],
-        [
-          "Jane Thompson",
-          "Maud Ackermann"
-        ],
-        [
-          "Tyler",
-          "Christian Rudolf"
-        ],
-        [
-          "Gardener",
-          "Christian Concilio"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jesse",
+          "sprecher" : "Jacob Weigert"
+        },
+        {
+          "rolle" : "Trainer",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Jaden",
+          "sprecher" : "Flemming Draeger"
+        },
+        {
+          "rolle" : "Joshua",
+          "sprecher" : "Louis Körting"
+        },
+        {
+          "rolle" : "April",
+          "sprecher" : "Lilli Körting"
+        },
+        {
+          "rolle" : "Autumn",
+          "sprecher" : "Sabrina Heuer-Diakow"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Charles Morland",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Tanika Frost",
+          "sprecher" : "Isabella Grothe"
+        },
+        {
+          "rolle" : "Savannah Frost",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Dennis Frost",
+          "sprecher" : "Sascha Oliver Bauer"
+        },
+        {
+          "rolle" : "Jane Thompson",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Tyler",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Gardener",
+          "sprecher" : "Christian Concilio"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/184/metadata.json",
@@ -23630,71 +23733,71 @@
           "end" : 3685613
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Adam Quinn",
-          "Romanus Fuhrmann"
-        ],
-        [
-          "Mr. Carrington",
-          "Martin May"
-        ],
-        [
-          "Mrs. Carrington",
-          "Manuela Dahm"
-        ],
-        [
-          "Liza Hawkins",
-          "Lucia-Angelina Mahler"
-        ],
-        [
-          "Mr. Hawkins",
-          "Achim Schülke"
-        ],
-        [
-          "Mrs. Hawkins",
-          "Birte Kretschmer"
-        ],
-        [
-          "Leslie Logue-Smith",
-          "Uschi Hugo"
-        ],
-        [
-          "Schauspieler",
-          "Erik Schäffler"
-        ],
-        [
-          "Britney Rogers",
-          "Theresa Berlage"
-        ],
-        [
-          "Sanitäter",
-          "Oliver Böttcher"
-        ],
-        [
-          "Mr. Sisko",
-          "Daniel Welbat"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Adam Quinn",
+          "sprecher" : "Romanus Fuhrmann"
+        },
+        {
+          "rolle" : "Mr. Carrington",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Mrs. Carrington",
+          "sprecher" : "Manuela Dahm"
+        },
+        {
+          "rolle" : "Liza Hawkins",
+          "sprecher" : "Lucia-Angelina Mahler"
+        },
+        {
+          "rolle" : "Mr. Hawkins",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Mrs. Hawkins",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Leslie Logue-Smith",
+          "sprecher" : "Uschi Hugo"
+        },
+        {
+          "rolle" : "Schauspieler",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Britney Rogers",
+          "sprecher" : "Theresa Berlage"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Mr. Sisko",
+          "sprecher" : "Daniel Welbat"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/185/metadata.json",
@@ -23754,71 +23857,71 @@
           "end" : 4356747
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ben Peck",
-          "Wolfgang Völz"
-        ],
-        [
-          "Sandra",
-          "Maureen Havlena"
-        ],
-        [
-          "TV-Nachrichtensprecher",
-          "Holger Wemhoff"
-        ],
-        [
-          "Mr. Castro",
-          "Jürgen Thormann"
-        ],
-        [
-          "Doktor Burke",
-          "Hans Peter Korff"
-        ],
-        [
-          "Mrs. Penny",
-          "Herma Koehn"
-        ],
-        [
-          "Schwester Beatrice",
-          "Roswitha Völz"
-        ],
-        [
-          "Mr. Hooper",
-          "Günther Karl"
-        ],
-        [
-          "Ellyn Djawadi",
-          "Annika Pages"
-        ],
-        [
-          "Mr. Turner",
-          "Klaus Dittmann"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ben Peck",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Sandra",
+          "sprecher" : "Maureen Havlena"
+        },
+        {
+          "rolle" : "TV-Nachrichtensprecher",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Mr. Castro",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Doktor Burke",
+          "sprecher" : "Hans Peter Korff"
+        },
+        {
+          "rolle" : "Mrs. Penny",
+          "sprecher" : "Herma Koehn"
+        },
+        {
+          "rolle" : "Schwester Beatrice",
+          "sprecher" : "Roswitha Völz"
+        },
+        {
+          "rolle" : "Mr. Hooper",
+          "sprecher" : "Günther Karl"
+        },
+        {
+          "rolle" : "Ellyn Djawadi",
+          "sprecher" : "Annika Pages"
+        },
+        {
+          "rolle" : "Mr. Turner",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/186/metadata.json",
@@ -23883,75 +23986,75 @@
           "end" : 4036133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Kramer",
-          "Volker Bogdan"
-        ],
-        [
-          "Emma Bailey",
-          "Hansi Jochmann"
-        ],
-        [
-          "Hank",
-          "Ben Hecker"
-        ],
-        [
-          "Lewis Geriwell",
-          "Frank Gustavus"
-        ],
-        [
-          "Henry Appleton",
-          "Peter Heeckt"
-        ],
-        [
-          "Amber",
-          "Sarah Madeleine Tusk"
-        ],
-        [
-          "Laura",
-          "Maud Ackermann"
-        ],
-        [
-          "Gerald",
-          "Michael von Rospatt"
-        ],
-        [
-          "Nat",
-          "Tobias Schmidt"
-        ],
-        [
-          "Collins",
-          "Gosta Liptow"
-        ],
-        [
-          "Nader Rope",
-          "Michael Bideller"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kramer",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Emma Bailey",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Hank",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Lewis Geriwell",
+          "sprecher" : "Frank Gustavus"
+        },
+        {
+          "rolle" : "Henry Appleton",
+          "sprecher" : "Peter Heeckt"
+        },
+        {
+          "rolle" : "Amber",
+          "sprecher" : "Sarah Madeleine Tusk"
+        },
+        {
+          "rolle" : "Laura",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Gerald",
+          "sprecher" : "Michael von Rospatt"
+        },
+        {
+          "rolle" : "Nat",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Collins",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Nader Rope",
+          "sprecher" : "Michael Bideller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/187/metadata.json",
@@ -24020,71 +24123,71 @@
           "end" : 4807547
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Clarissa Franklin",
-          "Judy Winter"
-        ],
-        [
-          "Laura Stryker",
-          "Regina Lemnitz"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Anruferin",
-          "Topsy Küppers"
-        ],
-        [
-          "Anrufer",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Regisseur",
-          "Nikolas Tantsoukes"
-        ],
-        [
-          "Stephen",
-          "Timo Hempel"
-        ],
-        [
-          "Redakteurin",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Sax Sandler",
-          "Christian Concilio"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Clarissa Franklin",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Laura Stryker",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Anruferin",
+          "sprecher" : "Topsy Küppers"
+        },
+        {
+          "rolle" : "Anrufer",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Regisseur",
+          "sprecher" : "Nikolas Tantsoukes"
+        },
+        {
+          "rolle" : "Stephen",
+          "sprecher" : "Timo Hempel"
+        },
+        {
+          "rolle" : "Redakteurin",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Sax Sandler",
+          "sprecher" : "Christian Concilio"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/188/metadata.json",
@@ -24143,67 +24246,67 @@
           "end" : 3917560
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Whitty",
-          "Claus Wilcke"
-        ],
-        [
-          "Hank",
-          "Robert Missler"
-        ],
-        [
-          "Cowboy Dick",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Mr. Arbuthnott",
-          "Eckart Dux"
-        ],
-        [
-          "Mrs. Lockwood",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Linda",
-          "Svenja Pages"
-        ],
-        [
-          "Roger",
-          "Christian Stark"
-        ],
-        [
-          "Mann",
-          "Gernot Endemann"
-        ],
-        [
-          "Einsatzleiter",
-          "Achim Schülke"
-        ],
-        [
-          "Polizist",
-          "Alexander Mettin"
-        ],
-        [
-          "Mechaniker",
-          "Joachim Kretzer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Whitty",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Hank",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Cowboy Dick",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Mr. Arbuthnott",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Mrs. Lockwood",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Linda",
+          "sprecher" : "Svenja Pages"
+        },
+        {
+          "rolle" : "Roger",
+          "sprecher" : "Christian Stark"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Einsatzleiter",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Alexander Mettin"
+        },
+        {
+          "rolle" : "Mechaniker",
+          "sprecher" : "Joachim Kretzer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/189/metadata.json",
@@ -24252,55 +24355,55 @@
           "end" : 3834400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Jeff Ranaldo",
-          "Till Huster"
-        ],
-        [
-          "Mr. McBrandon",
-          "Rainer Brandt"
-        ],
-        [
-          "Sandy",
-          "Anna Carlsson"
-        ],
-        [
-          "Roboter",
-          "Joachim Kretzer"
-        ],
-        [
-          "Computerstimme",
-          "Hansi Jochmann"
-        ],
-        [
-          "Bruce Torino",
-          "Michael Lott"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Jeff Ranaldo",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Mr. McBrandon",
+          "sprecher" : "Rainer Brandt"
+        },
+        {
+          "rolle" : "Sandy",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Roboter",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Computerstimme",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Bruce Torino",
+          "sprecher" : "Michael Lott"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/190/metadata.json",
@@ -24359,51 +24462,51 @@
           "end" : 4266120
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Priscilla Sicktree",
-          "Marianne Bernhardt"
-        ],
-        [
-          "Hank",
-          "Henry König"
-        ],
-        [
-          "Brian",
-          "Patrick Mölleken"
-        ],
-        [
-          "Ashlyn",
-          "Julia Fölster"
-        ],
-        [
-          "Rosie Wrenwick",
-          "Gerlinde Dillge"
-        ],
-        [
-          "Sheriff Stone",
-          "Horst Stark"
-        ],
-        [
-          "Hilfssheriff Jonathan",
-          "Christian Rudolf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Priscilla Sicktree",
+          "sprecher" : "Marianne Bernhardt"
+        },
+        {
+          "rolle" : "Hank",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Brian",
+          "sprecher" : "Patrick Mölleken"
+        },
+        {
+          "rolle" : "Ashlyn",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Rosie Wrenwick",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Sheriff Stone",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Hilfssheriff Jonathan",
+          "sprecher" : "Christian Rudolf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/191/metadata.json",
@@ -24462,63 +24565,63 @@
           "end" : 4081427
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Zuko",
-          "Kostja Ullmann"
-        ],
-        [
-          "Katara",
-          "Mitsue Kono"
-        ],
-        [
-          "Xiang Than",
-          "Horst Naumann"
-        ],
-        [
-          "Fan Quoc",
-          "Christine Wilhelmi"
-        ],
-        [
-          "Fan Yuen",
-          "Frank Gustavus"
-        ],
-        [
-          "Dealerin",
-          "Barbara Schipper"
-        ],
-        [
-          "Chinese 1",
-          "Frank Richartz"
-        ],
-        [
-          "Chinese 2",
-          "Erik Schäffler"
-        ],
-        [
-          "Fan Hao",
-          "Gerd Baltus"
-        ],
-        [
-          "Einlass",
-          "Matti Schmidt-Schaller"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Zuko",
+          "sprecher" : "Kostja Ullmann"
+        },
+        {
+          "rolle" : "Katara",
+          "sprecher" : "Mitsue Kono"
+        },
+        {
+          "rolle" : "Xiang Than",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Fan Quoc",
+          "sprecher" : "Christine Wilhelmi"
+        },
+        {
+          "rolle" : "Fan Yuen",
+          "sprecher" : "Frank Gustavus"
+        },
+        {
+          "rolle" : "Dealerin",
+          "sprecher" : "Barbara Schipper"
+        },
+        {
+          "rolle" : "Chinese 1",
+          "sprecher" : "Frank Richartz"
+        },
+        {
+          "rolle" : "Chinese 2",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Fan Hao",
+          "sprecher" : "Gerd Baltus"
+        },
+        {
+          "rolle" : "Einlass",
+          "sprecher" : "Matti Schmidt-Schaller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/192/metadata.json",
@@ -24577,83 +24680,83 @@
           "end" : 4183227
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Angler",
-          "Stephan Chrzescinski"
-        ],
-        [
-          "Mac Anderson",
-          "Achim Buch"
-        ],
-        [
-          "Reporterin",
-          "Marion Gretchen Schmitz"
-        ],
-        [
-          "Mann",
-          "Sven Dahlem"
-        ],
-        [
-          "Grady",
-          "Werner Wilkening"
-        ],
-        [
-          "Pettengill",
-          "Peter Kirchberger"
-        ],
-        [
-          "Sheriff Rolins",
-          "Tommi Piper"
-        ],
-        [
-          "Farragut",
-          "Hanns Jörg Krumpholz"
-        ],
-        [
-          "Leah",
-          "Antje Birnbaum"
-        ],
-        [
-          "Cynthia Wetmore",
-          "Dorothea Hagena"
-        ],
-        [
-          "Hotelier",
-          "Gordon Piedesack"
-        ],
-        [
-          "Frau",
-          "Maud Ackermann"
-        ],
-        [
-          "Junge",
-          "Tim Heuer"
-        ],
-        [
-          "Daniel",
-          "Jannik Schümann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Angler",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Mac Anderson",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Reporterin",
+          "sprecher" : "Marion Gretchen Schmitz"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Grady",
+          "sprecher" : "Werner Wilkening"
+        },
+        {
+          "rolle" : "Pettengill",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Sheriff Rolins",
+          "sprecher" : "Tommi Piper"
+        },
+        {
+          "rolle" : "Farragut",
+          "sprecher" : "Hanns Jörg Krumpholz"
+        },
+        {
+          "rolle" : "Leah",
+          "sprecher" : "Antje Birnbaum"
+        },
+        {
+          "rolle" : "Cynthia Wetmore",
+          "sprecher" : "Dorothea Hagena"
+        },
+        {
+          "rolle" : "Hotelier",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Tim Heuer"
+        },
+        {
+          "rolle" : "Daniel",
+          "sprecher" : "Jannik Schümann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/193/metadata.json",
@@ -24712,79 +24815,79 @@
           "end" : 4616840
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Gladys Pixie",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Frank Firhouse",
-          "Lutz Mackensy"
-        ],
-        [
-          "Maggie Smith",
-          "Susanne Wulkow"
-        ],
-        [
-          "Aurora",
-          "Andreja Schneider"
-        ],
-        [
-          "Angela",
-          "Lucia-Angelina Mahler"
-        ],
-        [
-          "Conchita Dominguez",
-          "Katja Brügger"
-        ],
-        [
-          "Reporter",
-          "Jörgpeter Ahlers"
-        ],
-        [
-          "Putzfrau",
-          "Clarissa Börner"
-        ],
-        [
-          "Heather",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Folder",
-          "Harald Weiler"
-        ],
-        [
-          "Hopper",
-          "Achim Schülke"
-        ],
-        [
-          "Rezeptionist",
-          "Christopher Hoseit"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Gladys Pixie",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Frank Firhouse",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Maggie Smith",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Aurora",
+          "sprecher" : "Andreja Schneider"
+        },
+        {
+          "rolle" : "Angela",
+          "sprecher" : "Lucia-Angelina Mahler"
+        },
+        {
+          "rolle" : "Conchita Dominguez",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Jörgpeter Ahlers"
+        },
+        {
+          "rolle" : "Putzfrau",
+          "sprecher" : "Clarissa Börner"
+        },
+        {
+          "rolle" : "Heather",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Folder",
+          "sprecher" : "Harald Weiler"
+        },
+        {
+          "rolle" : "Hopper",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Rezeptionist",
+          "sprecher" : "Christopher Hoseit"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/194/metadata.json",
@@ -24838,55 +24941,55 @@
           "end" : 4503053
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Wally Robertson",
-          "Michael Prelle"
-        ],
-        [
-          "Charmayne Robertson",
-          "Daniela Hoffmann"
-        ],
-        [
-          "Dwaight Hayward",
-          "Gordon Piedesack"
-        ],
-        [
-          "Mrs. Flagstaff",
-          "Sabine Hahn"
-        ],
-        [
-          "Polizist",
-          "Erik Schäffler"
-        ],
-        [
-          "Mann 1",
-          "Ingo Menowski"
-        ],
-        [
-          "Mann 2",
-          "Riko Tauber"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Wally Robertson",
+          "sprecher" : "Michael Prelle"
+        },
+        {
+          "rolle" : "Charmayne Robertson",
+          "sprecher" : "Daniela Hoffmann"
+        },
+        {
+          "rolle" : "Dwaight Hayward",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Mrs. Flagstaff",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Ingo Menowski"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Riko Tauber"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/195/metadata.json",
@@ -24945,59 +25048,59 @@
           "end" : 4728400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Patricia Osborne",
-          "Barbara Focke"
-        ],
-        [
-          "Osiris",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Sunshine",
-          "Dagmar Dreke"
-        ],
-        [
-          "Vandaan",
-          "Andreas Birnbaum"
-        ],
-        [
-          "Frank Corman / Mr Giggles",
-          "Lutz Mackensy"
-        ],
-        [
-          "Trixie Stiles",
-          "Anne Moll"
-        ],
-        [
-          "Bryan Bonfanti",
-          "Frank Roder"
-        ],
-        [
-          "Miller",
-          "Birte Kretschmer"
-        ],
-        [
-          "Henson",
-          "Constantin Stahlberg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Patricia Osborne",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Osiris",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Sunshine",
+          "sprecher" : "Dagmar Dreke"
+        },
+        {
+          "rolle" : "Vandaan",
+          "sprecher" : "Andreas Birnbaum"
+        },
+        {
+          "rolle" : "Frank Corman / Mr Giggles",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Trixie Stiles",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Bryan Bonfanti",
+          "sprecher" : "Frank Roder"
+        },
+        {
+          "rolle" : "Miller",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Henson",
+          "sprecher" : "Constantin Stahlberg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/196/metadata.json",
@@ -25061,83 +25164,84 @@
           "end" : 4190827
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Matthew Kooning",
-          "Tim Kreuer"
-        ],
-        [
-          "Doktor Kooning",
-          "Dietrich Adam"
-        ],
-        [
-          "Mrs. Kooning",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Finnley Stenseth",
-          "Julian Greis"
-        ],
-        [
-          "Farryn Stenseth",
-          "Clarissa Börner"
-        ],
-        [
-          "Mrs. Stenseth",
-          "Herma Koehn"
-        ],
-        [
-          "Stacey Warren",
-          "Katja Brügger"
-        ],
-        [
-          "Brandon",
-          "Stefan Exner"
-        ],
-        [
-          "Surferin",
-          "Simona Pahl"
-        ],
-        [
-          "Surfer",
-          "Tim Knauer"
-        ],
-        [
-          "Dylan",
-          "Sascha Rotermund"
-        ],
-        [
-          "Steven",
-          "Johannes Korff"
-        ],
-        [
-          "M. Keen",
-          "Detlef Tams"
-        ],
-        [
-          "George",
-          "Marcel Saibert"
-        ],
-        [
-          "Mann",
-          "Gunnar Bergmann [Peter Flechtner]"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Matthew Kooning",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Doktor Kooning",
+          "sprecher" : "Dietrich Adam"
+        },
+        {
+          "rolle" : "Mrs. Kooning",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Finnley Stenseth",
+          "sprecher" : "Julian Greis"
+        },
+        {
+          "rolle" : "Farryn Stenseth",
+          "sprecher" : "Clarissa Börner"
+        },
+        {
+          "rolle" : "Mrs. Stenseth",
+          "sprecher" : "Herma Koehn"
+        },
+        {
+          "rolle" : "Stacey Warren",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Brandon",
+          "sprecher" : "Stefan Exner"
+        },
+        {
+          "rolle" : "Surferin",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Surfer",
+          "sprecher" : "Tim Knauer"
+        },
+        {
+          "rolle" : "Dylan",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Steven",
+          "sprecher" : "Johannes Korff"
+        },
+        {
+          "rolle" : "M. Keen",
+          "sprecher" : "Detlef Tams"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Marcel Saibert"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Peter Flechtner",
+          "pseudonym" : "Gunnar Bergmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/197/metadata.json",
@@ -25196,83 +25300,83 @@
           "end" : 4166400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Elliot Littlehorn",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Tobin Muller",
-          "Niko Minninger"
-        ],
-        [
-          "Amalia",
-          "Malin Steffen"
-        ],
-        [
-          "Zauberer Miller",
-          "Julian Horeyseck"
-        ],
-        [
-          "Kelvin Mitchell",
-          "Kai Mertens"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Leigh",
-          "Vivian Brünner"
-        ],
-        [
-          "Mutter",
-          "Tina Eschmann"
-        ],
-        [
-          "Zoey",
-          "Manuela Eifrig"
-        ],
-        [
-          "Mabel",
-          "Nicola Schäffler"
-        ],
-        [
-          "Glatzkopf",
-          "Achim Schülke"
-        ],
-        [
-          "Dustin Cooper",
-          "Claus Fuchs"
-        ],
-        [
-          "Wahrsagerin Susannah",
-          "Mia Diekow"
-        ],
-        [
-          "Dr. Benchfield",
-          "Harald Dietl"
-        ],
-        [
-          "Emily",
-          "Birte Kretschmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Elliot Littlehorn",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Tobin Muller",
+          "sprecher" : "Niko Minninger"
+        },
+        {
+          "rolle" : "Amalia",
+          "sprecher" : "Malin Steffen"
+        },
+        {
+          "rolle" : "Zauberer Miller",
+          "sprecher" : "Julian Horeyseck"
+        },
+        {
+          "rolle" : "Kelvin Mitchell",
+          "sprecher" : "Kai Mertens"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Leigh",
+          "sprecher" : "Vivian Brünner"
+        },
+        {
+          "rolle" : "Mutter",
+          "sprecher" : "Tina Eschmann"
+        },
+        {
+          "rolle" : "Zoey",
+          "sprecher" : "Manuela Eifrig"
+        },
+        {
+          "rolle" : "Mabel",
+          "sprecher" : "Nicola Schäffler"
+        },
+        {
+          "rolle" : "Glatzkopf",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Dustin Cooper",
+          "sprecher" : "Claus Fuchs"
+        },
+        {
+          "rolle" : "Wahrsagerin Susannah",
+          "sprecher" : "Mia Diekow"
+        },
+        {
+          "rolle" : "Dr. Benchfield",
+          "sprecher" : "Harald Dietl"
+        },
+        {
+          "rolle" : "Emily",
+          "sprecher" : "Birte Kretschmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/198/metadata.json",
@@ -25331,59 +25435,59 @@
           "end" : 4506587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Mr. Aaron Grover",
-          "Gernot Endemann"
-        ],
-        [
-          "Msr. Patricia Grover",
-          "Heidi Berndt"
-        ],
-        [
-          "Elodie Grover",
-          "Henrike Fehrs"
-        ],
-        [
-          "Desmond Cathpole",
-          "Martin Brücker"
-        ],
-        [
-          "Hausmeister Spencer",
-          "Werner Cartano"
-        ],
-        [
-          "Mr. Rubberwood",
-          "Udo Schenk"
-        ],
-        [
-          "Mr. Parker Mayfield",
-          "Holger Umbreit"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Mr. Aaron Grover",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Msr. Patricia Grover",
+          "sprecher" : "Heidi Berndt"
+        },
+        {
+          "rolle" : "Elodie Grover",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Desmond Cathpole",
+          "sprecher" : "Martin Brücker"
+        },
+        {
+          "rolle" : "Hausmeister Spencer",
+          "sprecher" : "Werner Cartano"
+        },
+        {
+          "rolle" : "Mr. Rubberwood",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Mr. Parker Mayfield",
+          "sprecher" : "Holger Umbreit"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/199/metadata.json",
@@ -25688,127 +25792,127 @@
           "end" : 17712107
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Off-Sprecher",
-          "Udo Schenk"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Timothy",
-          "Peter Buchholz"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Rubbish George",
-          "Hans Peter Korff"
-        ],
-        [
-          "Vikram",
-          "Michael Deffert"
-        ],
-        [
-          "Bonnie Newman",
-          "Carla Becker"
-        ],
-        [
-          "Mr. August",
-          "Carlo von Tiedemann"
-        ],
-        [
-          "Gus August",
-          "Stephan Chrzescinski"
-        ],
-        [
-          "Helena",
-          "Neda Rahmanian"
-        ],
-        [
-          "Mr. Anderson",
-          "Hubertus Meyer-Burckhardt"
-        ],
-        [
-          "Gabriel White",
-          "Till Hagen"
-        ],
-        [
-          "Solomon Charles",
-          "Jürgen Thormann"
-        ],
-        [
-          "Mr. Dwiggins",
-          "Hanns Jörg Krumpholz"
-        ],
-        [
-          "Mr. Randur",
-          "Eckart Dux"
-        ],
-        [
-          "Beaver",
-          "Peter Franke"
-        ],
-        [
-          "Jariwala",
-          "Till Demtrøder"
-        ],
-        [
-          "Shakrabati",
-          "Sonny Pathak"
-        ],
-        [
-          "Shekinah",
-          "Madeleine Weingart"
-        ],
-        [
-          "Nachtwächter",
-          "Wolfgang Häntsch"
-        ],
-        [
-          "Maria",
-          "Caroline Kiesewetter"
-        ],
-        [
-          "Bruce",
-          "Michael Lott"
-        ],
-        [
-          "Polizist",
-          "Marcel Saibert"
-        ],
-        [
-          "Officer",
-          "Helge Halvé"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Off-Sprecher",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Timothy",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Hans Peter Korff"
+        },
+        {
+          "rolle" : "Vikram",
+          "sprecher" : "Michael Deffert"
+        },
+        {
+          "rolle" : "Bonnie Newman",
+          "sprecher" : "Carla Becker"
+        },
+        {
+          "rolle" : "Mr. August",
+          "sprecher" : "Carlo von Tiedemann"
+        },
+        {
+          "rolle" : "Gus August",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Helena",
+          "sprecher" : "Neda Rahmanian"
+        },
+        {
+          "rolle" : "Mr. Anderson",
+          "sprecher" : "Hubertus Meyer-Burckhardt"
+        },
+        {
+          "rolle" : "Gabriel White",
+          "sprecher" : "Till Hagen"
+        },
+        {
+          "rolle" : "Solomon Charles",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Mr. Dwiggins",
+          "sprecher" : "Hanns Jörg Krumpholz"
+        },
+        {
+          "rolle" : "Mr. Randur",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Beaver",
+          "sprecher" : "Peter Franke"
+        },
+        {
+          "rolle" : "Jariwala",
+          "sprecher" : "Till Demtrøder"
+        },
+        {
+          "rolle" : "Shakrabati",
+          "sprecher" : "Sonny Pathak"
+        },
+        {
+          "rolle" : "Shekinah",
+          "sprecher" : "Madeleine Weingart"
+        },
+        {
+          "rolle" : "Nachtwächter",
+          "sprecher" : "Wolfgang Häntsch"
+        },
+        {
+          "rolle" : "Maria",
+          "sprecher" : "Caroline Kiesewetter"
+        },
+        {
+          "rolle" : "Bruce",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Marcel Saibert"
+        },
+        {
+          "rolle" : "Officer",
+          "sprecher" : "Helge Halvé"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/200/metadata.json",
@@ -25871,59 +25975,59 @@
           "end" : 4703027
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ben Hustler",
-          "Christian Brückner"
-        ],
-        [
-          "Loomy",
-          "Achim Schülke"
-        ],
-        [
-          "Angie",
-          "Angelika Bartsch"
-        ],
-        [
-          "Lesley",
-          "Ann Montenbruck"
-        ],
-        [
-          "Buchhändlerin",
-          "Victoria Fleer"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Andrews",
-          "Heidrun von Goessel"
-        ],
-        [
-          "Kathy",
-          "Celine Fontanges"
-        ],
-        [
-          "Harry",
-          "Woody Mues"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ben Hustler",
+          "sprecher" : "Christian Brückner"
+        },
+        {
+          "rolle" : "Loomy",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Angie",
+          "sprecher" : "Angelika Bartsch"
+        },
+        {
+          "rolle" : "Lesley",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Buchhändlerin",
+          "sprecher" : "Victoria Fleer"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Heidrun von Goessel"
+        },
+        {
+          "rolle" : "Kathy",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Harry",
+          "sprecher" : "Woody Mues"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/201/metadata.json",
@@ -25977,47 +26081,47 @@
           "end" : 4568253
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Laurenne Duffy",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Joe Patwin",
-          "Jürgen Uter"
-        ],
-        [
-          "Trevor Tompson",
-          "Marek Erhardt"
-        ],
-        [
-          "Bruce Osborne",
-          "Martin Paas"
-        ],
-        [
-          "Kelly",
-          "Henrike Fehrs"
-        ],
-        [
-          "Walt Duffy",
-          "Stephan Benson"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Laurenne Duffy",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Joe Patwin",
+          "sprecher" : "Jürgen Uter"
+        },
+        {
+          "rolle" : "Trevor Tompson",
+          "sprecher" : "Marek Erhardt"
+        },
+        {
+          "rolle" : "Bruce Osborne",
+          "sprecher" : "Martin Paas"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Walt Duffy",
+          "sprecher" : "Stephan Benson"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/202/metadata.json",
@@ -26076,47 +26180,47 @@
           "end" : 4610333
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jorunn",
-          "Lilith Gebauer"
-        ],
-        [
-          "Mrs. Planter",
-          "Angela Quast"
-        ],
-        [
-          "Deidre",
-          "Gabriele Libbach"
-        ],
-        [
-          "Special Agent Ross",
-          "Udo Schenk"
-        ],
-        [
-          "Special Agent Wright",
-          "Astrid Kollex"
-        ],
-        [
-          "Fischer",
-          "Peter Franke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jorunn",
+          "sprecher" : "Lilith Gebauer"
+        },
+        {
+          "rolle" : "Mrs. Planter",
+          "sprecher" : "Angela Quast"
+        },
+        {
+          "rolle" : "Deidre",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Special Agent Ross",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Special Agent Wright",
+          "sprecher" : "Astrid Kollex"
+        },
+        {
+          "rolle" : "Fischer",
+          "sprecher" : "Peter Franke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/203/metadata.json",
@@ -26165,51 +26269,51 @@
           "end" : 4144067
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mary",
-          "Marion Gretchen Schmitz"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Potato-Fred",
-          "Peter Weis"
-        ],
-        [
-          "Mr. Pinches",
-          "Jürgen Uter"
-        ],
-        [
-          "Carter Bridou",
-          "Peter G. Dirmeier"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Marion Gretchen Schmitz"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Potato-Fred",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Mr. Pinches",
+          "sprecher" : "Jürgen Uter"
+        },
+        {
+          "rolle" : "Carter Bridou",
+          "sprecher" : "Peter G. Dirmeier"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/204/metadata.json",
@@ -26258,75 +26362,75 @@
           "end" : 4255120
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Trish",
-          "Katrin Decker"
-        ],
-        [
-          "Giovanni",
-          "Stephan Schad"
-        ],
-        [
-          "Rosaly",
-          "Gertie Honeck"
-        ],
-        [
-          "Matteo",
-          "Roman Rossa"
-        ],
-        [
-          "Caroline",
-          "Marianne Bernhardt"
-        ],
-        [
-          "Butler",
-          "Ivo Möller"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Charles Stapleton",
-          "Romanus Fuhrmann"
-        ],
-        [
-          "Direktor Greenwalt",
-          "Jürgen Uter"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Angestellter",
-          "Oliver Böttcher"
-        ],
-        [
-          "Polizist",
-          "Carlo von Tiedemann"
-        ],
-        [
-          "Papagei",
-          "Merete Brettschneider"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Trish",
+          "sprecher" : "Katrin Decker"
+        },
+        {
+          "rolle" : "Giovanni",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Rosaly",
+          "sprecher" : "Gertie Honeck"
+        },
+        {
+          "rolle" : "Matteo",
+          "sprecher" : "Roman Rossa"
+        },
+        {
+          "rolle" : "Caroline",
+          "sprecher" : "Marianne Bernhardt"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Charles Stapleton",
+          "sprecher" : "Romanus Fuhrmann"
+        },
+        {
+          "rolle" : "Direktor Greenwalt",
+          "sprecher" : "Jürgen Uter"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Angestellter",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Carlo von Tiedemann"
+        },
+        {
+          "rolle" : "Papagei",
+          "sprecher" : "Merete Brettschneider"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/205/metadata.json",
@@ -26375,51 +26479,51 @@
           "end" : 3762867
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Mason Huntington",
-          "Wolfgang Häntsch"
-        ],
-        [
-          "Mrs. Brankle",
-          "Mignon Remé"
-        ],
-        [
-          "Xeni",
-          "Lina Maria Millat"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Seymore-Wrightson",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Franklyn Seymore",
-          "Achim Schülke"
-        ],
-        [
-          "Liane Shore",
-          "Sandra Keck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Mason Huntington",
+          "sprecher" : "Wolfgang Häntsch"
+        },
+        {
+          "rolle" : "Mrs. Brankle",
+          "sprecher" : "Mignon Remé"
+        },
+        {
+          "rolle" : "Xeni",
+          "sprecher" : "Lina Maria Millat"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Seymore-Wrightson",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Franklyn Seymore",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Liane Shore",
+          "sprecher" : "Sandra Keck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/206/metadata.json",
@@ -26468,63 +26572,63 @@
           "end" : 3725680
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Minh",
-          "Jona Mues"
-        ],
-        [
-          "Luke",
-          "Alexander Merbeth"
-        ],
-        [
-          "Mark",
-          "Woody Mues"
-        ],
-        [
-          "Stéphane Mertens",
-          "Peter Kaempfe"
-        ],
-        [
-          "Kassiererin",
-          "Birte Kretschmer"
-        ],
-        [
-          "Ron Baxter",
-          "Robin Brosch"
-        ],
-        [
-          "Oma",
-          "Apollonia Jepsen"
-        ],
-        [
-          "Mrs. Willard",
-          "Daniela Ziegler"
-        ],
-        [
-          "Li",
-          "Traudel Sperber"
-        ],
-        [
-          "Tilan",
-          "Caroline Kiesewetter"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Minh",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Luke",
+          "sprecher" : "Alexander Merbeth"
+        },
+        {
+          "rolle" : "Mark",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Stéphane Mertens",
+          "sprecher" : "Peter Kaempfe"
+        },
+        {
+          "rolle" : "Kassiererin",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Ron Baxter",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Oma",
+          "sprecher" : "Apollonia Jepsen"
+        },
+        {
+          "rolle" : "Mrs. Willard",
+          "sprecher" : "Daniela Ziegler"
+        },
+        {
+          "rolle" : "Li",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Tilan",
+          "sprecher" : "Caroline Kiesewetter"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/207/metadata.json",
@@ -26573,79 +26677,79 @@
           "end" : 4250387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Bootsie Washington",
-          "Andreas Birnbaum"
-        ],
-        [
-          "Majorie Dever",
-          "Victoria Trauttmansdorff"
-        ],
-        [
-          "Schwester",
-          "Gabriele Libbach"
-        ],
-        [
-          "Leland Hanson",
-          "Matthias Keller"
-        ],
-        [
-          "Jolene",
-          "Sarah Madeleine Tusk"
-        ],
-        [
-          "Perceval",
-          "André Beyer"
-        ],
-        [
-          "Mercury",
-          "Kerstin Draeger"
-        ],
-        [
-          "Coldfield",
-          "Wolf-Dietrich Sprenger"
-        ],
-        [
-          "Urs",
-          "Hanns Jörg Krumpholz"
-        ],
-        [
-          "Nicolas",
-          "Uwe Lauschke"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Carver",
-          "Andreas Zaron"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Bootsie Washington",
+          "sprecher" : "Andreas Birnbaum"
+        },
+        {
+          "rolle" : "Majorie Dever",
+          "sprecher" : "Victoria Trauttmansdorff"
+        },
+        {
+          "rolle" : "Schwester",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Leland Hanson",
+          "sprecher" : "Matthias Keller"
+        },
+        {
+          "rolle" : "Jolene",
+          "sprecher" : "Sarah Madeleine Tusk"
+        },
+        {
+          "rolle" : "Perceval",
+          "sprecher" : "André Beyer"
+        },
+        {
+          "rolle" : "Mercury",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Coldfield",
+          "sprecher" : "Wolf-Dietrich Sprenger"
+        },
+        {
+          "rolle" : "Urs",
+          "sprecher" : "Hanns Jörg Krumpholz"
+        },
+        {
+          "rolle" : "Nicolas",
+          "sprecher" : "Uwe Lauschke"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Carver",
+          "sprecher" : "Andreas Zaron"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/208/metadata.json",
@@ -26699,59 +26803,59 @@
           "end" : 3596773
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Oisin Murphy",
-          "Douglas Welbat"
-        ],
-        [
-          "Lelia Murphy",
-          "Katja Brügger"
-        ],
-        [
-          "Virgil",
-          "Steffen Groth"
-        ],
-        [
-          "Wanda Waffle",
-          "Anja Topf"
-        ],
-        [
-          "Smiddie",
-          "Ivo Möller"
-        ],
-        [
-          "Clown",
-          "Andreas Birnbaum"
-        ],
-        [
-          "Zamora",
-          "Rainer Schmitt"
-        ],
-        [
-          "Easly",
-          "Paul Michaeli"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Oisin Murphy",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Lelia Murphy",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Virgil",
+          "sprecher" : "Steffen Groth"
+        },
+        {
+          "rolle" : "Wanda Waffle",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Smiddie",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Clown",
+          "sprecher" : "Andreas Birnbaum"
+        },
+        {
+          "rolle" : "Zamora",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Easly",
+          "sprecher" : "Paul Michaeli"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/209/metadata.json",
@@ -26800,51 +26904,51 @@
           "end" : 3627267
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Zach Cannings",
-          "Martin May"
-        ],
-        [
-          "Nicole",
-          "Saskia Weckler"
-        ],
-        [
-          "Mitarbeiter",
-          "Achim Funk"
-        ],
-        [
-          "Sara Roskin",
-          "Elke Reissert"
-        ],
-        [
-          "Caden Devlin",
-          "Werner Wilkening"
-        ],
-        [
-          "Offizier der Küstenwache 1",
-          "Thorsten Laussch"
-        ],
-        [
-          "Offizier der Küstenwache 2",
-          "Andreas Birnbaum"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Zach Cannings",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Nicole",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Mitarbeiter",
+          "sprecher" : "Achim Funk"
+        },
+        {
+          "rolle" : "Sara Roskin",
+          "sprecher" : "Elke Reissert"
+        },
+        {
+          "rolle" : "Caden Devlin",
+          "sprecher" : "Werner Wilkening"
+        },
+        {
+          "rolle" : "Offizier der Küstenwache 1",
+          "sprecher" : "Thorsten Laussch"
+        },
+        {
+          "rolle" : "Offizier der Küstenwache 2",
+          "sprecher" : "Andreas Birnbaum"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/210/metadata.json",
@@ -26893,59 +26997,59 @@
           "end" : 4321973
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jock",
-          "Christian Stark"
-        ],
-        [
-          "Gavin Sterling",
-          "Stephan Benson"
-        ],
-        [
-          "Judith Sterling",
-          "Hedi Kriegeskotte"
-        ],
-        [
-          "Leopold Nelson",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Marlow",
-          "Janis Zaurins"
-        ],
-        [
-          "Rick",
-          "Daniel Welbat"
-        ],
-        [
-          "Mrs. Torres",
-          "Heidi Berndt"
-        ],
-        [
-          "Dark Blue D",
-          "Ivo Möller"
-        ],
-        [
-          "Busfahrerin",
-          "Rosemarie Wohlbauer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jock",
+          "sprecher" : "Christian Stark"
+        },
+        {
+          "rolle" : "Gavin Sterling",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Judith Sterling",
+          "sprecher" : "Hedi Kriegeskotte"
+        },
+        {
+          "rolle" : "Leopold Nelson",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Marlow",
+          "sprecher" : "Janis Zaurins"
+        },
+        {
+          "rolle" : "Rick",
+          "sprecher" : "Daniel Welbat"
+        },
+        {
+          "rolle" : "Mrs. Torres",
+          "sprecher" : "Heidi Berndt"
+        },
+        {
+          "rolle" : "Dark Blue D",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Busfahrerin",
+          "sprecher" : "Rosemarie Wohlbauer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/211/metadata.json",
@@ -26999,59 +27103,59 @@
           "end" : 4395213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Larry Conklin",
-          "Helmut Zierl"
-        ],
-        [
-          "Fairfax",
-          "Wolfgang Pampel"
-        ],
-        [
-          "Zachary",
-          "Nicolas König"
-        ],
-        [
-          "Butler Francis",
-          "Bruno F. Apitz"
-        ],
-        [
-          "Mrs. Dutton",
-          "Monika Werner"
-        ],
-        [
-          "Noreen",
-          "Simona Pahl"
-        ],
-        [
-          "Mrs. Mobray",
-          "Eva Weissmann"
-        ],
-        [
-          "Polizist",
-          "Holger Wemhoff"
-        ],
-        [
-          "Miyazawa",
-          "Achim Schülke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Larry Conklin",
+          "sprecher" : "Helmut Zierl"
+        },
+        {
+          "rolle" : "Fairfax",
+          "sprecher" : "Wolfgang Pampel"
+        },
+        {
+          "rolle" : "Zachary",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Butler Francis",
+          "sprecher" : "Bruno F. Apitz"
+        },
+        {
+          "rolle" : "Mrs. Dutton",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Noreen",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Mrs. Mobray",
+          "sprecher" : "Eva Weissmann"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Miyazawa",
+          "sprecher" : "Achim Schülke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/212/metadata.json",
@@ -27105,75 +27209,75 @@
           "end" : 4378267
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Jojo",
-          "Lovis Harloff"
-        ],
-        [
-          "Mrs. Carmichael",
-          "Anne Moll"
-        ],
-        [
-          "Mr. Jeremiah Carmichael",
-          "Peter Bieringer"
-        ],
-        [
-          "Gravedigger",
-          "Lutz Mackensy"
-        ],
-        [
-          "Kruger",
-          "Gordon Piedesack"
-        ],
-        [
-          "Annabelle Delaney",
-          "Sabine Kaack"
-        ],
-        [
-          "Claire Delaney",
-          "Theresa Underberg"
-        ],
-        [
-          "Ace Hall",
-          "Patrick Berg"
-        ],
-        [
-          "Vince Buchanan",
-          "Joachim Kretzer"
-        ],
-        [
-          "Neal Buchanan",
-          "Marek Harloff"
-        ],
-        [
-          "Moderator",
-          "Holger Wemhoff"
-        ],
-        [
-          "Pearson",
-          "Till Huster"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Jojo",
+          "sprecher" : "Lovis Harloff"
+        },
+        {
+          "rolle" : "Mrs. Carmichael",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Mr. Jeremiah Carmichael",
+          "sprecher" : "Peter Bieringer"
+        },
+        {
+          "rolle" : "Gravedigger",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Kruger",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Annabelle Delaney",
+          "sprecher" : "Sabine Kaack"
+        },
+        {
+          "rolle" : "Claire Delaney",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Ace Hall",
+          "sprecher" : "Patrick Berg"
+        },
+        {
+          "rolle" : "Vince Buchanan",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Neal Buchanan",
+          "sprecher" : "Marek Harloff"
+        },
+        {
+          "rolle" : "Moderator",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Pearson",
+          "sprecher" : "Till Huster"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/213/metadata.json",
@@ -27222,67 +27326,67 @@
           "end" : 3938600
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Kommissarin Lisa Merryweather",
-          "Caroline Peters"
-        ],
-        [
-          "Elena Fleckenstein",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Roderick Sanders",
-          "Albrecht Ganskopf"
-        ],
-        [
-          "Fahrerin",
-          "Elga Schütz"
-        ],
-        [
-          "Rubbish George",
-          "Hans Peter Korff"
-        ],
-        [
-          "Officer Brown",
-          "André Beyer"
-        ],
-        [
-          "Bote",
-          "Achim Schülke"
-        ],
-        [
-          "Polizist",
-          "Alexander Mettin"
-        ],
-        [
-          "Angestellte im Altenheim",
-          "Barbara Schipper"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Kommissarin Lisa Merryweather",
+          "sprecher" : "Caroline Peters"
+        },
+        {
+          "rolle" : "Elena Fleckenstein",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Roderick Sanders",
+          "sprecher" : "Albrecht Ganskopf"
+        },
+        {
+          "rolle" : "Fahrerin",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Hans Peter Korff"
+        },
+        {
+          "rolle" : "Officer Brown",
+          "sprecher" : "André Beyer"
+        },
+        {
+          "rolle" : "Bote",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Alexander Mettin"
+        },
+        {
+          "rolle" : "Angestellte im Altenheim",
+          "sprecher" : "Barbara Schipper"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/214/metadata.json",
@@ -27341,63 +27445,63 @@
           "end" : 3954893
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Arnold Grasso",
-          "Patrick Berg"
-        ],
-        [
-          "Amalia",
-          "Verena Frost"
-        ],
-        [
-          "Sarah",
-          "Jana Catharina Schmidt"
-        ],
-        [
-          "Eric",
-          "Rasmus Borowski"
-        ],
-        [
-          "Nicolas",
-          "Lukas T. Sperber"
-        ],
-        [
-          "Dennis",
-          "Detlef Tams"
-        ],
-        [
-          "Dale Congden",
-          "Peter Kaempfe"
-        ],
-        [
-          "Professor Hogan",
-          "Hannes Hellmann"
-        ],
-        [
-          "Officer",
-          "Torsten Münchow"
-        ],
-        [
-          "Ansage",
-          "Anne Moll"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Arnold Grasso",
+          "sprecher" : "Patrick Berg"
+        },
+        {
+          "rolle" : "Amalia",
+          "sprecher" : "Verena Frost"
+        },
+        {
+          "rolle" : "Sarah",
+          "sprecher" : "Jana Catharina Schmidt"
+        },
+        {
+          "rolle" : "Eric",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Nicolas",
+          "sprecher" : "Lukas T. Sperber"
+        },
+        {
+          "rolle" : "Dennis",
+          "sprecher" : "Detlef Tams"
+        },
+        {
+          "rolle" : "Dale Congden",
+          "sprecher" : "Peter Kaempfe"
+        },
+        {
+          "rolle" : "Professor Hogan",
+          "sprecher" : "Hannes Hellmann"
+        },
+        {
+          "rolle" : "Officer",
+          "sprecher" : "Torsten Münchow"
+        },
+        {
+          "rolle" : "Ansage",
+          "sprecher" : "Anne Moll"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/215/metadata.json",
@@ -27461,55 +27565,55 @@
           "end" : 3884267
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kendra Bowman",
-          "Sandra Schwittau"
-        ],
-        [
-          "Huxley, Sittich",
-          "Achim Buch"
-        ],
-        [
-          "Matt",
-          "Manfred Liptow"
-        ],
-        [
-          "Carol",
-          "Gerlinde Dillge"
-        ],
-        [
-          "Trevor",
-          "Peter Kaempfe"
-        ],
-        [
-          "Officer",
-          "Torsten Münchow"
-        ],
-        [
-          "Reginald",
-          "Malte Janßen"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kendra Bowman",
+          "sprecher" : "Sandra Schwittau"
+        },
+        {
+          "rolle" : "Huxley, Sittich",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Matt",
+          "sprecher" : "Manfred Liptow"
+        },
+        {
+          "rolle" : "Carol",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Trevor",
+          "sprecher" : "Peter Kaempfe"
+        },
+        {
+          "rolle" : "Officer",
+          "sprecher" : "Torsten Münchow"
+        },
+        {
+          "rolle" : "Reginald",
+          "sprecher" : "Malte Janßen"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/216/metadata.json",
@@ -27568,67 +27672,67 @@
           "end" : 4520653
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Julia Scott",
-          "Stephanie Damare"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Gwendolyn",
-          "Maud Ackermann"
-        ],
-        [
-          "Nicholas",
-          "Max König"
-        ],
-        [
-          "Raphael Luca",
-          "Achim Buch"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Bronkowitz",
-          "Angela Stresemann"
-        ],
-        [
-          "Lady",
-          "Eva Monar"
-        ],
-        [
-          "Dame",
-          "Carolyn Walsh"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Hunter Scott",
-          "Hans-Jürgen Mende"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Julia Scott",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Gwendolyn",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Nicholas",
+          "sprecher" : "Max König"
+        },
+        {
+          "rolle" : "Raphael Luca",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Bronkowitz",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Lady",
+          "sprecher" : "Eva Monar"
+        },
+        {
+          "rolle" : "Dame",
+          "sprecher" : "Carolyn Walsh"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Hunter Scott",
+          "sprecher" : "Hans-Jürgen Mende"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/217/metadata.json",
@@ -27687,67 +27791,67 @@
           "end" : 4372133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Olivia",
-          "Uschi Hugo"
-        ],
-        [
-          "Pamela Parker, Olivias Mutter",
-          "Katrin Decker"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Eudora Kretschmer",
-          "Monika Werner"
-        ],
-        [
-          "Barbara",
-          "Carolyn Walsh"
-        ],
-        [
-          "Canyon Brookside",
-          "Marek Erhardt"
-        ],
-        [
-          "Owens",
-          "Jan Langer"
-        ],
-        [
-          "Bernie Walters",
-          "Vadim Goldfeld"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Edgar Mulligan",
-          "Karsten Haase"
-        ],
-        [
-          "Swift",
-          "Tim Grobe"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Olivia",
+          "sprecher" : "Uschi Hugo"
+        },
+        {
+          "rolle" : "Pamela Parker, Olivias Mutter",
+          "sprecher" : "Katrin Decker"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Eudora Kretschmer",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Barbara",
+          "sprecher" : "Carolyn Walsh"
+        },
+        {
+          "rolle" : "Canyon Brookside",
+          "sprecher" : "Marek Erhardt"
+        },
+        {
+          "rolle" : "Owens",
+          "sprecher" : "Jan Langer"
+        },
+        {
+          "rolle" : "Bernie Walters",
+          "sprecher" : "Vadim Goldfeld"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Edgar Mulligan",
+          "sprecher" : "Karsten Haase"
+        },
+        {
+          "rolle" : "Swift",
+          "sprecher" : "Tim Grobe"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/218/metadata.json",
@@ -27806,67 +27910,67 @@
           "end" : 4189547
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Detective Ella",
-          "Neda Rahmanian"
-        ],
-        [
-          "Officer James",
-          "Sascha Gutzeit"
-        ],
-        [
-          "Mr. Shaw",
-          "Michael Grimm"
-        ],
-        [
-          "Paul Forsters",
-          "Achim Buch"
-        ],
-        [
-          "Esprit",
-          "Matthias Keller"
-        ],
-        [
-          "Anthony Spring",
-          "Douglas Welbat"
-        ],
-        [
-          "Butch",
-          "Tom Pidde"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Polizist",
-          "Frank Meyer-Brockmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Detective Ella",
+          "sprecher" : "Neda Rahmanian"
+        },
+        {
+          "rolle" : "Officer James",
+          "sprecher" : "Sascha Gutzeit"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Michael Grimm"
+        },
+        {
+          "rolle" : "Paul Forsters",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Esprit",
+          "sprecher" : "Matthias Keller"
+        },
+        {
+          "rolle" : "Anthony Spring",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Butch",
+          "sprecher" : "Tom Pidde"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Frank Meyer-Brockmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/219/metadata.json",
@@ -27935,59 +28039,59 @@
           "end" : 4446747
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Bill Greyfield",
-          "Gordon Piedesack"
-        ],
-        [
-          "Karen Greyfield",
-          "Beate Rysopp"
-        ],
-        [
-          "Ralph Sanders",
-          "Jens Böttcher"
-        ],
-        [
-          "Dylan Reid",
-          "Matthias Keller"
-        ],
-        [
-          "Zoe",
-          "Marion Martienzen"
-        ],
-        [
-          "Simon Cobby",
-          "Pat Murphy"
-        ],
-        [
-          "Angela van Limbeek",
-          "Malin Steffen"
-        ],
-        [
-          "John Addington",
-          "Andreas Birnbaum"
-        ],
-        [
-          "Doktor Williams",
-          "Holger Wemhoff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Bill Greyfield",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Karen Greyfield",
+          "sprecher" : "Beate Rysopp"
+        },
+        {
+          "rolle" : "Ralph Sanders",
+          "sprecher" : "Jens Böttcher"
+        },
+        {
+          "rolle" : "Dylan Reid",
+          "sprecher" : "Matthias Keller"
+        },
+        {
+          "rolle" : "Zoe",
+          "sprecher" : "Marion Martienzen"
+        },
+        {
+          "rolle" : "Simon Cobby",
+          "sprecher" : "Pat Murphy"
+        },
+        {
+          "rolle" : "Angela van Limbeek",
+          "sprecher" : "Malin Steffen"
+        },
+        {
+          "rolle" : "John Addington",
+          "sprecher" : "Andreas Birnbaum"
+        },
+        {
+          "rolle" : "Doktor Williams",
+          "sprecher" : "Holger Wemhoff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/220/metadata.json",
@@ -28051,47 +28155,47 @@
           "end" : 3932520
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Professor Douglas Bancroft",
-          "Jürgen Thormann"
-        ],
-        [
-          "Butler Vernom",
-          "Jürgen Holdorf"
-        ],
-        [
-          "Miss Mortimer",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Elwood Shoreland",
-          "Martin May"
-        ],
-        [
-          "Darian",
-          "Marc Zabinski"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Professor Douglas Bancroft",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Butler Vernom",
+          "sprecher" : "Jürgen Holdorf"
+        },
+        {
+          "rolle" : "Miss Mortimer",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Elwood Shoreland",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Darian",
+          "sprecher" : "Marc Zabinski"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/221/metadata.json",
@@ -28150,67 +28254,67 @@
           "end" : 4615480
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Amanda Blunt",
-          "Katy Karrenbauer"
-        ],
-        [
-          "Quinn",
-          "Till Hagen"
-        ],
-        [
-          "Lyn",
-          "Henrike Fehrs"
-        ],
-        [
-          "Opossum",
-          "Reinhold Kammerer"
-        ],
-        [
-          "Nancy",
-          "Britta Steffenhagen"
-        ],
-        [
-          "Odo",
-          "Sebastian König"
-        ],
-        [
-          "Dimwitt",
-          "Achim Schülke"
-        ],
-        [
-          "Telefonstimme",
-          "Nicolas König"
-        ],
-        [
-          "Colstone",
-          "Peter G. Dirmeier"
-        ],
-        [
-          "Moderatorin",
-          "Petra Kleinert"
-        ],
-        [
-          "Sheriff",
-          "Konstantin Graudus"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Amanda Blunt",
+          "sprecher" : "Katy Karrenbauer"
+        },
+        {
+          "rolle" : "Quinn",
+          "sprecher" : "Till Hagen"
+        },
+        {
+          "rolle" : "Lyn",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Opossum",
+          "sprecher" : "Reinhold Kammerer"
+        },
+        {
+          "rolle" : "Nancy",
+          "sprecher" : "Britta Steffenhagen"
+        },
+        {
+          "rolle" : "Odo",
+          "sprecher" : "Sebastian König"
+        },
+        {
+          "rolle" : "Dimwitt",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Telefonstimme",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Colstone",
+          "sprecher" : "Peter G. Dirmeier"
+        },
+        {
+          "rolle" : "Moderatorin",
+          "sprecher" : "Petra Kleinert"
+        },
+        {
+          "rolle" : "Sheriff",
+          "sprecher" : "Konstantin Graudus"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/222/metadata.json",
@@ -28269,71 +28373,72 @@
           "end" : 4799880
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Trenton",
-          "Marco Steeger"
-        ],
-        [
-          "Buzzy",
-          "Merete Brettschneider"
-        ],
-        [
-          "Harold",
-          "Leonhard Mahlich"
-        ],
-        [
-          "George",
-          "Robin Brosch"
-        ],
-        [
-          "Roberta",
-          "Pamela Punti [Heikedine Körting]"
-        ],
-        [
-          "Evander Prettyman",
-          "Nicolas Böll"
-        ],
-        [
-          "Liam",
-          "Stefan Brönneke"
-        ],
-        [
-          "Lincoln",
-          "Hans Peter Korff"
-        ],
-        [
-          "Maya",
-          "Manuela Eifrig"
-        ],
-        [
-          "Haylie",
-          "Barbara Schipper"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Trenton",
+          "sprecher" : "Marco Steeger"
+        },
+        {
+          "rolle" : "Buzzy",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Harold",
+          "sprecher" : "Leonhard Mahlich"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Roberta",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Evander Prettyman",
+          "sprecher" : "Nicolas Böll"
+        },
+        {
+          "rolle" : "Liam",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Lincoln",
+          "sprecher" : "Hans Peter Korff"
+        },
+        {
+          "rolle" : "Maya",
+          "sprecher" : "Manuela Eifrig"
+        },
+        {
+          "rolle" : "Haylie",
+          "sprecher" : "Barbara Schipper"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/223/metadata.json",
@@ -28392,55 +28497,55 @@
           "end" : 4363613
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ian Carew",
-          "Sascha Draeger"
-        ],
-        [
-          "Mambo Mawu",
-          "Regina Lemnitz"
-        ],
-        [
-          "Kommissarin Martinez",
-          "Caroline Kiesewetter"
-        ],
-        [
-          "Larry",
-          "Stephan Schad"
-        ],
-        [
-          "Morton",
-          "Michael Prelle"
-        ],
-        [
-          "Thabani Mathoho",
-          "Tim Grobe"
-        ],
-        [
-          "Clayton Badu",
-          "Frank Roder"
-        ],
-        [
-          "Cumba Balewa",
-          "Heidi Berndt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ian Carew",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Mambo Mawu",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Kommissarin Martinez",
+          "sprecher" : "Caroline Kiesewetter"
+        },
+        {
+          "rolle" : "Larry",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Michael Prelle"
+        },
+        {
+          "rolle" : "Thabani Mathoho",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Clayton Badu",
+          "sprecher" : "Frank Roder"
+        },
+        {
+          "rolle" : "Cumba Balewa",
+          "sprecher" : "Heidi Berndt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/224/metadata.json",
@@ -28668,83 +28773,83 @@
           "end" : 10696453
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Kenneth",
-          "Till Huster"
-        ],
-        [
-          "Chief Householder",
-          "Gordon Piedesack"
-        ],
-        [
-          "Tricia Cooper",
-          "Anna Carlsson"
-        ],
-        [
-          "Mr. Rice",
-          "Stephan Schad"
-        ],
-        [
-          "Katee",
-          "Anne Moll"
-        ],
-        [
-          "Sergeant Murray",
-          "Achim Buch"
-        ],
-        [
-          "Mary",
-          "Svantje Wascher"
-        ],
-        [
-          "Scott",
-          "John Wesley Zielmann"
-        ],
-        [
-          "Johnson",
-          "Wanja Mues"
-        ],
-        [
-          "Nigel",
-          "Tim Mälzer"
-        ],
-        [
-          "Patrick",
-          "Christian Rudolf"
-        ],
-        [
-          "Dolly Craig",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Mrs. Cooper",
-          "Angelika Berg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Kenneth",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Chief Householder",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Tricia Cooper",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Mr. Rice",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Katee",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Sergeant Murray",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Svantje Wascher"
+        },
+        {
+          "rolle" : "Scott",
+          "sprecher" : "John Wesley Zielmann"
+        },
+        {
+          "rolle" : "Johnson",
+          "sprecher" : "Wanja Mues"
+        },
+        {
+          "rolle" : "Nigel",
+          "sprecher" : "Tim Mälzer"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Dolly Craig",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Mrs. Cooper",
+          "sprecher" : "Angelika Berg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/225/metadata.json",
@@ -28792,59 +28897,59 @@
           "end" : 4953600
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Clarissa Franklin",
-          "Judy Winter"
-        ],
-        [
-          "Jack Cliffwater",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Mr. Bumblebee",
-          "Tim Grobe"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Evans",
-          "Merete Brettschneider"
-        ],
-        [
-          "Mr. Powers",
-          "Achim Buch"
-        ],
-        [
-          "Meyer",
-          "Tim Helssen"
-        ],
-        [
-          "Polizist",
-          "John Wesley Zielmann"
-        ],
-        [
-          "Polizistin",
-          "Merle Tucholka"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Clarissa Franklin",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Jack Cliffwater",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Mr. Bumblebee",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Evans",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Mr. Powers",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Meyer",
+          "sprecher" : "Tim Helssen"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "John Wesley Zielmann"
+        },
+        {
+          "rolle" : "Polizistin",
+          "sprecher" : "Merle Tucholka"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/226/metadata.json",

--- a/data/Master_Serie.json
+++ b/data/Master_Serie.json
@@ -314,11 +314,11 @@
         ],
         [
           "Miss Chalmers",
-          "Pamela Punti"
+          "Pamela Punti [Heikedine Körting]"
         ],
         [
           "Mr. Hassel",
-          "Rolf Hundertwasser"
+          "Rolf Hundertwasser [Wolfgang Kubach]"
         ],
         [
           "Polizist",
@@ -420,8 +420,12 @@
           "Boris Stepin [Wolfgang Kubach]"
         ],
         [
-          "Junge",
-          "Philip Baader"
+          "Junge 1",
+          "Philip Baader [Stefan Brönneke]"
+        ],
+        [
+          "Junge 2",
+          "Alexander Körting"
         ],
         [
           "Hauptkommissar Reynolds",
@@ -434,10 +438,6 @@
         [
           "Wachmann",
           "Peter Buchholz"
-        ],
-        [
-          "Jungen",
-          "Stefan Brönneke, Alexander Körting"
         ],
         [
           "Jahrmarktfrau",
@@ -524,7 +524,7 @@
         ],
         [
           "August August, genannt Gus",
-          "Stephan Chreszinski"
+          "Stephan Chrzescinski"
         ],
         [
           "Tante Mathilda Jonas",
@@ -763,7 +763,7 @@
         ],
         [
           "Mr. Carter",
-          "F. J. Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "Jack Morgan",
@@ -775,7 +775,7 @@
         ],
         [
           "Telephonistin",
-          "Reinhild Schneider"
+          "Reinhilt Schneider"
         ]
       ],
       "links" : {
@@ -973,7 +973,7 @@
         ],
         [
           "Onkel Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda Jonas",
@@ -981,7 +981,7 @@
         ],
         [
           "Professor Carswell",
-          "Theodor Anzinger"
+          "Theodor Anzinger [Volker Bogdan]"
         ],
         [
           "Hal Carswell",
@@ -1104,7 +1104,7 @@
         ],
         [
           "Professor Freeman",
-          "Joachim Wolff [Klaus Stieringer]"
+          "Viktor Bramer [Klaus Stieringer]"
         ],
         [
           "Achmed",
@@ -1303,11 +1303,11 @@
         ],
         [
           "Mrs. Smith",
-          "Maria Benders"
+          "Maria Benders [Brigitte Alexis]"
         ],
         [
           "Harry",
-          "Marco Beddis"
+          "Marco Beddies"
         ],
         [
           "Mrs. King",
@@ -1319,11 +1319,11 @@
         ],
         [
           "Martha Harris",
-          "Marga Maasberg"
+          "Eva Gelb"
         ],
         [
           "Carlos",
-          "Hans-Werner Kuhn [Günter Heising]"
+          "Hans-Werner Kuhn [Günther Heising]"
         ],
         [
           "Gerald Cramer",
@@ -1426,15 +1426,15 @@
         ],
         [
           "Mr. Harris",
-          "Günter Heising"
+          "Günther Heising"
         ],
         [
           "Miss Sanchez",
-          "Marlene Lindner [Ursula Vogel]"
+          "Marlene Lindner [Cordula Hubrich]"
         ],
         [
           "Ted Sanchez",
-          "Nikolas Körting"
+          "Nicolas Körting"
         ],
         [
           "Sanders",
@@ -1446,7 +1446,7 @@
         ],
         [
           "Natches",
-          "Gernot Endermann"
+          "Gernot Endemann"
         ],
         [
           "Hauptkommissar Reynolds",
@@ -1577,7 +1577,7 @@
         ],
         [
           "Lieferant",
-          "F.-J. Steffens"
+          "Franz-Josef Steffens"
         ]
       ],
       "links" : {
@@ -1660,7 +1660,7 @@
         ],
         [
           "Onkel Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Miss Larson",
@@ -1795,7 +1795,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Gomez",
@@ -1996,7 +1996,7 @@
         ],
         [
           "Chris Markos",
-          "Stephan Chrzeszinski"
+          "Stephan Chrzescinski"
         ],
         [
           "Kommissar Nostigon",
@@ -2020,11 +2020,11 @@
         ],
         [
           "Bill Ballinger",
-          "Günter Flesh"
+          "Günther Flesch"
         ],
         [
           "Jim Ballinger",
-          "Heinz Werder"
+          "Heinz Werder [Hans Irle]"
         ],
         [
           "Mr. Norris",
@@ -2127,11 +2127,11 @@
         ],
         [
           "Ben Jackson",
-          "Günter Flesh"
+          "Günther Flesch"
         ],
         [
           "Wreston",
-          "Ulrich Benthin"
+          "Ulrich Benthien"
         ],
         [
           "Cardigo",
@@ -2234,7 +2234,7 @@
         ],
         [
           "Dr. Radulescu",
-          "Günter Flesh"
+          "Günther Flesch"
         ],
         [
           "Potter",
@@ -2353,7 +2353,7 @@
         ],
         [
           "Jim Clay",
-          "Marcus Meiering"
+          "Markus Meiering [Dieter B. Gerlach]"
         ],
         [
           "Walter Quail",
@@ -2369,7 +2369,7 @@
         ],
         [
           "Chiang",
-          "Tom Barrows [Hans Irle]"
+          "Tom Barrows [Jürgen Thormann]"
         ],
         [
           "Diakon Kastner",
@@ -2464,11 +2464,11 @@
         ],
         [
           "Mr. Togati",
-          "Reiner Brönnecke"
+          "Reiner Brönneke"
         ],
         [
           "Taro",
-          "Stefan Brönnecke"
+          "Stefan Brönneke"
         ],
         [
           "Patrick",
@@ -2484,11 +2484,11 @@
         ],
         [
           "Jordan",
-          "Hans Meinhardt [Franz Josef Steffens]"
+          "Hans Meinhardt [Franz-Josef Steffens]"
         ],
         [
           "Chuck",
-          "Roland Fabricius [Edgar Bessen?]"
+          "Roland Fabricius [Wolfgang Kaven]"
         ],
         [
           "Liliputaner",
@@ -2583,7 +2583,7 @@
         ],
         [
           "Cody",
-          "Simon Schuchadt [Wolfgang Kaven]"
+          "Simon Schuchardt [Wolfgang Kaven]"
         ],
         [
           "Diego Alvaro",
@@ -2595,7 +2595,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Assistent",
@@ -2603,23 +2603,23 @@
         ],
         [
           "Sheriff",
-          "F.J. Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "Tulsa",
-          "Klaus Klein [F.J. Steffens]"
+          "Klaus Klein [Siegfried Wald]"
         ],
         [
           "Cap",
-          "Fritz Wegely [Siegfried Wald]"
+          "Fritz Wegely [Joachim Wolff]"
         ],
         [
           "Pike",
-          "Philip Mehringer [Joachim Wolff]"
+          "Philip Mehringer [Franz-Josef Steffens]"
         ],
         [
           "Mr. Shaw",
-          "F.J. Steffens"
+          "Franz-Josef Steffens"
         ]
       ],
       "links" : {
@@ -2702,7 +2702,7 @@
         ],
         [
           "Britta",
-          "Ingeborg Kanstein"
+          "Ingeburg Kanstein"
         ],
         [
           "Lars Holmqvist",
@@ -2714,7 +2714,7 @@
         ],
         [
           "Forsborg",
-          "Richard Heelel [F.J. Steffens]"
+          "Richard Heelel [Franz-Josef Steffens]"
         ],
         [
           "Mann",
@@ -2845,7 +2845,7 @@
         ],
         [
           "Prof. Barrister",
-          "F. J. Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "Marie",
@@ -2944,7 +2944,7 @@
         ],
         [
           "Harrison Osborne",
-          "F.J. Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "Thurgood",
@@ -3051,7 +3051,7 @@
         ],
         [
           "William Tremayne",
-          "Günther Flesh"
+          "Günther Flesch"
         ],
         [
           "Marvin Gray",
@@ -3071,7 +3071,7 @@
         ],
         [
           "Clara Adams",
-          "Ingeborg Kanstein"
+          "Ingeburg Kanstein"
         ],
         [
           "Grean",
@@ -3385,7 +3385,7 @@
         ],
         [
           "Berg",
-          "Andreas Beurmann / Wolfgang Draeger"
+          "Andreas E. Beurmann / Wolfgang Draeger"
         ],
         [
           "Yamura",
@@ -3730,7 +3730,7 @@
         ],
         [
           "Elsie Spratt",
-          "Pia Werfel [Barbara Focke]"
+          "Barbara Focke"
         ],
         [
           "Leutnant Ferrante",
@@ -3948,7 +3948,7 @@
         ],
         [
           "Thalia",
-          "Ingeborg Kanstein"
+          "Ingeburg Kanstein"
         ],
         [
           "Stefano",
@@ -3960,7 +3960,7 @@
         ],
         [
           "Tankwart",
-          "F.-J. Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "LKW-Fahrer",
@@ -4067,7 +4067,7 @@
         ],
         [
           "Fischer",
-          "F.-J. Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "Ocean-World-Mitarbeiter",
@@ -4162,11 +4162,11 @@
         ],
         [
           "Burton",
-          "Günther Pfitzmann"
+          "Günter Pfitzmann"
         ],
         [
           "Kommissar",
-          "Günther Flesh"
+          "Günther Flesch"
         ],
         [
           "Mooch",
@@ -4178,7 +4178,7 @@
         ],
         [
           "Fergus",
-          "Günter Dockerill"
+          "Günther Dockerill"
         ]
       ],
       "links" : {
@@ -4479,7 +4479,7 @@
         ],
         [
           "Hauptkomm. Reynolds",
-          "Günter Flesch"
+          "Günther Flesch"
         ],
         [
           "Margon",
@@ -4677,7 +4677,7 @@
         ],
         [
           "Michael Cross",
-          "Matthias Klimser"
+          "Matthias Klimsa"
         ],
         [
           "Mrs. Cross",
@@ -4693,7 +4693,7 @@
         ],
         [
           "Brackmann",
-          "F. J. Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "Margie",
@@ -4701,7 +4701,7 @@
         ],
         [
           "Nachrichtensprecher",
-          "Diess Günter Flesh"
+          "Günther Flesch"
         ],
         [
           "Sawyer",
@@ -4713,7 +4713,7 @@
         ],
         [
           "Gärtner",
-          "Günter Dockerill"
+          "Günther Dockerill"
         ],
         [
           "Mr. Rossing",
@@ -5046,7 +5046,7 @@
         ],
         [
           "Sam Ragnarson",
-          "Marco Kröger"
+          "Marco Kröger [Lutz Harder]"
         ],
         [
           "Mr. Manning",
@@ -5054,7 +5054,7 @@
         ],
         [
           "Mrs. Manning",
-          "Julia Mahnkopf"
+          "Julia Mahnkopf [Micaëla Kreißler]"
         ],
         [
           "Kommissar Reynolds",
@@ -5062,11 +5062,11 @@
         ],
         [
           "Mrs. Andrews",
-          "Renate Pichler"
+          "Anne Schermutzki"
         ],
         [
           "Mr. Andrews",
-          "Manfred Bendixen"
+          "Manfred Bendixen [Günter König]"
         ],
         [
           "Mathilda",
@@ -5153,11 +5153,11 @@
         ],
         [
           "Millionär Pilcher",
-          "Michael von Raspatt"
+          "Michael von Rospatt"
         ],
         [
           "Marilyn Pilcher",
-          "Gabi Libbach"
+          "Gabriele Libbach"
         ],
         [
           "Sekretär Sanchez",
@@ -5169,11 +5169,11 @@
         ],
         [
           "Frau Durham",
-          "Micaela Kreißler"
+          "Micaëla Kreißler"
         ],
         [
           "Jim Westerbrook",
-          "Michael Quiatkowski"
+          "Michael Quiatkowsky"
         ],
         [
           "Mrs. Westerbrook",
@@ -5181,7 +5181,7 @@
         ],
         [
           "Dr. Gonzaga",
-          "Michael Liptow"
+          "Manfred Liptow"
         ],
         [
           "Ramon Navarro",
@@ -5288,11 +5288,11 @@
         ],
         [
           "Pandro Mischkin",
-          "Michael Hark"
+          "Michael Harck"
         ],
         [
           "Kranführer Dick",
-          "Ernst von Klippstein"
+          "Ernst von Klipstein"
         ]
       ],
       "links" : {
@@ -5482,7 +5482,7 @@
         ],
         [
           "Purvis",
-          "Heiner Kramm"
+          "Heiner Kramm [Michael Quiatkowsky]"
         ],
         [
           "Dan DeMento",
@@ -5490,11 +5490,11 @@
         ],
         [
           "Leo Rottweiler",
-          "Rainer Brönneke"
+          "Reiner Brönneke"
         ],
         [
           "Steve Trash",
-          "Thomas Naumann"
+          "Michael Griem"
         ],
         [
           "Rainey Fields",
@@ -5594,7 +5594,7 @@
         ],
         [
           "Marble Ackbourne-Smith",
-          "Wolf Rathjen"
+          "Wolf Rahtjen"
         ],
         [
           "Margo",
@@ -5910,11 +5910,11 @@
         ],
         [
           "Inspektor Cole",
-          "Wolfgang Schimmelpfennig [Günter König]"
+          "Wolfgang Schimmelpfennig"
         ],
         [
           "Kommissar Maxim",
-          "Peter Matic"
+          "Peter Matić"
         ],
         [
           "Gilbar",
@@ -6018,7 +6018,7 @@
         ],
         [
           "Buzz Newman",
-          "Manou Lubowski"
+          "Christian Weber [Manou Lubowski]"
         ],
         [
           "George Brandon",
@@ -6134,7 +6134,7 @@
         ],
         [
           "Trainer Tong",
-          "Michael Hark"
+          "Michael Harck"
         ],
         [
           "Trainer Duggan",
@@ -6270,7 +6270,7 @@
         ],
         [
           "Lys",
-          "Anika Pages"
+          "Annika Pages"
         ],
         [
           "Branson Barr",
@@ -6378,14 +6378,14 @@
         ],
         [
           "Alma",
-          "Eva Zlomitzky"
+          "Eva Zlonitzky"
         ],
         [
           "Schwester",
-          "Gerda Maria Jürgens"
+          "Gerda-Maria Jürgens"
         ],
         [
-          "[Shirley Kubinski]",
+          "Shirley Kubinski",
           "Thea Frank"
         ]
       ],
@@ -6470,7 +6470,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "William Ashley",
@@ -6494,7 +6494,7 @@
         ],
         [
           "Mrs. Bloomingdale",
-          "Eva Zlomitzky"
+          "Eva Zlonitzky"
         ],
         [
           "Stella",
@@ -6594,7 +6594,7 @@
         ],
         [
           "Chosmo, Journalist",
-          "Mathias Bullach"
+          "Matthias Bullach"
         ],
         [
           "Monsieur Jaubert",
@@ -6610,7 +6610,7 @@
         ],
         [
           "Hendrik Walton, Fabrikant",
-          "Karl Michael Mechel"
+          "Michael Mechel"
         ]
       ],
       "links" : {
@@ -6726,7 +6726,7 @@
         ],
         [
           "Eleonore Sharp",
-          "Margot Linde"
+          "Margot Linde [Eva Maria Bauer]"
         ]
       ],
       "links" : {
@@ -6822,7 +6822,7 @@
         ],
         [
           "Kellner",
-          "Thomas Stein"
+          "Thomas M. Stein"
         ],
         [
           "Portland",
@@ -6926,11 +6926,11 @@
         ],
         [
           "Mrs. Silverstone",
-          "Barbara Ratthay"
+          "Barbara Ratthey"
         ],
         [
           "Mr. Garfield",
-          "Holger Mahlich [Utz Richter]"
+          "Utz Richter"
         ],
         [
           "Mr. Hartford",
@@ -7054,7 +7054,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Elizabeth",
@@ -7182,7 +7182,7 @@
         ],
         [
           "Mandy Taylor",
-          "Micaela Kreißler"
+          "Micaëla Kreißler"
         ],
         [
           "Deborah Street",
@@ -7190,7 +7190,7 @@
         ],
         [
           "Greenwater",
-          "Norman Messer"
+          "Norman Messer [André Minninger]"
         ]
       ],
       "links" : {
@@ -7298,11 +7298,11 @@
         ],
         [
           "Thomas",
-          "Stephan Chreszinsky"
+          "Stephan Chrzescinski"
         ],
         [
           "Andrew",
-          "Michael Rospat"
+          "Michael von Rospatt"
         ],
         [
           "Mrs. Rodriguez",
@@ -7402,7 +7402,7 @@
         ],
         [
           "Ignazio, Pensionswirt",
-          "Leonardo Cuseneza"
+          "Leonardo Cusenza"
         ],
         [
           "Sofia, Pensionswirtin",
@@ -7502,7 +7502,7 @@
         ],
         [
           "Babette Eberle",
-          "M. Rospat"
+          "Michael von Rospatt"
         ],
         [
           "Bruder Benedikt",
@@ -7530,7 +7530,7 @@
         ],
         [
           "1. Polizist",
-          "Boris Sychowsky"
+          "Boris von Sychowski"
         ],
         [
           "2. Polizist",
@@ -7622,7 +7622,7 @@
         ],
         [
           "1. Mann",
-          "Nico König"
+          "Nicolas König"
         ],
         [
           "2. Mann",
@@ -7718,7 +7718,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Inspektor Cotta",
@@ -7830,7 +7830,7 @@
         ],
         [
           "Alan",
-          "Oliver Reinhardt"
+          "Oliver Reinhard"
         ],
         [
           "Sally Samson",
@@ -7858,7 +7858,7 @@
         ],
         [
           "Brenda",
-          "Micaela Kreißler"
+          "Micaëla Kreißler"
         ],
         [
           "Inspektor Cotta",
@@ -7950,7 +7950,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda",
@@ -7962,7 +7962,7 @@
         ],
         [
           "Mrs. Lu Kwan",
-          "Susanne von Loessel"
+          "Susanne von Loessl"
         ],
         [
           "Jefferson",
@@ -7978,11 +7978,11 @@
         ],
         [
           "Olivia",
-          "Eva Weißmann"
+          "Eva Weissmann"
         ],
         [
           "Santoria",
-          "Holger Ohlendieck"
+          "Dieter Ohlendiek"
         ],
         [
           "Pertier",
@@ -7994,7 +7994,7 @@
         ],
         [
           "Irma",
-          "Konstanze Ulmer"
+          "Konstanze Ullmer"
         ]
       ],
       "links" : {
@@ -8094,11 +8094,11 @@
         ],
         [
           "Polizist",
-          "Oliver Reinhardt"
+          "Oliver Reinhard"
         ],
         [
           "Wachmann",
-          "Dieter Ohlendieck"
+          "Dieter Ohlendiek"
         ],
         [
           "2. Wächter",
@@ -8118,7 +8118,7 @@
         ],
         [
           "Kundin",
-          "Susann Jarling"
+          "Susan Jarling"
         ]
       ],
       "links" : {
@@ -8198,11 +8198,11 @@
         ],
         [
           "Mrs. Madigan",
-          "Anne Marks-Rocke"
+          "Annemarie Marks-Rocke"
         ],
         [
           "Eathon Easton, ihr Untermieter",
-          "Helmo Liebig"
+          "Helgo Liebig"
         ],
         [
           "Mrs. Lydia Cartier",
@@ -8306,7 +8306,7 @@
         ],
         [
           "Onkel Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda Jonas",
@@ -8318,7 +8318,7 @@
         ],
         [
           "Steven Robinshaw, Anwalt",
-          "Helmo Liebig"
+          "Helgo Liebig"
         ],
         [
           "Inspektor Cotta",
@@ -8346,7 +8346,7 @@
         ],
         [
           "Carrie Hanson",
-          "Helga Osten-Sacken"
+          "Hella von der Osten-Sacken"
         ],
         [
           "Tim Conrad",
@@ -8446,7 +8446,7 @@
         ],
         [
           "Mrs. Aston",
-          "J.S."
+          "Joyceline Schmidt"
         ],
         [
           "Mr. Krieger",
@@ -8636,7 +8636,7 @@
         ],
         [
           "Karen Sulzenberger",
-          "Kristina von Welzin"
+          "Kristina von Weltzien"
         ],
         [
           "Nicola",
@@ -8660,7 +8660,7 @@
         ],
         [
           "Roger",
-          "H. P. Kaehler"
+          "Klaus-Peter Kaehler"
         ],
         [
           "1. Mann",
@@ -8672,11 +8672,11 @@
         ],
         [
           "Kellnerin",
-          "Micaela Kreißler"
+          "Micaëla Kreißler"
         ],
         [
           "Uli",
-          "Norman Messer"
+          "Norman Messer [André Minninger]"
         ]
       ],
       "links" : {
@@ -8750,7 +8750,7 @@
         ],
         [
           "Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Albert Hitfield",
@@ -8866,7 +8866,7 @@
         ],
         [
           "William Needle",
-          "Nico König"
+          "Nicolas König"
         ],
         [
           "Stevens",
@@ -8874,15 +8874,15 @@
         ],
         [
           "Bart",
-          "Doktor Renz"
+          "Dokter Renz [Martin Vandreier]"
         ],
         [
           "Luke",
-          "Schiffmeister"
+          "Schiffmeister [Björn Warns]"
         ],
         [
           "Frank",
-          "König Boris"
+          "König Boris [Boris Lauterbach]"
         ],
         [
           "Joan, Visagistin",
@@ -8980,7 +8980,7 @@
         ],
         [
           "Roger Carpenter",
-          "Igmar Frentzen"
+          "Igmar Frenzen [Gustav-Adolph Artz]"
         ]
       ],
       "links" : {
@@ -9152,7 +9152,7 @@
         ],
         [
           "Milva Summer, Astrologin",
-          "Elizabeth Volkmann"
+          "Elisabeth Volkmann"
         ],
         [
           "Professor Steed, Tiermediziner",
@@ -9238,7 +9238,7 @@
         ],
         [
           "Käptn Jason",
-          "F.J. Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "Professor Clark",
@@ -9250,7 +9250,7 @@
         ],
         [
           "Dr. Helprin, Wissenschaftler",
-          "Rudolf Herget"
+          "Rudolf H. Herget"
         ],
         [
           "Mr. Evans",
@@ -9536,7 +9536,7 @@
         ],
         [
           "Ceewee",
-          "Michael Quiatkowski"
+          "Michael Quiatkowsky"
         ]
       ],
       "links" : {
@@ -9634,11 +9634,11 @@
         ],
         [
           "Sandy, Verkäuferin",
-          "Kathi Robens"
+          "Cornelia Meinhardt"
         ],
         [
           "Kundin",
-          "Cornelia Meinhardt"
+          "Kathi Robens"
         ]
       ],
       "links" : {
@@ -9748,7 +9748,7 @@
         ],
         [
           "Hexe",
-          "Micaela Kreißler"
+          "Micaëla Kreißler"
         ],
         [
           "Oma",
@@ -9854,7 +9854,7 @@
         ],
         [
           "Wachmann",
-          "Ulli Plessmann"
+          "Uli Pleßmann"
         ]
       ],
       "links" : {
@@ -9932,7 +9932,7 @@
         ],
         [
           "Bruce Black",
-          "Til Demtröder"
+          "Till Demtrøder"
         ]
       ],
       "links" : {
@@ -10014,7 +10014,7 @@
         ],
         [
           "Mrs. Shoemaker",
-          "Barbara Schnipper"
+          "Barbara Schipper"
         ]
       ],
       "links" : {
@@ -10084,7 +10084,7 @@
         ],
         [
           "Gregstone",
-          "Wolf Rathjen"
+          "Wolf Rahtjen"
         ],
         [
           "Butch",
@@ -10178,7 +10178,7 @@
         ],
         [
           "Onkel Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Deborah Snell",
@@ -10264,7 +10264,7 @@
         ],
         [
           "Miss Lilly",
-          "Jocelyn Boisseaux-Endemann"
+          "Jocelyne Boisseau"
         ],
         [
           "Inspektor Cotta",
@@ -10272,7 +10272,7 @@
         ],
         [
           "Frau des Bürgermeisters",
-          "Wanda Osten"
+          "Wanda Osten [Hella von der Osten-Sacken]"
         ],
         [
           "Reporter",
@@ -10280,7 +10280,7 @@
         ],
         [
           "Stewart",
-          "Till Madaus"
+          "Tilman Madaus"
         ],
         [
           "Pico, Clown",
@@ -10362,7 +10362,7 @@
         ],
         [
           "Dr. Arroway",
-          "Sona Cervena"
+          "Soňa Červená"
         ],
         [
           "Janet, ihre Assistentin",
@@ -10570,7 +10570,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Mrs. White",
@@ -10694,7 +10694,7 @@
         ],
         [
           "Joe",
-          "Jakob Lichtblau [Eberhard Haar]"
+          "Jakob Lichtblau [Fabian Harloff]"
         ]
       ],
       "links" : {
@@ -10810,7 +10810,7 @@
         ],
         [
           "Bote",
-          "Stefan Rütter"
+          "Stefan Rüter"
         ],
         [
           "Goodween",
@@ -10982,7 +10982,7 @@
             ],
             [
               "Professor Phoenix",
-              "Wilfried Glatzeder"
+              "Winfried Glatzeder"
             ],
             [
               "Dr. Svenson",
@@ -11006,7 +11006,7 @@
             ],
             [
               "Al",
-              "Nico König"
+              "Nicolas König"
             ],
             [
               "Anne",
@@ -11079,7 +11079,7 @@
             ],
             [
               "Professor Phoenix",
-              "Wilfried Glatzeder"
+              "Winfried Glatzeder"
             ],
             [
               "Dr. Svenson",
@@ -11099,7 +11099,7 @@
             ],
             [
               "Al",
-              "Nico König"
+              "Nicolas König"
             ],
             [
               "Anne",
@@ -11165,7 +11165,7 @@
         ],
         [
           "Professor Phoenix",
-          "Wilfried Glatzeder"
+          "Winfried Glatzeder"
         ],
         [
           "Rachel Hadden",
@@ -11173,7 +11173,7 @@
         ],
         [
           "Al",
-          "Nico König"
+          "Nicolas König"
         ],
         [
           "Anne",
@@ -11279,7 +11279,7 @@
         ],
         [
           "Oma Scott",
-          "Apollonia Minniger"
+          "Apollonia Jepsen"
         ],
         [
           "Acer",
@@ -11475,7 +11475,7 @@
         ],
         [
           "Bruder Raphael",
-          "Siegfried Kernen"
+          "Siegfried W. Kernen"
         ],
         [
           "Inspektor Berger",
@@ -11563,7 +11563,7 @@
         ],
         [
           "Dick Perry",
-          "Ernst Hilbich"
+          "Ernst H. Hilbich"
         ],
         [
           "Mrs. Meg Baker",
@@ -11687,7 +11687,7 @@
         ],
         [
           "Marc",
-          "Hartmut Kollakowski"
+          "Hartmut Kollakowsky"
         ]
       ],
       "links" : {
@@ -11787,11 +11787,11 @@
         ],
         [
           "Jim Cowley",
-          "Cäsar"
+          "Cäsar [Marcus Kaiser]"
         ],
         [
           "Jeffrey",
-          "Kim Alexander Frank"
+          "Kim Frank"
         ],
         [
           "Mandy Robin",
@@ -11919,7 +11919,7 @@
         ],
         [
           "Lesley Dimple",
-          "Maja Stehli [Ingeborg Kantstein ?]"
+          "Ann Montenbruck"
         ],
         [
           "Mrs. Wilbur",
@@ -12016,7 +12016,7 @@
         ],
         [
           "Albert",
-          "Wolf Rathjen"
+          "Wolf Rahtjen"
         ],
         [
           "Montgomery",
@@ -12104,7 +12104,7 @@
         ],
         [
           "Sandy",
-          "Micaela Kreissler"
+          "Micaëla Kreißler"
         ],
         [
           "Bill",
@@ -12216,7 +12216,7 @@
         ],
         [
           "Pablo",
-          "Kai Hendrik Möller"
+          "Kai Henrik Möller"
         ],
         [
           "Dr. Brolin",
@@ -12236,7 +12236,7 @@
         ],
         [
           "Margie",
-          "Susanne Leu"
+          "Susanna Leu"
         ],
         [
           "Mike",
@@ -12244,7 +12244,7 @@
         ],
         [
           "Clark",
-          "Wolf Rathjen"
+          "Wolf Rahtjen"
         ],
         [
           "Wachmann",
@@ -12366,7 +12366,7 @@
         ],
         [
           "Elisabeth Waterstone",
-          "Linde Fulde"
+          "Linde Fulda"
         ],
         [
           "John Stanley",
@@ -12382,7 +12382,7 @@
         ],
         [
           "Corona",
-          "Stefanie Kirchberger"
+          "Stephanie Damare"
         ],
         [
           "Fahrer Ken",
@@ -12896,7 +12896,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Kommissar Reynolds",
@@ -12912,7 +12912,7 @@
         ],
         [
           "Anita Caballero",
-          "Isabell Navarro"
+          "Isabel Navarro"
         ],
         [
           "Lesley Dimple",
@@ -12932,7 +12932,7 @@
         ],
         [
           "Mrs O'Rien",
-          "Victoria von Trautmannsdorff"
+          "Victoria Trauttmansdorff"
         ]
       ],
       "links" : {
@@ -13140,7 +13140,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Inspektor Cotta",
@@ -13277,7 +13277,7 @@
         ],
         [
           "Ralph",
-          "Jan-David Rönnfeldt"
+          "Jan-David Rönfeldt"
         ],
         [
           "Robbie",
@@ -13423,7 +13423,7 @@
         ],
         [
           "Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Caitlin Kopperschmidt",
@@ -13439,11 +13439,11 @@
         ],
         [
           "George",
-          "Hendrik König"
+          "Henry König"
         ],
         [
           "Anthony Quinn",
-          "Franz-Joseph Steffens"
+          "Franz-Josef Steffens"
         ],
         [
           "Martha",
@@ -13451,7 +13451,7 @@
         ],
         [
           "Felix Kopperschmidt",
-          "Herrmann Otto"
+          "Hermann Otto"
         ],
         [
           "Mann",
@@ -13566,7 +13566,7 @@
         ],
         [
           "Zuschauer",
-          "Alexander Mülle"
+          "Alexander Müller"
         ]
       ],
       "links" : {
@@ -13695,7 +13695,7 @@
         ],
         [
           "William Boyd",
-          "Olaf Kreuzenbeck"
+          "Olaf Kreutzenbeck"
         ],
         [
           "Thorndike",
@@ -13927,7 +13927,7 @@
         ],
         [
           "Abelardo",
-          "Peter Brix"
+          "Peter Heinrich Brix"
         ]
       ],
       "links" : {
@@ -14042,7 +14042,7 @@
         ],
         [
           "Mr. O'Sullivan",
-          "Eckard Dux"
+          "Eckart Dux"
         ],
         [
           "Butler Paul",
@@ -14050,7 +14050,7 @@
         ],
         [
           "Dick Perry",
-          "Ernst Hilbich"
+          "Ernst H. Hilbich"
         ],
         [
           "Polizist",
@@ -14163,7 +14163,7 @@
             ],
             [
               "Hugenay",
-              "Albert Giro"
+              "Albert Giro [Wolfgang Kubach]"
             ],
             [
               "Inspektor Cotta",
@@ -14296,7 +14296,7 @@
             ],
             [
               "Hugenay",
-              "Albert Giro"
+              "Albert Giro [Wolfgang Kubach]"
             ],
             [
               "Inspektor Cotta",
@@ -14340,7 +14340,7 @@
             ],
             [
               "Onkel Titus Jonas",
-              "Hans Meinhardt"
+              "Hans Meinhardt [Andreas E. Beurmann]"
             ]
           ],
           "links" : {
@@ -14459,7 +14459,7 @@
             ],
             [
               "Hugenay",
-              "Albert Giro"
+              "Albert Giro [Wolfgang Kubach]"
             ],
             [
               "Inspektor Cotta",
@@ -14491,11 +14491,11 @@
             ],
             [
               "Nachtschatten",
-              "Frank Tannhäuser"
+              "Frank Thannhäuser"
             ],
             [
               "Onkel Titus Jonas",
-              "Hans Meinhardt"
+              "Hans Meinhardt [Andreas E. Beurmann]"
             ],
             [
               "Tante Mathilda Jonas",
@@ -14503,7 +14503,7 @@
             ],
             [
               "Mr. Baker",
-              "Wolf Pahls"
+              "Wolf Pahlke"
             ]
           ],
           "links" : {
@@ -14541,7 +14541,7 @@
         ],
         [
           "Onkel Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda Jonas",
@@ -14561,7 +14561,7 @@
         ],
         [
           "Hugenay",
-          "Albert Giro"
+          "Albert Giro [Wolfgang Kubach]"
         ],
         [
           "Moderator",
@@ -14577,7 +14577,7 @@
         ],
         [
           "Nachtschatten",
-          "Frank Tannhäuser"
+          "Frank Thannhäuser"
         ],
         [
           "Brittany",
@@ -14621,7 +14621,7 @@
         ],
         [
           "Mr. Baker",
-          "Wolf Pahls"
+          "Wolf Pahlke"
         ]
       ],
       "links" : {
@@ -14730,7 +14730,7 @@
         ],
         [
           "Mr. Monroe",
-          "Jochen Regelin"
+          "Joachim Regelien"
         ],
         [
           "Professor Rosenberg",
@@ -15127,11 +15127,11 @@
         ],
         [
           "Alaa Edine",
-          "Robert Missler"
+          "Abdul Kader-Diab"
         ],
         [
           "Abazza",
-          "Abdul Kader-Diab"
+          "Robert Missler"
         ],
         [
           "Kamelhändler",
@@ -15299,7 +15299,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Skinny Norris",
@@ -15331,7 +15331,7 @@
         ],
         [
           "Mr. Grogan",
-          "Günter Flesch"
+          "Günther Flesch"
         ]
       ],
       "links" : {
@@ -15416,11 +15416,11 @@
         ],
         [
           "Lloyd Scavenger",
-          "Stefan Benson"
+          "Stephan Benson"
         ],
         [
           "Jack Lowell",
-          "Siegfried Kernen"
+          "Siegfried W. Kernen"
         ],
         [
           "Alexander Nolan",
@@ -15436,7 +15436,7 @@
         ],
         [
           "Mary Parsley",
-          "Karin Abicht"
+          "Carin Abicht"
         ],
         [
           "Jasper Kittle",
@@ -15537,15 +15537,15 @@
         ],
         [
           "Karen",
-          "Celine Fontange"
+          "Celine Fontanges"
         ],
         [
           "Becky",
-          "Katharina v. Keller"
+          "Katharina von Keller"
         ],
         [
           "Felicia Sparing",
-          "Rhea Harder"
+          "Rhea Harder-Vennewald"
         ],
         [
           "Mrs. Amelia Sparing",
@@ -15670,7 +15670,7 @@
         ],
         [
           "Eddy Reardon",
-          "Lukas Sperber"
+          "Lukas T. Sperber"
         ],
         [
           "Spanier",
@@ -15960,7 +15960,7 @@
         ],
         [
           "Althena",
-          "Steffi Kirchberger"
+          "Stephanie Damare"
         ],
         [
           "Sarah Livingston",
@@ -16339,7 +16339,7 @@
         ],
         [
           "Davy Swann",
-          "Thorsten Sense"
+          "Torsten Sense"
         ],
         [
           "Inspektor Cotta",
@@ -16451,7 +16451,7 @@
         ],
         [
           "Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Inspektor Cotta",
@@ -16610,7 +16610,7 @@
         ],
         [
           "Otis Stamper",
-          "Klaus Dittman"
+          "Klaus Dittmann"
         ],
         [
           "Jonathan Black",
@@ -16622,11 +16622,11 @@
         ],
         [
           "Klara Kowalski",
-          "Steffi Kirchberger"
+          "Stephanie Damare"
         ],
         [
           "Silvester Proud",
-          "Gustav A. Artz"
+          "Gustav Adolph Artz"
         ],
         [
           "Pfarrer Clark",
@@ -16735,7 +16735,7 @@
         ],
         [
           "Onkel Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Inspektor Cotta",
@@ -16779,7 +16779,7 @@
         ],
         [
           "Butler",
-          "Olaf Kreuzenbeck"
+          "Olaf Kreutzenbeck"
         ]
       ],
       "links" : {
@@ -16904,7 +16904,7 @@
         ],
         [
           "Candace Duskin",
-          "Andrea Linau"
+          "Andrea Lienau"
         ],
         [
           "George Bennet",
@@ -17164,7 +17164,7 @@
         ],
         [
           "Onkel Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Arthur Sinclair",
@@ -17292,7 +17292,7 @@
         ],
         [
           "Takasi Yukawa",
-          "Wilfried Diallaz"
+          "Wilfried Dziallas"
         ],
         [
           "Frank Hektor",
@@ -17440,7 +17440,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda",
@@ -18031,7 +18031,7 @@
             ],
             [
               "Taylor",
-              "Bernhard Hoecker"
+              "Bernhard Hoëcker"
             ],
             [
               "Inspektor Cotta",
@@ -18170,7 +18170,7 @@
             ],
             [
               "Taylor",
-              "Bernhard Hoecker"
+              "Bernhard Hoëcker"
             ],
             [
               "Mr. Smith",
@@ -18218,7 +18218,7 @@
             ],
             [
               "Feuerwehrmann",
-              "Kai-Hendrik Möller"
+              "Kai Henrik Möller"
             ],
             [
               "Kapitän",
@@ -18320,7 +18320,7 @@
             ],
             [
               "Taylor",
-              "Bernhard Hoecker"
+              "Bernhard Hoëcker"
             ],
             [
               "Curtis Fisher",
@@ -18360,7 +18360,7 @@
             ],
             [
               "Sanitäter",
-              "Robert Kottula"
+              "Robert Kotulla"
             ],
             [
               "Anudhara",
@@ -18434,7 +18434,7 @@
         ],
         [
           "Taylor",
-          "Bernhard Hoecker"
+          "Bernhard Hoëcker"
         ],
         [
           "Inspektor Cotta",
@@ -18490,7 +18490,7 @@
         ],
         [
           "Feuerwehrmann",
-          "Kai-Hendrik Möller"
+          "Kai Henrik Möller"
         ],
         [
           "Kapitän",
@@ -18506,7 +18506,7 @@
         ],
         [
           "Sanitäter",
-          "Robert Kottula"
+          "Robert Kotulla"
         ],
         [
           "Anudhara",
@@ -18640,7 +18640,7 @@
         ],
         [
           "Goldie Hopkins",
-          "Madeleine Weingarten"
+          "Madeleine Weingart"
         ],
         [
           "Neil Rockwell",
@@ -18828,7 +18828,7 @@
         ],
         [
           "2. Mann",
-          "Jo Kappl"
+          "Joachim Kappl"
         ],
         [
           "Verkäufer",
@@ -18987,7 +18987,7 @@
         ],
         [
           "Live-Kommentator",
-          "Ulli Potofski"
+          "Ulrich Potofski"
         ],
         [
           "Ansager",
@@ -19104,7 +19104,7 @@
         ],
         [
           "Titus Jonas",
-          "Hans Meinhard"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda",
@@ -19112,7 +19112,7 @@
         ],
         [
           "Prof. Jane Heathcliff",
-          "Victoria von Trauttmansdorff"
+          "Victoria Trauttmansdorff"
         ],
         [
           "Kommissar Reynolds",
@@ -19140,7 +19140,7 @@
         ],
         [
           "Mr. Burke",
-          "Kai-Hendrik Möller"
+          "Kai Henrik Möller"
         ],
         [
           "Miss Trimble",
@@ -19292,7 +19292,7 @@
         ],
         [
           "Mary-Ann Leigh",
-          "Manuela Bäcker"
+          "Manuela Eifrig"
         ],
         [
           "Latona Johnson",
@@ -19455,7 +19455,7 @@
         ],
         [
           "Al Dahab",
-          "Neil Malik"
+          "Neil Malik Abdullah"
         ],
         [
           "Frau",
@@ -19575,7 +19575,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Riese",
@@ -19736,7 +19736,7 @@
         ],
         [
           "Vladas Abakulow",
-          "Eric Schäffler"
+          "Erik Schäffler"
         ],
         [
           "Moody Firthway",
@@ -19863,7 +19863,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Inspektor Cotta",
@@ -19871,7 +19871,7 @@
         ],
         [
           "Caroline Cotta",
-          "Michaela Mahlich"
+          "Micaëla Kreißler"
         ],
         [
           "Morton",
@@ -20380,7 +20380,7 @@
         ],
         [
           "Fynch",
-          "Stefan Benson"
+          "Stephan Benson"
         ],
         [
           "Inspektor Cotta",
@@ -20494,19 +20494,19 @@
         ],
         [
           "Freddy Hays",
-          "Woody Mues"
-        ],
-        [
-          "Trainer",
           "Bruno F. Apitz"
         ],
         [
+          "Trainer",
+          "Woody Mues"
+        ],
+        [
           "Mann",
-          "Wolfram Winfried"
+          "Wolfram Winfried [Wolfram Damerius]"
         ],
         [
           "Junge",
-          "Francesco Nieheim"
+          "Francesco Nieheim [Frank Boldewin]"
         ],
         [
           "Spieler",
@@ -20869,11 +20869,11 @@
         ],
         [
           "Nicky DeLores",
-          "Morgens von Gadow"
+          "Mogens von Gadow"
         ],
         [
           "Miss Woodrow",
-          "Karin Abicht"
+          "Carin Abicht"
         ],
         [
           "Judy Nigel",
@@ -20896,8 +20896,12 @@
           "Sascha Draeger"
         ],
         [
-          "Mädchen",
-          "Nicola Melissian"
+          "Mädchen 1",
+          "Julia Fölster"
+        ],
+        [
+          "Mädchen 2",
+          "Saskia Weckler"
         ],
         [
           "Inspektor Cotta",
@@ -20913,7 +20917,7 @@
         ],
         [
           "Ned",
-          "Bruno Ploeger"
+          "Bruno Ploeger [Charles Rettinghaus]"
         ]
       ],
       "links" : {
@@ -21003,15 +21007,15 @@
         ],
         [
           "Deborah",
-          "Gabi Libbach"
+          "Gabriele Libbach"
         ],
         [
-          "Cotta",
+          "Inspektor Cotta",
           "Holger Mahlich"
         ],
         [
           "Samuel Rodman",
-          "Christian Concillio"
+          "Christian Concilio"
         ],
         [
           "Benjamin Rodman",
@@ -21039,7 +21043,7 @@
         ],
         [
           "Journalistin",
-          "Nicola Melissian"
+          "Nicolá Melissian"
         ],
         [
           "Prescott",
@@ -21149,7 +21153,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda",
@@ -21157,7 +21161,7 @@
         ],
         [
           "Bradley",
-          "Nico König"
+          "Nicolas König"
         ],
         [
           "Bishop Blake",
@@ -21328,7 +21332,7 @@
         ],
         [
           "Casino-Besucher",
-          "Robin Bosch"
+          "Robin Brosch"
         ],
         [
           "Casino-Besucherin",
@@ -21466,7 +21470,7 @@
         ],
         [
           "Jimmy Blue Eye",
-          "Ulli Potofski"
+          "Ulrich Potofski"
         ],
         [
           "1. Mann",
@@ -21490,7 +21494,7 @@
         ],
         [
           "Jessy",
-          "Manuela Bäcker"
+          "Manuela Eifrig"
         ],
         [
           "Sergeant",
@@ -21731,7 +21735,7 @@
         ],
         [
           "Gwendolyn Pembroke",
-          "Aranka Mamero"
+          "Aranka Jaenke-Mamero"
         ],
         [
           "Lance Vaughn",
@@ -22014,7 +22018,7 @@
             ],
             [
               "Barfrau",
-              "Rhesi Underberg"
+              "Theresa Underberg"
             ],
             [
               "John",
@@ -22255,7 +22259,7 @@
             ],
             [
               "Ivy",
-              "Leonie Lander"
+              "Leonie Landa"
             ],
             [
               "Prof. Haynthorb",
@@ -22364,7 +22368,7 @@
         ],
         [
           "Barfrau",
-          "Rhesi Underberg"
+          "Theresa Underberg"
         ],
         [
           "John",
@@ -22420,7 +22424,7 @@
         ],
         [
           "Ivy",
-          "Leonie Lander"
+          "Leonie Landa"
         ],
         [
           "Prof. Haynthorb",
@@ -22682,7 +22686,7 @@
         ],
         [
           "Polizist",
-          "Kai-Hendrik Möller"
+          "Kai Henrik Möller"
         ]
       ],
       "links" : {
@@ -22907,7 +22911,7 @@
         ],
         [
           "Stephen",
-          "Alexander Kruuse-Mettin"
+          "Alexander Mettin"
         ],
         [
           "Billy",
@@ -23015,7 +23019,7 @@
         ],
         [
           "Chef",
-          "Eric Schäffler"
+          "Erik Schäffler"
         ],
         [
           "Ron",
@@ -23242,6 +23246,10 @@
         ],
         [
           "Godween",
+          "André Minninger"
+        ],
+        [
+          "Busfahrer",
           "Rüdiger Schulzki"
         ],
         [
@@ -23257,12 +23265,8 @@
           "Pia Werfel"
         ],
         [
-          "Rosemarie Wohlbauer",
+          "Edna Shinefield",
           "Rosemarie Wohlbauer"
-        ],
-        [
-          "Shinefield, Edna",
-          "Edna Shinefield"
         ],
         [
           "George",
@@ -23422,7 +23426,7 @@
         ],
         [
           "Frank Wheeler",
-          "Timo Wenzel"
+          "Timo Alexander Wenzel"
         ],
         [
           "Joe",
@@ -23438,7 +23442,7 @@
         ],
         [
           "Partygäste",
-          "Die Gäste der Record-Release-Party am 8. Mai 2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
+          "Die Gäste der Record-Release-Party am 08.05.2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
         ]
       ],
       "links" : {
@@ -23657,11 +23661,11 @@
         ],
         [
           "Mrs. Carrington",
-          "Manuela Dahm-Mauerhofer"
+          "Manuela Dahm"
         ],
         [
           "Liza Hawkins",
-          "Lucia Angela Mahler"
+          "Lucia-Angelina Mahler"
         ],
         [
           "Mr. Hawkins",
@@ -23801,7 +23805,7 @@
         ],
         [
           "Ellyn Djawadi",
-          "Anika Pages"
+          "Annika Pages"
         ],
         [
           "Mr. Turner",
@@ -24751,7 +24755,7 @@
         ],
         [
           "Angela",
-          "Lucia Mahler"
+          "Lucia-Angelina Mahler"
         ],
         [
           "Conchita Dominguez",
@@ -24759,7 +24763,7 @@
         ],
         [
           "Reporter",
-          "Jörgpeter von Clarenau"
+          "Jörgpeter Ahlers"
         ],
         [
           "Putzfrau",
@@ -25128,11 +25132,11 @@
         ],
         [
           "George",
-          "Mars Saibert"
+          "Marcel Saibert"
         ],
         [
           "Mann",
-          "Gunnar Bergmann"
+          "Gunnar Bergmann [Peter Flechtner]"
         ]
       ],
       "links" : {
@@ -25799,7 +25803,7 @@
         ],
         [
           "Polizist",
-          "Mars Saibert"
+          "Marcel Saibert"
         ],
         [
           "Officer",
@@ -26180,7 +26184,7 @@
         ],
         [
           "Mary",
-          "Marion Gretchen-Schmitz"
+          "Marion Gretchen Schmitz"
         ],
         [
           "Tante Mathilda",
@@ -26414,7 +26418,7 @@
         ],
         [
           "Liane Shore",
-          "Sadra Keck"
+          "Sandra Keck"
         ]
       ],
       "links" : {
@@ -27364,7 +27368,7 @@
         ],
         [
           "Sarah",
-          "Jana Schmidt"
+          "Jana Catharina Schmidt"
         ],
         [
           "Eric",
@@ -27583,7 +27587,7 @@
         ],
         [
           "Mrs. Julia Scott",
-          "Stephanie Kirchberger"
+          "Stephanie Damare"
         ],
         [
           "Onkel Titus",
@@ -28193,7 +28197,7 @@
         ],
         [
           "Telefonstimme",
-          "Nico König"
+          "Nicolas König"
         ],
         [
           "Colstone",
@@ -28308,7 +28312,7 @@
         ],
         [
           "Roberta",
-          "Pamela Punti"
+          "Pamela Punti [Heikedine Körting]"
         ],
         [
           "Evander Prettyman",

--- a/data/Master_Spezial.json
+++ b/data/Master_Spezial.json
@@ -168,67 +168,68 @@
           "end" : 5400124
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mr. Claudius, Kunsthändler",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Mrs. Claudius",
-          "Brigitte Böttrich"
-        ],
-        [
-          "Mr. Fentriss, Schriftsteller",
-          "Detlef Bierstedt"
-        ],
-        [
-          "Hugenay",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Carlos",
-          "Stefan Brönneke"
-        ],
-        [
-          "Onkel Ramos",
-          "Dario Bertoli [Detlef Bierstedt]"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Opa",
-          "Harry Rowohlt"
-        ],
-        [
-          "Miss Waggoner",
-          "Ursula Vogel"
-        ],
-        [
-          "Senora",
-          "Barbara Benuel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mr. Claudius, Kunsthändler",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Mrs. Claudius",
+          "sprecher" : "Brigitte Böttrich"
+        },
+        {
+          "rolle" : "Mr. Fentriss, Schriftsteller",
+          "sprecher" : "Detlef Bierstedt"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Carlos",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Onkel Ramos",
+          "sprecher" : "Detlef Bierstedt",
+          "pseudonym" : "Dario Bertoli"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Opa",
+          "sprecher" : "Harry Rowohlt"
+        },
+        {
+          "rolle" : "Miss Waggoner",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Senora",
+          "sprecher" : "Barbara Benuel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/metadata.json",
@@ -311,99 +312,100 @@
               "end" : 4757160
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda",
-              "Karin Lieneweg"
-            ],
-            [
-              "Onkel Titus",
-              "Hans Meinhardt [Andreas E. Beurmann]"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Officer Flann Doyle",
-              "Douglas Welbat"
-            ],
-            [
-              "Tanya Sullivan",
-              "Marion Elskis"
-            ],
-            [
-              "Sebastian Dawson",
-              "Bastian Pastewka"
-            ],
-            [
-              "Miss Tomkins",
-              "Stephanie Damare"
-            ],
-            [
-              "Mr. Foley",
-              "Dirk Bach"
-            ],
-            [
-              "John Gabbin",
-              "Tobias Schmidt"
-            ],
-            [
-              "Matthew Gabbin",
-              "Jürgen Thormann"
-            ],
-            [
-              "Georgina",
-              "Maud Ackermann"
-            ],
-            [
-              "Gil Renard",
-              "Udo Schenk"
-            ],
-            [
-              "Hedy Carlson",
-              "Luise Helm"
-            ],
-            [
-              "Steve",
-              "Sascha Draeger"
-            ],
-            [
-              "Jack",
-              "Hendrik Buchna"
-            ],
-            [
-              "Laury",
-              "Rhea Harder-Vennewald"
-            ],
-            [
-              "Gast 1",
-              "Christian Senger"
-            ],
-            [
-              "Fahrerin",
-              "Corinna Wodrich"
-            ],
-            [
-              "Radiosprecher",
-              "Tobias Meister"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Officer Flann Doyle",
+              "sprecher" : "Douglas Welbat"
+            },
+            {
+              "rolle" : "Tanya Sullivan",
+              "sprecher" : "Marion Elskis"
+            },
+            {
+              "rolle" : "Sebastian Dawson",
+              "sprecher" : "Bastian Pastewka"
+            },
+            {
+              "rolle" : "Miss Tomkins",
+              "sprecher" : "Stephanie Damare"
+            },
+            {
+              "rolle" : "Mr. Foley",
+              "sprecher" : "Dirk Bach"
+            },
+            {
+              "rolle" : "John Gabbin",
+              "sprecher" : "Tobias Schmidt"
+            },
+            {
+              "rolle" : "Matthew Gabbin",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Georgina",
+              "sprecher" : "Maud Ackermann"
+            },
+            {
+              "rolle" : "Gil Renard",
+              "sprecher" : "Udo Schenk"
+            },
+            {
+              "rolle" : "Hedy Carlson",
+              "sprecher" : "Luise Helm"
+            },
+            {
+              "rolle" : "Steve",
+              "sprecher" : "Sascha Draeger"
+            },
+            {
+              "rolle" : "Jack",
+              "sprecher" : "Hendrik Buchna"
+            },
+            {
+              "rolle" : "Laury",
+              "sprecher" : "Rhea Harder-Vennewald"
+            },
+            {
+              "rolle" : "Gast 1",
+              "sprecher" : "Christian Senger"
+            },
+            {
+              "rolle" : "Fahrerin",
+              "sprecher" : "Corinna Wodrich"
+            },
+            {
+              "rolle" : "Radiosprecher",
+              "sprecher" : "Tobias Meister"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/1/metadata.json",
@@ -479,95 +481,95 @@
               "end" : 3904933
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda",
-              "Karin Lieneweg"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Officer Flann Doyle",
-              "Douglas Welbat"
-            ],
-            [
-              "Gil Renard",
-              "Udo Schenk"
-            ],
-            [
-              "Hedy Carlson",
-              "Luise Helm"
-            ],
-            [
-              "Peter Foster",
-              "Gerrit Schmidt-Foß"
-            ],
-            [
-              "Mrs. Shaw",
-              "Isabella Grothe"
-            ],
-            [
-              "Sebastian Dawson",
-              "Bastian Pastewka"
-            ],
-            [
-              "Annie Wilkes",
-              "Regina Lemnitz"
-            ],
-            [
-              "Mädchen 1",
-              "Katinka Körting"
-            ],
-            [
-              "Mädchen 2",
-              "Jacqueline Meybauer"
-            ],
-            [
-              "Georgina",
-              "Maud Ackermann"
-            ],
-            [
-              "Alter Mann",
-              "Jörg Gillner"
-            ],
-            [
-              "Junger Mann",
-              "Patrick Bach"
-            ],
-            [
-              "Dick Perry",
-              "Ernst H. Hilbich"
-            ],
-            [
-              "Matthew Gabbin",
-              "Jürgen Thormann"
-            ],
-            [
-              "Steve",
-              "Sascha Draeger"
-            ],
-            [
-              "Radiosprecher",
-              "Tobias Meister"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Officer Flann Doyle",
+              "sprecher" : "Douglas Welbat"
+            },
+            {
+              "rolle" : "Gil Renard",
+              "sprecher" : "Udo Schenk"
+            },
+            {
+              "rolle" : "Hedy Carlson",
+              "sprecher" : "Luise Helm"
+            },
+            {
+              "rolle" : "Peter Foster",
+              "sprecher" : "Gerrit Schmidt-Foß"
+            },
+            {
+              "rolle" : "Mrs. Shaw",
+              "sprecher" : "Isabella Grothe"
+            },
+            {
+              "rolle" : "Sebastian Dawson",
+              "sprecher" : "Bastian Pastewka"
+            },
+            {
+              "rolle" : "Annie Wilkes",
+              "sprecher" : "Regina Lemnitz"
+            },
+            {
+              "rolle" : "Mädchen 1",
+              "sprecher" : "Katinka Körting"
+            },
+            {
+              "rolle" : "Mädchen 2",
+              "sprecher" : "Jacqueline Meybauer"
+            },
+            {
+              "rolle" : "Georgina",
+              "sprecher" : "Maud Ackermann"
+            },
+            {
+              "rolle" : "Alter Mann",
+              "sprecher" : "Jörg Gillner"
+            },
+            {
+              "rolle" : "Junger Mann",
+              "sprecher" : "Patrick Bach"
+            },
+            {
+              "rolle" : "Dick Perry",
+              "sprecher" : "Ernst H. Hilbich"
+            },
+            {
+              "rolle" : "Matthew Gabbin",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Steve",
+              "sprecher" : "Sascha Draeger"
+            },
+            {
+              "rolle" : "Radiosprecher",
+              "sprecher" : "Tobias Meister"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/2/metadata.json",
@@ -658,131 +660,131 @@
               "end" : 4416000
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda",
-              "Karin Lieneweg"
-            ],
-            [
-              "Mr. Andrews",
-              "Henry König"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Miss Bennett",
-              "Renate Pichler"
-            ],
-            [
-              "Dick Perry",
-              "Ernst H. Hilbich"
-            ],
-            [
-              "Walter Bush",
-              "Rolf E. Schenker"
-            ],
-            [
-              "Officer Flann Doyle",
-              "Douglas Welbat"
-            ],
-            [
-              "Ian Bush",
-              "Sky du Mont / Lukas T. Sperber"
-            ],
-            [
-              "Jimmy Sinclair",
-              "Siegfried W. Kernen / Nils Noller"
-            ],
-            [
-              "Charlie Parker",
-              "Oliver Böttcher / Laurence Kalaidjian"
-            ],
-            [
-              "Brianna Jackson",
-              "Hansi Jochmann / Natalie Demtrøder"
-            ],
-            [
-              "Chloe Smathers",
-              "Valerie Demtrøder"
-            ],
-            [
-              "Joseph Quick",
-              "Harry Rowohlt"
-            ],
-            [
-              "Mr. Raynes",
-              "Olaf Kreutzenbeck"
-            ],
-            [
-              "Jeff White",
-              "Horst Naumann"
-            ],
-            [
-              "Hedy Carlson",
-              "Luise Helm"
-            ],
-            [
-              "Gil Renard",
-              "Udo Schenk"
-            ],
-            [
-              "Peter Foster",
-              "Gerrit Schmidt-Foß"
-            ],
-            [
-              "Matthew Gabbin",
-              "Jürgen Thormann"
-            ],
-            [
-              "Steve",
-              "Sascha Draeger"
-            ],
-            [
-              "Laury",
-              "Rhea Harder-Vennewald"
-            ],
-            [
-              "Georgina",
-              "Maud Ackermann"
-            ],
-            [
-              "Bedienung",
-              "Tim Wenderoth"
-            ],
-            [
-              "Gast",
-              "Andreas Otto"
-            ],
-            [
-              "Sekretärin",
-              "Corinna Wodrich"
-            ],
-            [
-              "Sebastian Dawson",
-              "Bastian Pastewka"
-            ],
-            [
-              "Radiosprecher",
-              "Tobias Meister"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Miss Bennett",
+              "sprecher" : "Renate Pichler"
+            },
+            {
+              "rolle" : "Dick Perry",
+              "sprecher" : "Ernst H. Hilbich"
+            },
+            {
+              "rolle" : "Walter Bush",
+              "sprecher" : "Rolf E. Schenker"
+            },
+            {
+              "rolle" : "Officer Flann Doyle",
+              "sprecher" : "Douglas Welbat"
+            },
+            {
+              "rolle" : "Ian Bush",
+              "sprecher" : "Sky du Mont / Lukas T. Sperber"
+            },
+            {
+              "rolle" : "Jimmy Sinclair",
+              "sprecher" : "Siegfried W. Kernen / Nils Noller"
+            },
+            {
+              "rolle" : "Charlie Parker",
+              "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+            },
+            {
+              "rolle" : "Brianna Jackson",
+              "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+            },
+            {
+              "rolle" : "Chloe Smathers",
+              "sprecher" : "Valerie Demtrøder"
+            },
+            {
+              "rolle" : "Joseph Quick",
+              "sprecher" : "Harry Rowohlt"
+            },
+            {
+              "rolle" : "Mr. Raynes",
+              "sprecher" : "Olaf Kreutzenbeck"
+            },
+            {
+              "rolle" : "Jeff White",
+              "sprecher" : "Horst Naumann"
+            },
+            {
+              "rolle" : "Hedy Carlson",
+              "sprecher" : "Luise Helm"
+            },
+            {
+              "rolle" : "Gil Renard",
+              "sprecher" : "Udo Schenk"
+            },
+            {
+              "rolle" : "Peter Foster",
+              "sprecher" : "Gerrit Schmidt-Foß"
+            },
+            {
+              "rolle" : "Matthew Gabbin",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Steve",
+              "sprecher" : "Sascha Draeger"
+            },
+            {
+              "rolle" : "Laury",
+              "sprecher" : "Rhea Harder-Vennewald"
+            },
+            {
+              "rolle" : "Georgina",
+              "sprecher" : "Maud Ackermann"
+            },
+            {
+              "rolle" : "Bedienung",
+              "sprecher" : "Tim Wenderoth"
+            },
+            {
+              "rolle" : "Gast",
+              "sprecher" : "Andreas Otto"
+            },
+            {
+              "rolle" : "Sekretärin",
+              "sprecher" : "Corinna Wodrich"
+            },
+            {
+              "rolle" : "Sebastian Dawson",
+              "sprecher" : "Bastian Pastewka"
+            },
+            {
+              "rolle" : "Radiosprecher",
+              "sprecher" : "Tobias Meister"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/3/metadata.json",
@@ -795,187 +797,188 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Kann ein und derselbe Tag dreimal völlig unterschiedlich verlaufen? Kann ein unscheinbares Detail wie ein Colaglas darüber entscheiden, wie sich alle weiteren Geschehnisse entwickeln? Erlebe, wie Justus, Peter und Bob auf den unheimlichen Fluch der Sheldon Street, die mysteriösen Zeichen der Ritter stoßen und den bedrohlichen Fremden Freund stoßen – und zwar zeitgleich am selben Tag!\nDrei Geschichten von drei Autoren führen dich dreimal durch einen Tag, wie er unterschiedlicher nicht verlaufen könnte.",
       "veröffentlichungsdatum" : "2010-10-01",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Officer Flann Doyle",
-          "Douglas Welbat"
-        ],
-        [
-          "Tanya Sullivan",
-          "Marion Elskis"
-        ],
-        [
-          "Sebastian Dawson",
-          "Bastian Pastewka"
-        ],
-        [
-          "Miss Tomkins",
-          "Stephanie Damare"
-        ],
-        [
-          "Mr. Foley",
-          "Dirk Bach"
-        ],
-        [
-          "John Gabbin",
-          "Tobias Schmidt"
-        ],
-        [
-          "Matthew Gabbin",
-          "Jürgen Thormann"
-        ],
-        [
-          "Georgina",
-          "Maud Ackermann"
-        ],
-        [
-          "Gil Renard",
-          "Udo Schenk"
-        ],
-        [
-          "Hedy Carlson",
-          "Luise Helm"
-        ],
-        [
-          "Steve",
-          "Sascha Draeger"
-        ],
-        [
-          "Jack",
-          "Hendrik Buchna"
-        ],
-        [
-          "Laury",
-          "Rhea Harder-Vennewald"
-        ],
-        [
-          "Gast 1",
-          "Christian Senger"
-        ],
-        [
-          "Fahrerin",
-          "Corinna Wodrich"
-        ],
-        [
-          "Radiosprecher",
-          "Tobias Meister"
-        ],
-        [
-          "Peter Foster",
-          "Gerrit Schmidt-Foß"
-        ],
-        [
-          "Mrs. Shaw",
-          "Isabella Grothe"
-        ],
-        [
-          "Annie Wilkes",
-          "Regina Lemnitz"
-        ],
-        [
-          "Mädchen 1",
-          "Katinka Körting"
-        ],
-        [
-          "Mädchen 2",
-          "Jacqueline Meybauer"
-        ],
-        [
-          "Alter Mann",
-          "Jörg Gillner"
-        ],
-        [
-          "Junger Mann",
-          "Patrick Bach"
-        ],
-        [
-          "Dick Perry",
-          "Ernst H. Hilbich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Miss Bennett",
-          "Renate Pichler"
-        ],
-        [
-          "Walter Bush",
-          "Rolf E. Schenker"
-        ],
-        [
-          "Ian Bush",
-          "Sky du Mont / Lukas T. Sperber"
-        ],
-        [
-          "Jimmy Sinclair",
-          "Siegfried W. Kernen / Nils Noller"
-        ],
-        [
-          "Charlie Parker",
-          "Oliver Böttcher / Laurence Kalaidjian"
-        ],
-        [
-          "Brianna Jackson",
-          "Hansi Jochmann / Natalie Demtrøder"
-        ],
-        [
-          "Chloe Smathers",
-          "Valerie Demtrøder"
-        ],
-        [
-          "Joseph Quick",
-          "Harry Rowohlt"
-        ],
-        [
-          "Mr. Raynes",
-          "Olaf Kreutzenbeck"
-        ],
-        [
-          "Jeff White",
-          "Horst Naumann"
-        ],
-        [
-          "Bedienung",
-          "Tim Wenderoth"
-        ],
-        [
-          "Gast 2",
-          "Andreas Otto"
-        ],
-        [
-          "Sekretärin",
-          "Corinna Wodrich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Officer Flann Doyle",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Tanya Sullivan",
+          "sprecher" : "Marion Elskis"
+        },
+        {
+          "rolle" : "Sebastian Dawson",
+          "sprecher" : "Bastian Pastewka"
+        },
+        {
+          "rolle" : "Miss Tomkins",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Mr. Foley",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "John Gabbin",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Matthew Gabbin",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Georgina",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Gil Renard",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Hedy Carlson",
+          "sprecher" : "Luise Helm"
+        },
+        {
+          "rolle" : "Steve",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Hendrik Buchna"
+        },
+        {
+          "rolle" : "Laury",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Gast 1",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Fahrerin",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Radiosprecher",
+          "sprecher" : "Tobias Meister"
+        },
+        {
+          "rolle" : "Peter Foster",
+          "sprecher" : "Gerrit Schmidt-Foß"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Isabella Grothe"
+        },
+        {
+          "rolle" : "Annie Wilkes",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Mädchen 1",
+          "sprecher" : "Katinka Körting"
+        },
+        {
+          "rolle" : "Mädchen 2",
+          "sprecher" : "Jacqueline Meybauer"
+        },
+        {
+          "rolle" : "Alter Mann",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Junger Mann",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Dick Perry",
+          "sprecher" : "Ernst H. Hilbich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Miss Bennett",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Walter Bush",
+          "sprecher" : "Rolf E. Schenker"
+        },
+        {
+          "rolle" : "Ian Bush",
+          "sprecher" : "Sky du Mont / Lukas T. Sperber"
+        },
+        {
+          "rolle" : "Jimmy Sinclair",
+          "sprecher" : "Siegfried W. Kernen / Nils Noller"
+        },
+        {
+          "rolle" : "Charlie Parker",
+          "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+        },
+        {
+          "rolle" : "Brianna Jackson",
+          "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+        },
+        {
+          "rolle" : "Chloe Smathers",
+          "sprecher" : "Valerie Demtrøder"
+        },
+        {
+          "rolle" : "Joseph Quick",
+          "sprecher" : "Harry Rowohlt"
+        },
+        {
+          "rolle" : "Mr. Raynes",
+          "sprecher" : "Olaf Kreutzenbeck"
+        },
+        {
+          "rolle" : "Jeff White",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Bedienung",
+          "sprecher" : "Tim Wenderoth"
+        },
+        {
+          "rolle" : "Gast 2",
+          "sprecher" : "Andreas Otto"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Corinna Wodrich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/metadata.json",
@@ -1051,99 +1054,101 @@
           "end" : 3675453
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ben",
-          "Fabian Harloff"
-        ],
-        [
-          "Silvia",
-          "Marion von Stengel"
-        ],
-        [
-          "Ralph",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Spud",
-          "Rasmus Borowski"
-        ],
-        [
-          "O-Ian",
-          "Celine Fontanges"
-        ],
-        [
-          "Setch",
-          "Stefan Brönneke"
-        ],
-        [
-          "Hi-Top",
-          "Robin Brosch"
-        ],
-        [
-          "Car",
-          "Volker Hanisch"
-        ],
-        [
-          "Chip-Shape",
-          "Jens Wendland"
-        ],
-        [
-          "Carol",
-          "Alexandra Garcia"
-        ],
-        [
-          "Slide Terranova",
-          "Nicolas König"
-        ],
-        [
-          "P. \"Pejo\" Joseph McGaskill",
-          "Peter Kirchberger"
-        ],
-        [
-          "Sax Sandler",
-          "Christian Concilio"
-        ],
-        [
-          "Hausmeister",
-          "Edgar Bessen"
-        ],
-        [
-          "Bau-Kollege",
-          "Holger Umbreit"
-        ],
-        [
-          "Junge",
-          "Michael Lampe [André Minninger]"
-        ],
-        [
-          "Mädchen",
-          "Pamela Punti [Heikedine Körting]"
-        ],
-        [
-          "Weibl. Offstimme",
-          "Susanne Wulkow"
-        ],
-        [
-          "Werbestimme",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Menge",
-          "Lauscherlounge-Zuschauer (www.dreifragezeichen.de/www/menge-brainwash)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ben",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Silvia",
+          "sprecher" : "Marion von Stengel"
+        },
+        {
+          "rolle" : "Ralph",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Spud",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "O-Ian",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Setch",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Hi-Top",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Car",
+          "sprecher" : "Volker Hanisch"
+        },
+        {
+          "rolle" : "Chip-Shape",
+          "sprecher" : "Jens Wendland"
+        },
+        {
+          "rolle" : "Carol",
+          "sprecher" : "Alexandra Garcia"
+        },
+        {
+          "rolle" : "Slide Terranova",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "P. \"Pejo\" Joseph McGaskill",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Sax Sandler",
+          "sprecher" : "Christian Concilio"
+        },
+        {
+          "rolle" : "Hausmeister",
+          "sprecher" : "Edgar Bessen"
+        },
+        {
+          "rolle" : "Bau-Kollege",
+          "sprecher" : "Holger Umbreit"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "André Minninger",
+          "pseudonym" : "Michael Lampe"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Weibl. Offstimme",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Werbestimme",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Menge",
+          "sprecher" : "Lauscherlounge-Zuschauer (www.dreifragezeichen.de/www/menge-brainwash)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json",
@@ -1294,91 +1299,91 @@
               "end" : 3498480
             }
           ],
-          "sprecher" : [
-            [
-              "Off-Stimme",
-              "Claudia Stocksieker"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tony",
-              "Stefan Kaminski"
-            ],
-            [
-              "Joey",
-              "Tommaso Cacciapuoti"
-            ],
-            [
-              "Ansager in der Schlammringkampfarena",
-              "Christian Rudolf"
-            ],
-            [
-              "Margarine",
-              "Alma Clausen"
-            ],
-            [
-              "Lincolnfahrer",
-              "Mike Olsowski"
-            ],
-            [
-              "Freakshow-Jack",
-              "Peter Bänker"
-            ],
-            [
-              "Der unergründliche Mickey",
-              "Krystian Martinek"
-            ],
-            [
-              "Die bärtige Marilyn",
-              "Santiago Ziesmer"
-            ],
-            [
-              "Miss Luzzy",
-              "Katja Brügger"
-            ],
-            [
-              "Bubba Detroit",
-              "Klaus Dittmann"
-            ],
-            [
-              "Junge",
-              "Patrick Bach"
-            ],
-            [
-              "Burger-Verkäufer Arnie",
-              "Manou Lubowski"
-            ],
-            [
-              "Reporterin",
-              "Mara Bergmann"
-            ],
-            [
-              "Anna Millar",
-              "Christine Pappert"
-            ],
-            [
-              "Bombenattentäter Daniel",
-              "Tim Grobe"
-            ],
-            [
-              "Polizist",
-              "Wolfgang Kaven"
-            ],
-            [
-              "Blacky",
-              "Heikedine Körting"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Off-Stimme",
+              "sprecher" : "Claudia Stocksieker"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tony",
+              "sprecher" : "Stefan Kaminski"
+            },
+            {
+              "rolle" : "Joey",
+              "sprecher" : "Tommaso Cacciapuoti"
+            },
+            {
+              "rolle" : "Ansager in der Schlammringkampfarena",
+              "sprecher" : "Christian Rudolf"
+            },
+            {
+              "rolle" : "Margarine",
+              "sprecher" : "Alma Clausen"
+            },
+            {
+              "rolle" : "Lincolnfahrer",
+              "sprecher" : "Mike Olsowski"
+            },
+            {
+              "rolle" : "Freakshow-Jack",
+              "sprecher" : "Peter Bänker"
+            },
+            {
+              "rolle" : "Der unergründliche Mickey",
+              "sprecher" : "Krystian Martinek"
+            },
+            {
+              "rolle" : "Die bärtige Marilyn",
+              "sprecher" : "Santiago Ziesmer"
+            },
+            {
+              "rolle" : "Miss Luzzy",
+              "sprecher" : "Katja Brügger"
+            },
+            {
+              "rolle" : "Bubba Detroit",
+              "sprecher" : "Klaus Dittmann"
+            },
+            {
+              "rolle" : "Junge",
+              "sprecher" : "Patrick Bach"
+            },
+            {
+              "rolle" : "Burger-Verkäufer Arnie",
+              "sprecher" : "Manou Lubowski"
+            },
+            {
+              "rolle" : "Reporterin",
+              "sprecher" : "Mara Bergmann"
+            },
+            {
+              "rolle" : "Anna Millar",
+              "sprecher" : "Christine Pappert"
+            },
+            {
+              "rolle" : "Bombenattentäter Daniel",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Polizist",
+              "sprecher" : "Wolfgang Kaven"
+            },
+            {
+              "rolle" : "Blacky",
+              "sprecher" : "Heikedine Körting"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/1/metadata.json",
@@ -1679,79 +1684,79 @@
               "end" : 4497427
             }
           ],
-          "sprecher" : [
-            [
-              "Off-Stimme",
-              "Claudia Stocksieker"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tony",
-              "Stefan Kaminski"
-            ],
-            [
-              "Joey",
-              "Tommaso Cacciapuoti"
-            ],
-            [
-              "Anna Millar",
-              "Christine Pappert"
-            ],
-            [
-              "Lily",
-              "Verena Wolfien"
-            ],
-            [
-              "Max",
-              "Holger Umbreit"
-            ],
-            [
-              "Milli",
-              "Ulrike Knief"
-            ],
-            [
-              "Celeste Hummer",
-              "Maria Willer"
-            ],
-            [
-              "Anthem Hummer",
-              "Martin May"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Blacky",
-              "Heikedine Körting"
-            ],
-            [
-              "Bruce Millar",
-              "Ben Hecker"
-            ],
-            [
-              "Kommissar Reynolds",
-              "Wolfgang Draeger"
-            ],
-            [
-              "Albert Hitfield",
-              "Volker Bogdan"
-            ],
-            [
-              "TV-Sprecher",
-              "Friedel Bott"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Off-Stimme",
+              "sprecher" : "Claudia Stocksieker"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tony",
+              "sprecher" : "Stefan Kaminski"
+            },
+            {
+              "rolle" : "Joey",
+              "sprecher" : "Tommaso Cacciapuoti"
+            },
+            {
+              "rolle" : "Anna Millar",
+              "sprecher" : "Christine Pappert"
+            },
+            {
+              "rolle" : "Lily",
+              "sprecher" : "Verena Wolfien"
+            },
+            {
+              "rolle" : "Max",
+              "sprecher" : "Holger Umbreit"
+            },
+            {
+              "rolle" : "Milli",
+              "sprecher" : "Ulrike Knief"
+            },
+            {
+              "rolle" : "Celeste Hummer",
+              "sprecher" : "Maria Willer"
+            },
+            {
+              "rolle" : "Anthem Hummer",
+              "sprecher" : "Martin May"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Blacky",
+              "sprecher" : "Heikedine Körting"
+            },
+            {
+              "rolle" : "Bruce Millar",
+              "sprecher" : "Ben Hecker"
+            },
+            {
+              "rolle" : "Kommissar Reynolds",
+              "sprecher" : "Wolfgang Draeger"
+            },
+            {
+              "rolle" : "Albert Hitfield",
+              "sprecher" : "Volker Bogdan"
+            },
+            {
+              "rolle" : "TV-Sprecher",
+              "sprecher" : "Friedel Bott"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/2/metadata.json",
@@ -2056,131 +2061,131 @@
           "end" : 7594170
         }
       ],
-      "sprecher" : [
-        [
-          "Off-Stimme",
-          "Claudia Stocksieker"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tony",
-          "Stefan Kaminski"
-        ],
-        [
-          "Joey",
-          "Tommaso Cacciapuoti"
-        ],
-        [
-          "Ansager in der Schlammringkampfarena",
-          "Christian Rudolf"
-        ],
-        [
-          "Margarine",
-          "Alma Clausen"
-        ],
-        [
-          "Lincolnfahrer",
-          "Mike Olsowski"
-        ],
-        [
-          "Freakshow-Jack",
-          "Peter Bänker"
-        ],
-        [
-          "Der unergründliche Mickey",
-          "Krystian Martinek"
-        ],
-        [
-          "Die bärtige Marilyn",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Miss Luzzy",
-          "Katja Brügger"
-        ],
-        [
-          "Bubba Detroit",
-          "Klaus Dittmann"
-        ],
-        [
-          "Junge",
-          "Patrick Bach"
-        ],
-        [
-          "Burger-Verkäufer Arnie",
-          "Manou Lubowski"
-        ],
-        [
-          "Reporterin",
-          "Mara Bergmann"
-        ],
-        [
-          "Anna Millar",
-          "Christine Pappert"
-        ],
-        [
-          "Bombenattentäter Daniel",
-          "Tim Grobe"
-        ],
-        [
-          "Polizist",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Lily",
-          "Verena Wolfien"
-        ],
-        [
-          "Max",
-          "Holger Umbreit"
-        ],
-        [
-          "Milli",
-          "Ulrike Knief"
-        ],
-        [
-          "Celeste Hummer",
-          "Maria Willer"
-        ],
-        [
-          "Anthem Hummer",
-          "Martin May"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Bruce Millar",
-          "Ben Hecker"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Albert Hitfield",
-          "Volker Bogdan"
-        ],
-        [
-          "TV-Sprecher",
-          "Friedel Bott"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Off-Stimme",
+          "sprecher" : "Claudia Stocksieker"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Stefan Kaminski"
+        },
+        {
+          "rolle" : "Joey",
+          "sprecher" : "Tommaso Cacciapuoti"
+        },
+        {
+          "rolle" : "Ansager in der Schlammringkampfarena",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Margarine",
+          "sprecher" : "Alma Clausen"
+        },
+        {
+          "rolle" : "Lincolnfahrer",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Freakshow-Jack",
+          "sprecher" : "Peter Bänker"
+        },
+        {
+          "rolle" : "Der unergründliche Mickey",
+          "sprecher" : "Krystian Martinek"
+        },
+        {
+          "rolle" : "Die bärtige Marilyn",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Miss Luzzy",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Bubba Detroit",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Burger-Verkäufer Arnie",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Reporterin",
+          "sprecher" : "Mara Bergmann"
+        },
+        {
+          "rolle" : "Anna Millar",
+          "sprecher" : "Christine Pappert"
+        },
+        {
+          "rolle" : "Bombenattentäter Daniel",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Lily",
+          "sprecher" : "Verena Wolfien"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Holger Umbreit"
+        },
+        {
+          "rolle" : "Milli",
+          "sprecher" : "Ulrike Knief"
+        },
+        {
+          "rolle" : "Celeste Hummer",
+          "sprecher" : "Maria Willer"
+        },
+        {
+          "rolle" : "Anthem Hummer",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Bruce Millar",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Albert Hitfield",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "TV-Sprecher",
+          "sprecher" : "Friedel Bott"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json",
@@ -2242,59 +2247,59 @@
           "end" : 3170453
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Doktor Ax Me",
-          "Krystian Martinek"
-        ],
-        [
-          "Stinky Rossiter",
-          "Dustin Semmelrogge"
-        ],
-        [
-          "Fear Crowther",
-          "Ingo Nommsen"
-        ],
-        [
-          "Mouth Crosby",
-          "Stefan Gabriel"
-        ],
-        [
-          "Mack Dolland",
-          "Mike Olsowski"
-        ],
-        [
-          "Eric Mukogawa",
-          "Marek Harloff"
-        ],
-        [
-          "Marilla",
-          "Saskia Mayerhoff"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Rosie",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Doktor Ax Me",
+          "sprecher" : "Krystian Martinek"
+        },
+        {
+          "rolle" : "Stinky Rossiter",
+          "sprecher" : "Dustin Semmelrogge"
+        },
+        {
+          "rolle" : "Fear Crowther",
+          "sprecher" : "Ingo Nommsen"
+        },
+        {
+          "rolle" : "Mouth Crosby",
+          "sprecher" : "Stefan Gabriel"
+        },
+        {
+          "rolle" : "Mack Dolland",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Eric Mukogawa",
+          "sprecher" : "Marek Harloff"
+        },
+        {
+          "rolle" : "Marilla",
+          "sprecher" : "Saskia Mayerhoff"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Rosie",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/metadata.json",
@@ -2581,67 +2586,67 @@
           "end" : 10281307
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Lydia Candle",
-          "Monika John"
-        ],
-        [
-          "Jeremias Howard",
-          "Gosta Liptow"
-        ],
-        [
-          "Empfangsdame",
-          "Katja Brügger"
-        ],
-        [
-          "Radiosprecherin",
-          "Simona Pahl"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Patricia Handerson",
-          "Janina Richter"
-        ],
-        [
-          "Polizistin",
-          "Carolin Fortenbacher"
-        ],
-        [
-          "Schausteller",
-          "Eckart Dux"
-        ],
-        [
-          "Edward Candle",
-          "Robin Brosch"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Lydia Candle",
+          "sprecher" : "Monika John"
+        },
+        {
+          "rolle" : "Jeremias Howard",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Empfangsdame",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Radiosprecherin",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Patricia Handerson",
+          "sprecher" : "Janina Richter"
+        },
+        {
+          "rolle" : "Polizistin",
+          "sprecher" : "Carolin Fortenbacher"
+        },
+        {
+          "rolle" : "Schausteller",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Edward Candle",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/metadata.json",
@@ -2927,79 +2932,79 @@
           "end" : 9893400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Nostigan",
-          "Volker Brandt"
-        ],
-        [
-          "Beastor",
-          "Michael Grimm"
-        ],
-        [
-          "Freeman",
-          "Helgo Liebig"
-        ],
-        [
-          "Skulldor",
-          "Herbert Tennigkeit"
-        ],
-        [
-          "Desmond Calbourne",
-          "Monty Arnold"
-        ],
-        [
-          "Frederic Barnes",
-          "Martin May"
-        ],
-        [
-          "Charlton Hogart",
-          "Christian Rode"
-        ],
-        [
-          "Santa Claus",
-          "Klaus Dittmann"
-        ],
-        [
-          "Mason Wachinsk",
-          "Achim Schülke"
-        ],
-        [
-          "Elfe",
-          "Linda Fölster"
-        ],
-        [
-          "Elfenbeinfrau",
-          "Heidi Berndt"
-        ],
-        [
-          "Milhouse",
-          "Hans-Joachim Dethlof"
-        ],
-        [
-          "Cafelyn McBryde",
-          "Marianne Bernhardt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Nostigan",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Beastor",
+          "sprecher" : "Michael Grimm"
+        },
+        {
+          "rolle" : "Freeman",
+          "sprecher" : "Helgo Liebig"
+        },
+        {
+          "rolle" : "Skulldor",
+          "sprecher" : "Herbert Tennigkeit"
+        },
+        {
+          "rolle" : "Desmond Calbourne",
+          "sprecher" : "Monty Arnold"
+        },
+        {
+          "rolle" : "Frederic Barnes",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Charlton Hogart",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Santa Claus",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Mason Wachinsk",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Elfe",
+          "sprecher" : "Linda Fölster"
+        },
+        {
+          "rolle" : "Elfenbeinfrau",
+          "sprecher" : "Heidi Berndt"
+        },
+        {
+          "rolle" : "Milhouse",
+          "sprecher" : "Hans-Joachim Dethlof"
+        },
+        {
+          "rolle" : "Cafelyn McBryde",
+          "sprecher" : "Marianne Bernhardt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json",
@@ -3285,67 +3290,67 @@
           "end" : 9948853
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Gianna",
-          "Celine Fontanges"
-        ],
-        [
-          "Lance",
-          "Armin Schlagwein"
-        ],
-        [
-          "Debra",
-          "Melanie Kastaun"
-        ],
-        [
-          "Audrey",
-          "Anja Topf"
-        ],
-        [
-          "Bellins",
-          "Joachim Kretzer"
-        ],
-        [
-          "Jerry",
-          "Matthias Keller"
-        ],
-        [
-          "Corey",
-          "Andreas Zaron"
-        ],
-        [
-          "Joe",
-          "André Beyer"
-        ],
-        [
-          "Mr. Allister Frain",
-          "Fabian Harloff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Gianna",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Lance",
+          "sprecher" : "Armin Schlagwein"
+        },
+        {
+          "rolle" : "Debra",
+          "sprecher" : "Melanie Kastaun"
+        },
+        {
+          "rolle" : "Audrey",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Bellins",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Jerry",
+          "sprecher" : "Matthias Keller"
+        },
+        {
+          "rolle" : "Corey",
+          "sprecher" : "Andreas Zaron"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "André Beyer"
+        },
+        {
+          "rolle" : "Mr. Allister Frain",
+          "sprecher" : "Fabian Harloff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/metadata.json",
@@ -3622,131 +3627,132 @@
           "end" : 9154760
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Santa Claus",
-          "Claus Wilcke"
-        ],
-        [
-          "Fotograf",
-          "Stephan Schad"
-        ],
-        [
-          "Sandy",
-          "Angela Stresemann"
-        ],
-        [
-          "Mutter",
-          "Pamela Punti [Heikedine Körting]"
-        ],
-        [
-          "Mr. Puckle",
-          "Christian Rudolf"
-        ],
-        [
-          "Mrs. Hatchett",
-          "Petra Kleinert"
-        ],
-        [
-          "Matty",
-          "Joshua Rudolf Goralsky"
-        ],
-        [
-          "Security 1",
-          "Patrick Berg"
-        ],
-        [
-          "Security 2",
-          "Philipp Stumpp"
-        ],
-        [
-          "Security 3",
-          "Max König"
-        ],
-        [
-          "Security 4",
-          "Tony Curting"
-        ],
-        [
-          "Pater",
-          "Achim Schülke"
-        ],
-        [
-          "Engel",
-          "Theresa Underberg"
-        ],
-        [
-          "Polizist 1",
-          "Patrick Baehr"
-        ],
-        [
-          "Polizist 2",
-          "Alexander Mettin"
-        ],
-        [
-          "Polizist 3",
-          "Douglas Welbat"
-        ],
-        [
-          "Angestellte",
-          "Katrin Decker"
-        ],
-        [
-          "Larry",
-          "Jan Langer"
-        ],
-        [
-          "Luke Bigelow",
-          "Harald Effenberg"
-        ],
-        [
-          "Molly",
-          "Regine Lamster"
-        ],
-        [
-          "Emmett",
-          "Reinhold Kammerer"
-        ],
-        [
-          "Durchsage",
-          "Andrea Lüdke"
-        ],
-        [
-          "Krankenschwester",
-          "Scarlet Cavadenti Lubowski"
-        ],
-        [
-          "Mann",
-          "Helge Halvé"
-        ],
-        [
-          "Bandenchef",
-          "Lars Schmidtke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Santa Claus",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Fotograf",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Sandy",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Mutter",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Mr. Puckle",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Mrs. Hatchett",
+          "sprecher" : "Petra Kleinert"
+        },
+        {
+          "rolle" : "Matty",
+          "sprecher" : "Joshua Rudolf Goralsky"
+        },
+        {
+          "rolle" : "Security 1",
+          "sprecher" : "Patrick Berg"
+        },
+        {
+          "rolle" : "Security 2",
+          "sprecher" : "Philipp Stumpp"
+        },
+        {
+          "rolle" : "Security 3",
+          "sprecher" : "Max König"
+        },
+        {
+          "rolle" : "Security 4",
+          "sprecher" : "Tony Curting"
+        },
+        {
+          "rolle" : "Pater",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Engel",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Patrick Baehr"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Alexander Mettin"
+        },
+        {
+          "rolle" : "Polizist 3",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Angestellte",
+          "sprecher" : "Katrin Decker"
+        },
+        {
+          "rolle" : "Larry",
+          "sprecher" : "Jan Langer"
+        },
+        {
+          "rolle" : "Luke Bigelow",
+          "sprecher" : "Harald Effenberg"
+        },
+        {
+          "rolle" : "Molly",
+          "sprecher" : "Regine Lamster"
+        },
+        {
+          "rolle" : "Emmett",
+          "sprecher" : "Reinhold Kammerer"
+        },
+        {
+          "rolle" : "Durchsage",
+          "sprecher" : "Andrea Lüdke"
+        },
+        {
+          "rolle" : "Krankenschwester",
+          "sprecher" : "Scarlet Cavadenti Lubowski"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Helge Halvé"
+        },
+        {
+          "rolle" : "Bandenchef",
+          "sprecher" : "Lars Schmidtke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/metadata.json",
@@ -4032,79 +4038,79 @@
           "end" : 12210266
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Emily",
-          "Gerlinde Dillge"
-        ],
-        [
-          "Glenda",
-          "Saskia Haisch"
-        ],
-        [
-          "Mrs. Kirk",
-          "Suzanne von Borsody"
-        ],
-        [
-          "Desmond",
-          "Patrick Baehr"
-        ],
-        [
-          "Megan",
-          "Henrike Fehrs"
-        ],
-        [
-          "Samuel Leech",
-          "Achim Buch"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Kathy Hiller",
-          "Lucia-Angelina Mahler"
-        ],
-        [
-          "Violet Bell",
-          "Andrea Lüdke"
-        ],
-        [
-          "Jack",
-          "Manou Lubowski"
-        ],
-        [
-          "Daniel",
-          "Sebastian König"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Emily",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Glenda",
+          "sprecher" : "Saskia Haisch"
+        },
+        {
+          "rolle" : "Mrs. Kirk",
+          "sprecher" : "Suzanne von Borsody"
+        },
+        {
+          "rolle" : "Desmond",
+          "sprecher" : "Patrick Baehr"
+        },
+        {
+          "rolle" : "Megan",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Samuel Leech",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kathy Hiller",
+          "sprecher" : "Lucia-Angelina Mahler"
+        },
+        {
+          "rolle" : "Violet Bell",
+          "sprecher" : "Andrea Lüdke"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Daniel",
+          "sprecher" : "Sebastian König"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json",
@@ -4261,99 +4267,100 @@
           "end" : 5382547
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Nayra Paredes",
-          "Sonja Stein"
-        ],
-        [
-          "Andrés Paredes",
-          "Tim Kreuer"
-        ],
-        [
-          "Mr. Gabriel Paredes",
-          "Urs Affolter"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Quentin Montgrove",
-          "Eberhard Haar"
-        ],
-        [
-          "Emma Miller",
-          "Kerstin Draeger"
-        ],
-        [
-          "Der Einzige Inka",
-          "Eckart Dux"
-        ],
-        [
-          "Kassiererin im Museum",
-          "Merete Brettschneider"
-        ],
-        [
-          "Ansagerin im Museum",
-          "Merete Brettschneider"
-        ],
-        [
-          "Eisdielen-Besitzer",
-          "Robert Missler"
-        ],
-        [
-          "Alte Frau",
-          "Katja Brügger"
-        ],
-        [
-          "Mann",
-          "André Gatzke"
-        ],
-        [
-          "Frau 1",
-          "Heikedine Körting"
-        ],
-        [
-          "Frau 2",
-          "Susan Jarling"
-        ],
-        [
-          "Frau 3",
-          "Hella von der Osten-Sacken"
-        ],
-        [
-          "Frau 4",
-          "Saskia Weckler"
-        ],
-        [
-          "Mädchen",
-          "Theresa Underberg"
-        ],
-        [
-          "Kind 1",
-          "Malon Stahlhuth"
-        ],
-        [
-          "Kind 2",
-          "Julia Fölster"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Nayra Paredes",
+          "sprecher" : "Sonja Stein"
+        },
+        {
+          "rolle" : "Andrés Paredes",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Mr. Gabriel Paredes",
+          "sprecher" : "Urs Affolter"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Quentin Montgrove",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Emma Miller",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Der Einzige Inka",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Kassiererin im Museum",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Ansagerin im Museum",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Eisdielen-Besitzer",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Alte Frau",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "André Gatzke"
+        },
+        {
+          "rolle" : "Frau 1",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Frau 2",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Frau 3",
+          "sprecher" : "Hella von der Osten-Sacken"
+        },
+        {
+          "rolle" : "Frau 4",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Kind 1",
+          "sprecher" : "Malon Stahlhuth"
+        },
+        {
+          "rolle" : "Kind 2",
+          "sprecher" : "Julia Fölster"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json",
@@ -4430,71 +4437,71 @@
           "end" : 4300133
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dylan Harvey",
-          "Stephan Schad"
-        ],
-        [
-          "Mrs. Violet Conroy",
-          "Birte Kretschmer"
-        ],
-        [
-          "Mr. Alex Scott",
-          "Oliver Böttcher"
-        ],
-        [
-          "Myriel",
-          "Undine Ullmer"
-        ],
-        [
-          "Zimmermädchen",
-          "Theresa Underberg"
-        ],
-        [
-          "Zimmerjunge",
-          "Jannik Endemann"
-        ],
-        [
-          "Mutter im Stadtpark",
-          "Saskia Weckler"
-        ],
-        [
-          "Klein Peter",
-          "Malon Stahlhuth"
-        ],
-        [
-          "Kellnerin im Hotel",
-          "Alexandra Garcia"
-        ],
-        [
-          "Handwerker im Hotel 1",
-          "André Gatzke"
-        ],
-        [
-          "Handwerker im Hotel 2",
-          "Bent Schönemann"
-        ],
-        [
-          "Internetcafébesitzer",
-          "Tim Kreuer"
-        ],
-        [
-          "Vortragsbesucher, Parkbesucher, Frühstücksgäste, Nachbarn",
-          "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Damare, Ingeborg Christiansen, Micaëla Kreißler, Theresa Underberg, Kerstin Draeger, Lennardt Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dylan Harvey",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Mrs. Violet Conroy",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Mr. Alex Scott",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Myriel",
+          "sprecher" : "Undine Ullmer"
+        },
+        {
+          "rolle" : "Zimmermädchen",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Zimmerjunge",
+          "sprecher" : "Jannik Endemann"
+        },
+        {
+          "rolle" : "Mutter im Stadtpark",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Klein Peter",
+          "sprecher" : "Malon Stahlhuth"
+        },
+        {
+          "rolle" : "Kellnerin im Hotel",
+          "sprecher" : "Alexandra Garcia"
+        },
+        {
+          "rolle" : "Handwerker im Hotel 1",
+          "sprecher" : "André Gatzke"
+        },
+        {
+          "rolle" : "Handwerker im Hotel 2",
+          "sprecher" : "Bent Schönemann"
+        },
+        {
+          "rolle" : "Internetcafébesitzer",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Vortragsbesucher, Parkbesucher, Frühstücksgäste, Nachbarn",
+          "sprecher" : "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Damare, Ingeborg Christiansen, Micaëla Kreißler, Theresa Underberg, Kerstin Draeger, Lennardt Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/metadata.json",
@@ -4642,115 +4649,116 @@
           "end" : 5066480
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Zachary Collister",
-          "Stephan Benson"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mrs. Hilton",
-          "Katja Brügger"
-        ],
-        [
-          "Mr. Warren",
-          "Stephan Schwartz"
-        ],
-        [
-          "Luke Havering",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Colin Havering",
-          "Santiago Ziesmer"
-        ],
-        [
-          "MacKenzie",
-          "Traudel Sperber"
-        ],
-        [
-          "Erial",
-          "Robert Missler"
-        ],
-        [
-          "Andy",
-          "Tim Grobe"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Francine",
-          "Merete Brettschneider"
-        ],
-        [
-          "Matrose",
-          "Eberhard Haar"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Watson",
-          "Corinna Wodrich"
-        ],
-        [
-          "Betrunkener",
-          "Patrick Bach"
-        ],
-        [
-          "Kind 1",
-          "Malon Stahlhuth"
-        ],
-        [
-          "Kind 2",
-          "Julia Fölster"
-        ],
-        [
-          "Taxifahrer",
-          "Tilman Madaus"
-        ],
-        [
-          "Kartenspieler",
-          "Robin Brosch"
-        ],
-        [
-          "Tochter von Erial",
-          "Zelda Jahreis"
-        ],
-        [
-          "AB-Ansage-Stimme",
-          "Susan Jarling"
-        ],
-        [
-          "Reporter",
-          "Ivo Möller"
-        ],
-        [
-          "Journalistin",
-          "Birte Kretschmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Zachary Collister",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mrs. Hilton",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Mr. Warren",
+          "sprecher" : "Stephan Schwartz"
+        },
+        {
+          "rolle" : "Luke Havering",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Colin Havering",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "MacKenzie",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Erial",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Andy",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Francine",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Matrose",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Watson",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Betrunkener",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Kind 1",
+          "sprecher" : "Malon Stahlhuth"
+        },
+        {
+          "rolle" : "Kind 2",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Taxifahrer",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Kartenspieler",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Tochter von Erial",
+          "sprecher" : "Zelda Jahreis"
+        },
+        {
+          "rolle" : "AB-Ansage-Stimme",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Journalistin",
+          "sprecher" : "Birte Kretschmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/metadata.json",
@@ -4927,95 +4935,96 @@
           "end" : 5317587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Andy Carson",
-          "Stefan Schwade"
-        ],
-        [
-          "Carson, Andys Vater",
-          "Hans Kahlert"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt [Andreas E. Beurmann]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Gabbo",
-          "Manfred Reddemann"
-        ],
-        [
-          "Wachmann",
-          "Till Huster"
-        ],
-        [
-          "Iwan",
-          "Urs Affolter"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Christian Redl"
-        ],
-        [
-          "Khan",
-          "Klaus Dittmann"
-        ],
-        [
-          "Schaustellerin",
-          "Ursula Sieg"
-        ],
-        [
-          "Vermieter",
-          "Stephan Benson"
-        ],
-        [
-          "Polizist 1",
-          "Jürgen Holdorf"
-        ],
-        [
-          "Polizist 2 (Prolog)",
-          "Daniel Welbat"
-        ],
-        [
-          "Polizist 3 (Prolog)",
-          "Matthias Krauße"
-        ],
-        [
-          "Losverkäufer",
-          "Joachim Kretzer"
-        ],
-        [
-          "Kassiererin",
-          "Birte Kretschmer"
-        ],
-        [
-          "Feuerschlucker",
-          "Robert Missler"
-        ],
-        [
-          "Jack",
-          "Timo Alexander Wenzel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Andy Carson",
+          "sprecher" : "Stefan Schwade"
+        },
+        {
+          "rolle" : "Carson, Andys Vater",
+          "sprecher" : "Hans Kahlert"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Gabbo",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Iwan",
+          "sprecher" : "Urs Affolter"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Christian Redl"
+        },
+        {
+          "rolle" : "Khan",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Schaustellerin",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Vermieter",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Jürgen Holdorf"
+        },
+        {
+          "rolle" : "Polizist 2 (Prolog)",
+          "sprecher" : "Daniel Welbat"
+        },
+        {
+          "rolle" : "Polizist 3 (Prolog)",
+          "sprecher" : "Matthias Krauße"
+        },
+        {
+          "rolle" : "Losverkäufer",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Kassiererin",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Feuerschlucker",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Timo Alexander Wenzel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/metadata.json",
@@ -5212,71 +5221,71 @@
           "end" : 6126040
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Amanda Ellis",
-          "Simona Pahl"
-        ],
-        [
-          "Jo",
-          "Birte Kretschmer"
-        ],
-        [
-          "Steve Young",
-          "Till Huster"
-        ],
-        [
-          "Ford Follows",
-          "Stephan Benson"
-        ],
-        [
-          "Eric Ellis",
-          "Horst Stark"
-        ],
-        [
-          "Ricardo Yarbrough",
-          "Stefan Brönneke"
-        ],
-        [
-          "Bibliothekarin",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Mr. Friedman",
-          "Douglas Welbat"
-        ],
-        [
-          "Mann in der Bibliothek",
-          "Erik Schäffler"
-        ],
-        [
-          "Sekretärin",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Jackson Cooper",
-          "Oliver Böttcher"
-        ],
-        [
-          "Mr. Miller",
-          "Pierre Brand"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Amanda Ellis",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Jo",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Steve Young",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Ford Follows",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Eric Ellis",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Ricardo Yarbrough",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Bibliothekarin",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Mr. Friedman",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Mann in der Bibliothek",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Jackson Cooper",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Mr. Miller",
+          "sprecher" : "Pierre Brand"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/metadata.json",
@@ -5413,87 +5422,87 @@
           "end" : 5753347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Roger Kind",
-          "Holger Mahlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Regisseur Kushing",
-          "Tim Grobe"
-        ],
-        [
-          "Melanie Shepard",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Laura",
-          "Henrike Fehrs"
-        ],
-        [
-          "Lara Bix",
-          "Ursula Sieg"
-        ],
-        [
-          "Jason Frost",
-          "Robert Missler"
-        ],
-        [
-          "Kellnerin",
-          "Simona Pahl"
-        ],
-        [
-          "Museumsdame",
-          "Rhea Harder-Vennewald"
-        ],
-        [
-          "Monsterpuppe",
-          "Kerstin Draeger"
-        ],
-        [
-          "Betty Frost",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Wachmann",
-          "Markus Schäfer"
-        ],
-        [
-          "Kameramann",
-          "Helge Halvé"
-        ],
-        [
-          "Tonmann",
-          "Timo Alexander Wenzel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Roger Kind",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Regisseur Kushing",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Melanie Shepard",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Laura",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Lara Bix",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Jason Frost",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Museumsdame",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Monsterpuppe",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Betty Frost",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Markus Schäfer"
+        },
+        {
+          "rolle" : "Kameramann",
+          "sprecher" : "Helge Halvé"
+        },
+        {
+          "rolle" : "Tonmann",
+          "sprecher" : "Timo Alexander Wenzel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json",
@@ -5730,67 +5739,67 @@
           "end" : 6770387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Tim Kreuer"
-        ],
-        [
-          "Sheryl",
-          "Merete Brettschneider"
-        ],
-        [
-          "Professor Burnham",
-          "Jürgen Thormann"
-        ],
-        [
-          "Salvador Pérez",
-          "Matthias Klimsa"
-        ],
-        [
-          "Tuyucim Florentino Ixmatá",
-          "Mario Ramos"
-        ],
-        [
-          "Tuyucim",
-          "Nicolás Klimsa"
-        ],
-        [
-          "Maria Pérez",
-          "Caroline Kiesewetter"
-        ],
-        [
-          "Zachary",
-          "Roman Rossa"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Conrad Williams",
-          "Peter Weis"
-        ],
-        [
-          "Nachrichtensprecher",
-          "André Schünke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Sheryl",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Professor Burnham",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Salvador Pérez",
+          "sprecher" : "Matthias Klimsa"
+        },
+        {
+          "rolle" : "Tuyucim Florentino Ixmatá",
+          "sprecher" : "Mario Ramos"
+        },
+        {
+          "rolle" : "Tuyucim",
+          "sprecher" : "Nicolás Klimsa"
+        },
+        {
+          "rolle" : "Maria Pérez",
+          "sprecher" : "Caroline Kiesewetter"
+        },
+        {
+          "rolle" : "Zachary",
+          "sprecher" : "Roman Rossa"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Conrad Williams",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "André Schünke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/metadata.json",

--- a/data/Master_Spezial.json
+++ b/data/Master_Spezial.json
@@ -190,7 +190,7 @@
           "Andreas von der Meden"
         ],
         [
-          "Mr. Claudius",
+          "Mr. Claudius, Kunsthändler",
           "Gerlach Fiedler"
         ],
         [
@@ -198,7 +198,7 @@
           "Brigitte Böttrich"
         ],
         [
-          "Mr. Fentriss",
+          "Mr. Fentriss, Schriftsteller",
           "Detlef Bierstedt"
         ],
         [
@@ -210,7 +210,7 @@
           "Stefan Brönneke"
         ],
         [
-          "Ramos",
+          "Onkel Ramos",
           "Dario Bertoli [Detlef Bierstedt]"
         ],
         [
@@ -317,23 +317,23 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
-              "Tante Mathilda Jonas",
+              "Tante Mathilda",
               "Karin Lieneweg"
             ],
             [
-              "Onkel Titus Jonas",
+              "Onkel Titus",
               "Hans Meinhardt [Andreas E. Beurmann]"
             ],
             [
@@ -485,19 +485,19 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
-              "Tante Mathilda Jonas",
+              "Tante Mathilda",
               "Karin Lieneweg"
             ],
             [
@@ -664,23 +664,23 @@
               "Thomas Fritsch"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
-              "Tante Mathilda Jonas",
+              "Tante Mathilda",
               "Karin Lieneweg"
             ],
             [
-              "Bill Andrews",
+              "Mr. Andrews",
               "Henry König"
             ],
             [
@@ -801,23 +801,23 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
-          "Tante Mathilda Jonas",
+          "Tante Mathilda",
           "Karin Lieneweg"
         ],
         [
-          "Onkel Titus Jonas",
+          "Onkel Titus",
           "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
@@ -921,7 +921,7 @@
           "Ernst H. Hilbich"
         ],
         [
-          "Bill Andrews",
+          "Mr. Andrews",
           "Henry König"
         ],
         [
@@ -1053,15 +1053,15 @@
       ],
       "sprecher" : [
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -1113,7 +1113,7 @@
           "Peter Kirchberger"
         ],
         [
-          "Sax Sendler",
+          "Sax Sandler",
           "Christian Concilio"
         ],
         [
@@ -1300,15 +1300,15 @@
               "Claudia Stocksieker"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -1376,7 +1376,7 @@
               "Wolfgang Kaven"
             ],
             [
-              "Papagei",
+              "Blacky",
               "Heikedine Körting"
             ]
           ],
@@ -1685,15 +1685,15 @@
               "Claudia Stocksieker"
             ],
             [
-              "Justus Jonas",
+              "Justus Jonas, Erster Detektiv",
               "Oliver Rohrbeck"
             ],
             [
-              "Peter Shaw",
+              "Peter Shaw, Zweiter Detektiv",
               "Jens Wawrczeck"
             ],
             [
-              "Bob Andrews",
+              "Bob Andrews, Recherchen und Archiv",
               "Andreas Fröhlich"
             ],
             [
@@ -1733,7 +1733,7 @@
               "Andreas von der Meden"
             ],
             [
-              "Papagei",
+              "Blacky",
               "Heikedine Körting"
             ],
             [
@@ -1745,7 +1745,7 @@
               "Wolfgang Draeger"
             ],
             [
-              "Mr. Albert Hitfield",
+              "Albert Hitfield",
               "Volker Bogdan"
             ],
             [
@@ -2062,15 +2062,15 @@
           "Claudia Stocksieker"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -2170,7 +2170,7 @@
           "Wolfgang Draeger"
         ],
         [
-          "Mr. Albert Hitfield",
+          "Albert Hitfield",
           "Volker Bogdan"
         ],
         [
@@ -2178,7 +2178,7 @@
           "Friedel Bott"
         ],
         [
-          "Papagei",
+          "Blacky",
           "Heikedine Körting"
         ]
       ],
@@ -2244,15 +2244,15 @@
       ],
       "sprecher" : [
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -2587,15 +2587,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -2933,15 +2933,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -3676,19 +3676,19 @@
           "Joshua Rudolf Goralsky"
         ],
         [
-          "1. Security",
+          "Security 1",
           "Patrick Berg"
         ],
         [
-          "2. Security",
+          "Security 2",
           "Philipp Stumpp"
         ],
         [
-          "3. Security",
+          "Security 3",
           "Max König"
         ],
         [
-          "4. Security",
+          "Security 4",
           "Tony Curting"
         ],
         [
@@ -3700,15 +3700,15 @@
           "Theresa Underberg"
         ],
         [
-          "1. Polizist",
+          "Polizist 1",
           "Patrick Baehr"
         ],
         [
-          "2. Polizist",
+          "Polizist 2",
           "Alexander Mettin"
         ],
         [
-          "3. Polizist",
+          "Polizist 3",
           "Douglas Welbat"
         ],
         [
@@ -4263,15 +4263,15 @@
       ],
       "sprecher" : [
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -4432,15 +4432,15 @@
       ],
       "sprecher" : [
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -4644,15 +4644,15 @@
       ],
       "sprecher" : [
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -4973,7 +4973,7 @@
           "Urs Affolter"
         ],
         [
-          "Reynolds",
+          "Kommissar Reynolds",
           "Christian Redl"
         ],
         [
@@ -5419,15 +5419,15 @@
           "Thomas Fritsch"
         ],
         [
-          "Justus Jonas",
+          "Justus Jonas, Erster Detektiv",
           "Oliver Rohrbeck"
         ],
         [
-          "Peter Shaw",
+          "Peter Shaw, Zweiter Detektiv",
           "Jens Wawrczeck"
         ],
         [
-          "Bob Andrews",
+          "Bob Andrews, Recherchen und Archiv",
           "Andreas Fröhlich"
         ],
         [
@@ -5440,14 +5440,6 @@
         ],
         [
           "Roger Kind",
-          "Holger Mahlich"
-        ],
-        [
-          "R. Kind als Regisseur Kushing",
-          "Holger Mahlich"
-        ],
-        [
-          "R. Kind als Cotta",
           "Holger Mahlich"
         ],
         [

--- a/data/Master_Spezial.json
+++ b/data/Master_Spezial.json
@@ -211,7 +211,7 @@
         ],
         [
           "Ramos",
-          "Dario Bertoli"
+          "Dario Bertoli [Detlef Bierstedt]"
         ],
         [
           "Morton",
@@ -334,7 +334,7 @@
             ],
             [
               "Onkel Titus Jonas",
-              "Hans Meinhardt"
+              "Hans Meinhardt [Andreas E. Beurmann]"
             ],
             [
               "Inspektor Cotta",
@@ -354,7 +354,7 @@
             ],
             [
               "Miss Tomkins",
-              "Steffi Kirchberger"
+              "Stephanie Damare"
             ],
             [
               "Mr. Foley",
@@ -518,11 +518,11 @@
             ],
             [
               "Peter Foster",
-              "Gerrit Schmidt-Foss"
+              "Gerrit Schmidt-Foß"
             ],
             [
               "Mrs. Shaw",
-              "Isabella Grote"
+              "Isabella Grothe"
             ],
             [
               "Sebastian Dawson",
@@ -689,7 +689,7 @@
             ],
             [
               "Miss Bennett",
-              "Renate Pilcher"
+              "Renate Pichler"
             ],
             [
               "Dick Perry",
@@ -705,23 +705,23 @@
             ],
             [
               "Ian Bush",
-              "Sky du Mont / Lucas Sperber"
+              "Sky du Mont / Lukas T. Sperber"
             ],
             [
               "Jimmy Sinclair",
-              "Siegfried Kernen / Nils Noller"
+              "Siegfried W. Kernen / Nils Noller"
             ],
             [
               "Charlie Parker",
-              "Jörg Gillner / Laurence Kalaidjan"
+              "Oliver Böttcher / Laurence Kalaidjian"
             ],
             [
               "Brianna Jackson",
-              "Hansi Jochmann / Natalie Demtröder"
+              "Hansi Jochmann / Natalie Demtrøder"
             ],
             [
               "Chloe Smathers",
-              "Valerie Demtröder"
+              "Valerie Demtrøder"
             ],
             [
               "Joseph Quick",
@@ -729,7 +729,7 @@
             ],
             [
               "Mr. Raynes",
-              "Olaf Kreuzenbeck"
+              "Olaf Kreutzenbeck"
             ],
             [
               "Jeff White",
@@ -745,7 +745,7 @@
             ],
             [
               "Peter Foster",
-              "Gerrit Schmidt-Foss"
+              "Gerrit Schmidt-Foß"
             ],
             [
               "Matthew Gabbin",
@@ -818,7 +818,7 @@
         ],
         [
           "Onkel Titus Jonas",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Inspektor Cotta",
@@ -838,7 +838,7 @@
         ],
         [
           "Miss Tomkins",
-          "Steffi Kirchberger"
+          "Stephanie Damare"
         ],
         [
           "Mr. Foley",
@@ -890,11 +890,11 @@
         ],
         [
           "Peter Foster",
-          "Gerrit Schmidt-Foss"
+          "Gerrit Schmidt-Foß"
         ],
         [
           "Mrs. Shaw",
-          "Isabella Grote"
+          "Isabella Grothe"
         ],
         [
           "Annie Wilkes",
@@ -926,7 +926,7 @@
         ],
         [
           "Miss Bennett",
-          "Renate Pilcher"
+          "Renate Pichler"
         ],
         [
           "Walter Bush",
@@ -934,23 +934,23 @@
         ],
         [
           "Ian Bush",
-          "Sky du Mont / Lucas Sperber"
+          "Sky du Mont / Lukas T. Sperber"
         ],
         [
           "Jimmy Sinclair",
-          "Siegfried Kernen / Nils Noller"
+          "Siegfried W. Kernen / Nils Noller"
         ],
         [
           "Charlie Parker",
-          "Jörg Gillner / Laurence Kalaidjan"
+          "Oliver Böttcher / Laurence Kalaidjian"
         ],
         [
           "Brianna Jackson",
-          "Hansi Jochmann / Natalie Demtröder"
+          "Hansi Jochmann / Natalie Demtrøder"
         ],
         [
           "Chloe Smathers",
-          "Valerie Demtröder"
+          "Valerie Demtrøder"
         ],
         [
           "Joseph Quick",
@@ -958,7 +958,7 @@
         ],
         [
           "Mr. Raynes",
-          "Olaf Kreuzenbeck"
+          "Olaf Kreutzenbeck"
         ],
         [
           "Jeff White",
@@ -1106,7 +1106,7 @@
         ],
         [
           "Slide Terranova",
-          "Nico König"
+          "Nicolas König"
         ],
         [
           "P. \"Pejo\" Joseph McGaskill",
@@ -1114,7 +1114,7 @@
         ],
         [
           "Sax Sendler",
-          "Christian Concillio"
+          "Christian Concilio"
         ],
         [
           "Hausmeister",
@@ -1126,11 +1126,11 @@
         ],
         [
           "Junge",
-          "Michael Lampe"
+          "Michael Lampe [André Minninger]"
         ],
         [
           "Mädchen",
-          "Pamela Punti"
+          "Pamela Punti [Heikedine Körting]"
         ],
         [
           "Weibl. Offstimme",
@@ -1142,7 +1142,7 @@
         ],
         [
           "Menge",
-          "www.dreifragezeichen.de/www/menge-brainwash"
+          "Lauscherlounge-Zuschauer (www.dreifragezeichen.de/www/menge-brainwash)"
         ]
       ],
       "links" : {
@@ -2261,11 +2261,11 @@
         ],
         [
           "Stinky Rossiter",
-          "Dustin Sattler-Semmelrogge"
+          "Dustin Semmelrogge"
         ],
         [
           "Fear Crowther",
-          "Ingo Mommsen"
+          "Ingo Nommsen"
         ],
         [
           "Mouth Crosby",
@@ -2966,6 +2966,10 @@
         ],
         [
           "Desmond Calbourne",
+          "Monty Arnold"
+        ],
+        [
+          "Frederic Barnes",
           "Martin May"
         ],
         [
@@ -3657,7 +3661,7 @@
         ],
         [
           "Mutter",
-          "Pamela Punti"
+          "Pamela Punti [Heikedine Körting]"
         ],
         [
           "Mr. Puckle",
@@ -3669,7 +3673,7 @@
         ],
         [
           "Matty",
-          "Joshua Rudolf"
+          "Joshua Rudolf Goralsky"
         ],
         [
           "1. Security",
@@ -3733,7 +3737,7 @@
         ],
         [
           "Krankenschwester",
-          "Scarlett Lubowski"
+          "Scarlet Cavadenti Lubowski"
         ],
         [
           "Mann",
@@ -4083,7 +4087,7 @@
         ],
         [
           "Kathy Hiller",
-          "Lucia Angelina Mahler"
+          "Lucia-Angelina Mahler"
         ],
         [
           "Violet Bell",
@@ -4288,7 +4292,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Quentin Montgrove",
@@ -4320,7 +4324,7 @@
         ],
         [
           "Mann",
-          "Andre Gatzke"
+          "André Gatzke"
         ],
         [
           "Frau 1",
@@ -4332,7 +4336,7 @@
         ],
         [
           "Frau 3",
-          "Hella von der Osten"
+          "Hella von der Osten-Sacken"
         ],
         [
           "Frau 4",
@@ -4340,11 +4344,11 @@
         ],
         [
           "Mädchen",
-          "Theresa Unterberg"
+          "Theresa Underberg"
         ],
         [
           "Kind 1",
-          "Malon Stahlhut"
+          "Malon Stahlhuth"
         ],
         [
           "Kind 2",
@@ -4449,7 +4453,7 @@
         ],
         [
           "Mr. Alex Scott",
-          "Oliver Böttche"
+          "Oliver Böttcher"
         ],
         [
           "Myriel",
@@ -4469,7 +4473,7 @@
         ],
         [
           "Klein Peter",
-          "Malon Stahlhut"
+          "Malon Stahlhuth"
         ],
         [
           "Kellnerin im Hotel",
@@ -4489,7 +4493,7 @@
         ],
         [
           "Vortragsbesucher, Parkbesucher, Frühstücksgäste, Nachbarn",
-          "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Kirchberger, Ingeborg Christiansen, Michaela Kreissler, Theresa Underberg, Kerstin Draeger, Lennart Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
+          "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Damare, Ingeborg Christiansen, Micaëla Kreißler, Theresa Underberg, Kerstin Draeger, Lennardt Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
         ]
       ],
       "links" : {
@@ -4689,7 +4693,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda",
@@ -4725,7 +4729,7 @@
         ],
         [
           "Taxifahrer",
-          "Tillmann Madaus"
+          "Tilman Madaus"
         ],
         [
           "Kartenspieler",
@@ -4950,7 +4954,7 @@
         ],
         [
           "Onkel Titus",
-          "Hans Meinhardt"
+          "Hans Meinhardt [Andreas E. Beurmann]"
         ],
         [
           "Tante Mathilda",
@@ -5267,7 +5271,7 @@
         ],
         [
           "Jackson Cooper",
-          "Oliver Bröttcher"
+          "Oliver Böttcher"
         ],
         [
           "Mr. Miller",
@@ -5420,7 +5424,7 @@
         ],
         [
           "Peter Shaw",
-          "Jens Wawrczek"
+          "Jens Wawrczeck"
         ],
         [
           "Bob Andrews",
@@ -5476,7 +5480,7 @@
         ],
         [
           "Museumsdame",
-          "Rhea Harder"
+          "Rhea Harder-Vennewald"
         ],
         [
           "Monsterpuppe",
@@ -5492,7 +5496,7 @@
         ],
         [
           "Kameramann",
-          "Helgé Halvé"
+          "Helge Halvé"
         ],
         [
           "Tonmann",
@@ -5773,7 +5777,7 @@
         ],
         [
           "Tuyucim",
-          "Nicolas Klimsa"
+          "Nicolás Klimsa"
         ],
         [
           "Maria Pérez",

--- a/web/data/DiE_DR3i.json
+++ b/web/data/DiE_DR3i.json
@@ -283,71 +283,71 @@
       "hörspielskriptautor" : "Ivar Leon Menger",
       "beschreibung" : "Eine Nacht in einem Luxushotel, direkt an der malerischen Steilküste Nordkaliforniens? Normalerweise ein Grund zur Freude. Doch nicht für Jupiter, Peter und Bob! Denn Die Dr3i müssen um ihr Leben fürchten! Und das, obwohl das unheimliche Hotel vollkommen menschenleer ist …\nErlebe das erste interaktive Hörspiel mit Jupiter Jones, Peter Crenshaw und Bob Andrews! Mit einem Knopfdruck auf deinem CD-Player kannst du mitbestimmen, welche Lösungswege die drei Detektive bei diesem mysteriösen Abenteuer einschlagen sollen.\nAuf 2 CDs erwarten dich viele ungelöste Rätsel und Geheimnisse, sowie 16 alternative Enden!",
       "veröffentlichungsdatum" : "2006-11-24",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jones",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Overlook",
-          "Joachim Kerzel"
-        ],
-        [
-          "Portier Stanley",
-          "Lutz Mackensy"
-        ],
-        [
-          "Liftboy Jack",
-          "Jan-David Rönfeldt"
-        ],
-        [
-          "Barkeeper Lloyd",
-          "Roman Kretschmer"
-        ],
-        [
-          "Mr. Torrance",
-          "Holger Löwenberg"
-        ],
-        [
-          "Mrs. Torrence",
-          "Katja Brügger"
-        ],
-        [
-          "Shelley",
-          "Saskia Weckler"
-        ],
-        [
-          "Stuart",
-          "Nicolas König"
-        ],
-        [
-          "Danny",
-          "Patrick Bach"
-        ],
-        [
-          "Police Officer",
-          "Jürgen Thormann"
-        ],
-        [
-          "Nachrichtensprecher",
-          "Bernd Klose"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda Jones",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Overlook",
+          "sprecher" : "Joachim Kerzel"
+        },
+        {
+          "rolle" : "Portier Stanley",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Liftboy Jack",
+          "sprecher" : "Jan-David Rönfeldt"
+        },
+        {
+          "rolle" : "Barkeeper Lloyd",
+          "sprecher" : "Roman Kretschmer"
+        },
+        {
+          "rolle" : "Mr. Torrance",
+          "sprecher" : "Holger Löwenberg"
+        },
+        {
+          "rolle" : "Mrs. Torrance",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Shelley Torrance",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Stuart",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Danny",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Police Officer",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "Bernd Klose"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/metadata.json",
@@ -643,67 +643,67 @@
           "end" : 7993773
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Ashby",
-          "Sabine Hahn"
-        ],
-        [
-          "Charles Prendergast",
-          "Rolf Nagel"
-        ],
-        [
-          "Richard Crandall",
-          "Konstantin Graudus"
-        ],
-        [
-          "Kirk Prendergast",
-          "Wolf Frass"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ],
-        [
-          "Jonathan Godfrey",
-          "Eric Schäffler"
-        ],
-        [
-          "Carlos",
-          "Eduardo Garcia"
-        ],
-        [
-          "Garrett",
-          "Dietrich Adam"
-        ],
-        [
-          "Riteman",
-          "Till Demtrøder"
-        ],
-        [
-          "Stanley",
-          "Lutz Schnell"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Ashby",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Charles Prendergast",
+          "sprecher" : "Rolf Nagel"
+        },
+        {
+          "rolle" : "Richard Crandall",
+          "sprecher" : "Konstantin Graudus"
+        },
+        {
+          "rolle" : "Kirk Prendergast",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Jonathan Godfrey",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Carlos",
+          "sprecher" : "Eduardo Garcia"
+        },
+        {
+          "rolle" : "Garrett",
+          "sprecher" : "Dietrich Adam"
+        },
+        {
+          "rolle" : "Riteman",
+          "sprecher" : "Till Demtrøder"
+        },
+        {
+          "rolle" : "Stanley",
+          "sprecher" : "Lutz Schnell"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/1/metadata.json",
@@ -780,59 +780,59 @@
           "end" : 4634013
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sylvester Meyzel",
-          "Wolfgang Völz"
-        ],
-        [
-          "Dorothy Winter",
-          "Doris Kunstmann"
-        ],
-        [
-          "Mr. Hendrik",
-          "Utz Richter"
-        ],
-        [
-          "Kassiererin",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Inspektor Tomlin",
-          "Klaus Dittmann"
-        ],
-        [
-          "Mr. X",
-          "Dirk Eichhorn"
-        ],
-        [
-          "Tao",
-          "Tilman Maddaus"
-        ],
-        [
-          "Supermarkt-Durchsage",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sylvester Meyzel",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Dorothy Winter",
+          "sprecher" : "Doris Kunstmann"
+        },
+        {
+          "rolle" : "Mr. Hendrik",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Kassiererin",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Inspektor Tomlin",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Mr. X",
+          "sprecher" : "Dirk Eichhorn"
+        },
+        {
+          "rolle" : "Tao",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Supermarkt-Durchsage",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/2/metadata.json",
@@ -915,51 +915,51 @@
           "end" : 4113813
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "James Taylor",
-          "Wanja Mues"
-        ],
-        [
-          "Ray Wells",
-          "Dietrich Adam"
-        ],
-        [
-          "Frank Caspian",
-          "Christian Redl"
-        ],
-        [
-          "Jonathan Grant",
-          "Bernd Stephan"
-        ],
-        [
-          "Christy Grant",
-          "Anja Topf"
-        ],
-        [
-          "George Drummond",
-          "Eberhard Haar"
-        ],
-        [
-          "Tom Drummond",
-          "Patrick Bach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "James Taylor",
+          "sprecher" : "Wanja Mues"
+        },
+        {
+          "rolle" : "Ray Wells",
+          "sprecher" : "Dietrich Adam"
+        },
+        {
+          "rolle" : "Frank Caspian",
+          "sprecher" : "Christian Redl"
+        },
+        {
+          "rolle" : "Jonathan Grant",
+          "sprecher" : "Bernd Stephan"
+        },
+        {
+          "rolle" : "Christy Grant",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "George Drummond",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Tom Drummond",
+          "sprecher" : "Patrick Bach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/3/metadata.json",
@@ -1032,63 +1032,64 @@
           "end" : 4747133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus Jones",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda Jones",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mr. Walker",
-          "Gustav-Adolph Artz"
-        ],
-        [
-          "Donald Forthland",
-          "Günter Lüdke"
-        ],
-        [
-          "Shane Montana",
-          "Jürgen Thormann"
-        ],
-        [
-          "Jim",
-          "Wolfgang Berger"
-        ],
-        [
-          "Doc Brown",
-          "Tim Wenderoth"
-        ],
-        [
-          "Finnegan",
-          "Fabian Harloff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus Jones",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda Jones",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mr. Walker",
+          "sprecher" : "Gustav-Adolph Artz"
+        },
+        {
+          "rolle" : "Donald Forthland",
+          "sprecher" : "Günter Lüdke"
+        },
+        {
+          "rolle" : "Shane Montana",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Jim",
+          "sprecher" : "Wolfgang Berger"
+        },
+        {
+          "rolle" : "Doc Brown",
+          "sprecher" : "Tim Wenderoth"
+        },
+        {
+          "rolle" : "Finnegan",
+          "sprecher" : "Fabian Harloff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/4/metadata.json",
@@ -1161,47 +1162,47 @@
           "end" : 4409520
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jack Doolan",
-          "Eckart Dux"
-        ],
-        [
-          "Harold",
-          "Gernot Endemann"
-        ],
-        [
-          "Miss Lana",
-          "Sabine Schmidt-Kirchner"
-        ],
-        [
-          "Mademoiselle Nadine",
-          "Jennie Appel"
-        ],
-        [
-          "Toby Grissom",
-          "Lothar Grützner"
-        ],
-        [
-          "Frank Mortimer",
-          "Karl-Friedrich Gerster"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jack Doolan",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Harold",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Miss Lana",
+          "sprecher" : "Sabine Schmidt-Kirchner"
+        },
+        {
+          "rolle" : "Mademoiselle Nadine",
+          "sprecher" : "Jennie Appel"
+        },
+        {
+          "rolle" : "Toby Grissom",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Frank Mortimer",
+          "sprecher" : "Karl-Friedrich Gerster"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/5/metadata.json",
@@ -1269,51 +1270,51 @@
           "end" : 3924760
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ellen Maxell",
-          "Traudel Sperber"
-        ],
-        [
-          "Audrey Moonshadow",
-          "Judy Winter"
-        ],
-        [
-          "Sandy Stryker",
-          "Martina Regenhardt"
-        ],
-        [
-          "Mandy Honeyball",
-          "Celine Fontanges"
-        ],
-        [
-          "Mars Chaplin",
-          "Rainer Schmitt"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Assistent",
-          "Dirk Bach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ellen Maxell",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Audrey Moonshadow",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Sandy Stryker",
+          "sprecher" : "Martina Regenhardt"
+        },
+        {
+          "rolle" : "Mandy Honeyball",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Mars Chaplin",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Assistent",
+          "sprecher" : "Dirk Bach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/6/metadata.json",
@@ -1381,67 +1382,68 @@
           "end" : 3920920
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jones",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus Jones",
-          "Hans Meinhardt"
-        ],
-        [
-          "Marty Stevens",
-          "Lutz Harder"
-        ],
-        [
-          "Joshua Apeh",
-          "Achim Schülke"
-        ],
-        [
-          "Claudia Salazar",
-          "Marion Elskis"
-        ],
-        [
-          "Ralf Dempsey",
-          "Robin Brosch"
-        ],
-        [
-          "Marvin Cox",
-          "Jörg Gillner"
-        ],
-        [
-          "Anna",
-          "Micaela Kreissler"
-        ],
-        [
-          "George",
-          "Eric Schaeffler"
-        ],
-        [
-          "Hapa",
-          "Michael Weckler"
-        ],
-        [
-          "Lastwagenfahrer",
-          "Tim Wenderoth"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda Jones",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus Jones",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Marty Stevens",
+          "sprecher" : "Lutz Harder"
+        },
+        {
+          "rolle" : "Joshua Apeh",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Claudia Salazar",
+          "sprecher" : "Marion Elskis"
+        },
+        {
+          "rolle" : "Ralf Dempsey",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Marvin Cox",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Anna",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Hapa",
+          "sprecher" : "Michael Weckler"
+        },
+        {
+          "rolle" : "Lastwagenfahrer",
+          "sprecher" : "Tim Wenderoth"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/7/metadata.json",
@@ -1499,67 +1501,67 @@
           "end" : 4627360
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Jupiter Jones",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Crenshaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Taro Togati",
-          "Stefan Brönneke"
-        ],
-        [
-          "Officer Hunter",
-          "Jürgen Kluckert"
-        ],
-        [
-          "Türsteher",
-          "Arndt Schmöle"
-        ],
-        [
-          "Motelangestellter",
-          "Jelko von Tiele-Winckler"
-        ],
-        [
-          "Museumsdirektor",
-          "Rainer Schmitt"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Harvey Denton",
-          "Klaus Herm"
-        ],
-        [
-          "Mrs. Fox",
-          "Nana Spier"
-        ],
-        [
-          "Inspektor Milton",
-          "Holger Mahlich"
-        ],
-        [
-          "Arthur Heatherly",
-          "Rainer Brandt"
-        ],
-        [
-          "Melissa Heatherly",
-          "Stephanie Kirchberger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Jupiter Jones",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Crenshaw",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Taro Togati",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Officer Hunter",
+          "sprecher" : "Jürgen Kluckert"
+        },
+        {
+          "rolle" : "Türsteher",
+          "sprecher" : "Arndt Schmöle"
+        },
+        {
+          "rolle" : "Motelangestellter",
+          "sprecher" : "Jelko von Tiele-Winckler"
+        },
+        {
+          "rolle" : "Museumsdirektor",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Tante Mathilda Jones",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Harvey Denton",
+          "sprecher" : "Klaus Herm"
+        },
+        {
+          "rolle" : "Mrs. Fox",
+          "sprecher" : "Nana Spier"
+        },
+        {
+          "rolle" : "Inspektor Milton",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Arthur Heatherly",
+          "sprecher" : "Rainer Brandt"
+        },
+        {
+          "rolle" : "Melissa Heatherly",
+          "sprecher" : "Stephanie Damare"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/8/metadata.json",

--- a/web/data/DiE_DR3i/1/metadata.json
+++ b/web/data/DiE_DR3i/1/metadata.json
@@ -287,67 +287,67 @@
       "end" : 7993773
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Milton",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Ashby",
-      "Sabine Hahn"
-    ],
-    [
-      "Charles Prendergast",
-      "Rolf Nagel"
-    ],
-    [
-      "Richard Crandall",
-      "Konstantin Graudus"
-    ],
-    [
-      "Kirk Prendergast",
-      "Wolf Frass"
-    ],
-    [
-      "Blacky",
-      "Heikedine Körting"
-    ],
-    [
-      "Jonathan Godfrey",
-      "Eric Schäffler"
-    ],
-    [
-      "Carlos",
-      "Eduardo Garcia"
-    ],
-    [
-      "Garrett",
-      "Dietrich Adam"
-    ],
-    [
-      "Riteman",
-      "Till Demtrøder"
-    ],
-    [
-      "Stanley",
-      "Lutz Schnell"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Milton",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Ashby",
+      "sprecher" : "Sabine Hahn"
+    },
+    {
+      "rolle" : "Charles Prendergast",
+      "sprecher" : "Rolf Nagel"
+    },
+    {
+      "rolle" : "Richard Crandall",
+      "sprecher" : "Konstantin Graudus"
+    },
+    {
+      "rolle" : "Kirk Prendergast",
+      "sprecher" : "Wolf Frass"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Jonathan Godfrey",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Carlos",
+      "sprecher" : "Eduardo Garcia"
+    },
+    {
+      "rolle" : "Garrett",
+      "sprecher" : "Dietrich Adam"
+    },
+    {
+      "rolle" : "Riteman",
+      "sprecher" : "Till Demtrøder"
+    },
+    {
+      "rolle" : "Stanley",
+      "sprecher" : "Lutz Schnell"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/1/metadata.json",

--- a/web/data/DiE_DR3i/2/metadata.json
+++ b/web/data/DiE_DR3i/2/metadata.json
@@ -67,59 +67,59 @@
       "end" : 4634013
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Sylvester Meyzel",
-      "Wolfgang Völz"
-    ],
-    [
-      "Dorothy Winter",
-      "Doris Kunstmann"
-    ],
-    [
-      "Mr. Hendrik",
-      "Utz Richter"
-    ],
-    [
-      "Kassiererin",
-      "Enie van de Meiklokjes"
-    ],
-    [
-      "Inspektor Milton",
-      "Holger Mahlich"
-    ],
-    [
-      "Inspektor Tomlin",
-      "Klaus Dittmann"
-    ],
-    [
-      "Mr. X",
-      "Dirk Eichhorn"
-    ],
-    [
-      "Tao",
-      "Tilman Maddaus"
-    ],
-    [
-      "Supermarkt-Durchsage",
-      "André Minninger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Sylvester Meyzel",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Dorothy Winter",
+      "sprecher" : "Doris Kunstmann"
+    },
+    {
+      "rolle" : "Mr. Hendrik",
+      "sprecher" : "Utz Richter"
+    },
+    {
+      "rolle" : "Kassiererin",
+      "sprecher" : "Enie van de Meiklokjes"
+    },
+    {
+      "rolle" : "Inspektor Milton",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Inspektor Tomlin",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Mr. X",
+      "sprecher" : "Dirk Eichhorn"
+    },
+    {
+      "rolle" : "Tao",
+      "sprecher" : "Tilman Madaus"
+    },
+    {
+      "rolle" : "Supermarkt-Durchsage",
+      "sprecher" : "André Minninger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/2/metadata.json",

--- a/web/data/DiE_DR3i/3/metadata.json
+++ b/web/data/DiE_DR3i/3/metadata.json
@@ -72,51 +72,51 @@
       "end" : 4113813
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "James Taylor",
-      "Wanja Mues"
-    ],
-    [
-      "Ray Wells",
-      "Dietrich Adam"
-    ],
-    [
-      "Frank Caspian",
-      "Christian Redl"
-    ],
-    [
-      "Jonathan Grant",
-      "Bernd Stephan"
-    ],
-    [
-      "Christy Grant",
-      "Anja Topf"
-    ],
-    [
-      "George Drummond",
-      "Eberhard Haar"
-    ],
-    [
-      "Tom Drummond",
-      "Patrick Bach"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "James Taylor",
+      "sprecher" : "Wanja Mues"
+    },
+    {
+      "rolle" : "Ray Wells",
+      "sprecher" : "Dietrich Adam"
+    },
+    {
+      "rolle" : "Frank Caspian",
+      "sprecher" : "Christian Redl"
+    },
+    {
+      "rolle" : "Jonathan Grant",
+      "sprecher" : "Bernd Stephan"
+    },
+    {
+      "rolle" : "Christy Grant",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "George Drummond",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Tom Drummond",
+      "sprecher" : "Patrick Bach"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/3/metadata.json",

--- a/web/data/DiE_DR3i/4/metadata.json
+++ b/web/data/DiE_DR3i/4/metadata.json
@@ -62,63 +62,64 @@
       "end" : 4747133
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus Jones",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda Jones",
-      "Karin Lieneweg"
-    ],
-    [
-      "Inspektor Milton",
-      "Holger Mahlich"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Mr. Walker",
-      "Gustav-Adolph Artz"
-    ],
-    [
-      "Donald Forthland",
-      "Günter Lüdke"
-    ],
-    [
-      "Shane Montana",
-      "Jürgen Thormann"
-    ],
-    [
-      "Jim",
-      "Wolfgang Berger"
-    ],
-    [
-      "Doc Brown",
-      "Tim Wenderoth"
-    ],
-    [
-      "Finnegan",
-      "Fabian Harloff"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus Jones",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda Jones",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Inspektor Milton",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Mr. Walker",
+      "sprecher" : "Gustav-Adolph Artz"
+    },
+    {
+      "rolle" : "Donald Forthland",
+      "sprecher" : "Günter Lüdke"
+    },
+    {
+      "rolle" : "Shane Montana",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Jim",
+      "sprecher" : "Wolfgang Berger"
+    },
+    {
+      "rolle" : "Doc Brown",
+      "sprecher" : "Tim Wenderoth"
+    },
+    {
+      "rolle" : "Finnegan",
+      "sprecher" : "Fabian Harloff"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/4/metadata.json",

--- a/web/data/DiE_DR3i/5/metadata.json
+++ b/web/data/DiE_DR3i/5/metadata.json
@@ -62,47 +62,47 @@
       "end" : 4409520
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jack Doolan",
-      "Eckart Dux"
-    ],
-    [
-      "Harold",
-      "Gernot Endemann"
-    ],
-    [
-      "Miss Lana",
-      "Sabine Schmidt-Kirchner"
-    ],
-    [
-      "Mademoiselle Nadine",
-      "Jennie Appel"
-    ],
-    [
-      "Toby Grissom",
-      "Lothar Grützner"
-    ],
-    [
-      "Frank Mortimer",
-      "Karl-Friedrich Gerster"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jack Doolan",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Harold",
+      "sprecher" : "Gernot Endemann"
+    },
+    {
+      "rolle" : "Miss Lana",
+      "sprecher" : "Sabine Schmidt-Kirchner"
+    },
+    {
+      "rolle" : "Mademoiselle Nadine",
+      "sprecher" : "Jennie Appel"
+    },
+    {
+      "rolle" : "Toby Grissom",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Frank Mortimer",
+      "sprecher" : "Karl-Friedrich Gerster"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/5/metadata.json",

--- a/web/data/DiE_DR3i/6/metadata.json
+++ b/web/data/DiE_DR3i/6/metadata.json
@@ -57,51 +57,51 @@
       "end" : 3924760
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ellen Maxell",
-      "Traudel Sperber"
-    ],
-    [
-      "Audrey Moonshadow",
-      "Judy Winter"
-    ],
-    [
-      "Sandy Stryker",
-      "Martina Regenhardt"
-    ],
-    [
-      "Mandy Honeyball",
-      "Celine Fontanges"
-    ],
-    [
-      "Mars Chaplin",
-      "Rainer Schmitt"
-    ],
-    [
-      "Inspektor Milton",
-      "Holger Mahlich"
-    ],
-    [
-      "Assistent",
-      "Dirk Bach"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ellen Maxell",
+      "sprecher" : "Traudel Sperber"
+    },
+    {
+      "rolle" : "Audrey Moonshadow",
+      "sprecher" : "Judy Winter"
+    },
+    {
+      "rolle" : "Sandy Stryker",
+      "sprecher" : "Martina Regenhardt"
+    },
+    {
+      "rolle" : "Mandy Honeyball",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Mars Chaplin",
+      "sprecher" : "Rainer Schmitt"
+    },
+    {
+      "rolle" : "Inspektor Milton",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Assistent",
+      "sprecher" : "Dirk Bach"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/6/metadata.json",

--- a/web/data/DiE_DR3i/7/metadata.json
+++ b/web/data/DiE_DR3i/7/metadata.json
@@ -57,67 +57,68 @@
       "end" : 3920920
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jones",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus Jones",
-      "Hans Meinhardt"
-    ],
-    [
-      "Marty Stevens",
-      "Lutz Harder"
-    ],
-    [
-      "Joshua Apeh",
-      "Achim Schülke"
-    ],
-    [
-      "Claudia Salazar",
-      "Marion Elskis"
-    ],
-    [
-      "Ralf Dempsey",
-      "Robin Brosch"
-    ],
-    [
-      "Marvin Cox",
-      "Jörg Gillner"
-    ],
-    [
-      "Anna",
-      "Micaela Kreissler"
-    ],
-    [
-      "George",
-      "Eric Schaeffler"
-    ],
-    [
-      "Hapa",
-      "Michael Weckler"
-    ],
-    [
-      "Lastwagenfahrer",
-      "Tim Wenderoth"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda Jones",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus Jones",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Marty Stevens",
+      "sprecher" : "Lutz Harder"
+    },
+    {
+      "rolle" : "Joshua Apeh",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Claudia Salazar",
+      "sprecher" : "Marion Elskis"
+    },
+    {
+      "rolle" : "Ralf Dempsey",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Marvin Cox",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Anna",
+      "sprecher" : "Micaëla Kreißler"
+    },
+    {
+      "rolle" : "George",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Hapa",
+      "sprecher" : "Michael Weckler"
+    },
+    {
+      "rolle" : "Lastwagenfahrer",
+      "sprecher" : "Tim Wenderoth"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/7/metadata.json",

--- a/web/data/DiE_DR3i/8/metadata.json
+++ b/web/data/DiE_DR3i/8/metadata.json
@@ -47,67 +47,67 @@
       "end" : 4627360
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Taro Togati",
-      "Stefan Brönneke"
-    ],
-    [
-      "Officer Hunter",
-      "Jürgen Kluckert"
-    ],
-    [
-      "Türsteher",
-      "Arndt Schmöle"
-    ],
-    [
-      "Motelangestellter",
-      "Jelko von Tiele-Winckler"
-    ],
-    [
-      "Museumsdirektor",
-      "Rainer Schmitt"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Harvey Denton",
-      "Klaus Herm"
-    ],
-    [
-      "Mrs. Fox",
-      "Nana Spier"
-    ],
-    [
-      "Inspektor Milton",
-      "Holger Mahlich"
-    ],
-    [
-      "Arthur Heatherly",
-      "Rainer Brandt"
-    ],
-    [
-      "Melissa Heatherly",
-      "Stephanie Kirchberger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Taro Togati",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Officer Hunter",
+      "sprecher" : "Jürgen Kluckert"
+    },
+    {
+      "rolle" : "Türsteher",
+      "sprecher" : "Arndt Schmöle"
+    },
+    {
+      "rolle" : "Motelangestellter",
+      "sprecher" : "Jelko von Tiele-Winckler"
+    },
+    {
+      "rolle" : "Museumsdirektor",
+      "sprecher" : "Rainer Schmitt"
+    },
+    {
+      "rolle" : "Tante Mathilda Jones",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Harvey Denton",
+      "sprecher" : "Klaus Herm"
+    },
+    {
+      "rolle" : "Mrs. Fox",
+      "sprecher" : "Nana Spier"
+    },
+    {
+      "rolle" : "Inspektor Milton",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Arthur Heatherly",
+      "sprecher" : "Rainer Brandt"
+    },
+    {
+      "rolle" : "Melissa Heatherly",
+      "sprecher" : "Stephanie Damare"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/8/metadata.json",

--- a/web/data/DiE_DR3i/Hotel-Luxury-End/metadata.json
+++ b/web/data/DiE_DR3i/Hotel-Luxury-End/metadata.json
@@ -281,71 +281,71 @@
   "hörspielskriptautor" : "Ivar Leon Menger",
   "beschreibung" : "Eine Nacht in einem Luxushotel, direkt an der malerischen Steilküste Nordkaliforniens? Normalerweise ein Grund zur Freude. Doch nicht für Jupiter, Peter und Bob! Denn Die Dr3i müssen um ihr Leben fürchten! Und das, obwohl das unheimliche Hotel vollkommen menschenleer ist …\nErlebe das erste interaktive Hörspiel mit Jupiter Jones, Peter Crenshaw und Bob Andrews! Mit einem Knopfdruck auf deinem CD-Player kannst du mitbestimmen, welche Lösungswege die drei Detektive bei diesem mysteriösen Abenteuer einschlagen sollen.\nAuf 2 CDs erwarten dich viele ungelöste Rätsel und Geheimnisse, sowie 16 alternative Enden!",
   "veröffentlichungsdatum" : "2006-11-24",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Jupiter Jones",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Crenshaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jones",
-      "Karin Lieneweg"
-    ],
-    [
-      "Mr. Overlook",
-      "Joachim Kerzel"
-    ],
-    [
-      "Portier Stanley",
-      "Lutz Mackensy"
-    ],
-    [
-      "Liftboy Jack",
-      "Jan-David Rönfeldt"
-    ],
-    [
-      "Barkeeper Lloyd",
-      "Roman Kretschmer"
-    ],
-    [
-      "Mr. Torrance",
-      "Holger Löwenberg"
-    ],
-    [
-      "Mrs. Torrence",
-      "Katja Brügger"
-    ],
-    [
-      "Shelley",
-      "Saskia Weckler"
-    ],
-    [
-      "Stuart",
-      "Nicolas König"
-    ],
-    [
-      "Danny",
-      "Patrick Bach"
-    ],
-    [
-      "Police Officer",
-      "Jürgen Thormann"
-    ],
-    [
-      "Nachrichtensprecher",
-      "Bernd Klose"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Jupiter Jones",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Crenshaw",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda Jones",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Mr. Overlook",
+      "sprecher" : "Joachim Kerzel"
+    },
+    {
+      "rolle" : "Portier Stanley",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Liftboy Jack",
+      "sprecher" : "Jan-David Rönfeldt"
+    },
+    {
+      "rolle" : "Barkeeper Lloyd",
+      "sprecher" : "Roman Kretschmer"
+    },
+    {
+      "rolle" : "Mr. Torrance",
+      "sprecher" : "Holger Löwenberg"
+    },
+    {
+      "rolle" : "Mrs. Torrance",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Shelley Torrance",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Stuart",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Danny",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Police Officer",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Nachrichtensprecher",
+      "sprecher" : "Bernd Klose"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/metadata.json",

--- a/web/data/Kurzgeschichten.json
+++ b/web/data/Kurzgeschichten.json
@@ -10,51 +10,51 @@
               "autor" : "Kari Erlhoff",
               "beschreibung" : "Mr. Vancura ist Schauspieler und sammelt alles, was mit dem Orient zu tun hat. Sein ganzer Stolz ist eine Wunderlampe, in der ein richtiger Dschinn lebt. Aber der Dschinn ist verschwunden …",
               "veröffentlichungsdatum" : "2011-12-02",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Mr. Vancura",
-                  "Lutz Herkenrath"
-                ],
-                [
-                  "Mrs. Fox",
-                  "Susan Jarling"
-                ],
-                [
-                  "Inspektor Cotta",
-                  "Holger Mahlich"
-                ],
-                [
-                  "Mr. Shaw",
-                  "Rasmus Borowski"
-                ],
-                [
-                  "Shannon",
-                  "Kerstin Draeger"
-                ],
-                [
-                  "Mr. Mosley",
-                  "Neil Malik Abdullah"
-                ],
-                [
-                  "Mann",
-                  "Thor W. Müller"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Mr. Vancura",
+                  "sprecher" : "Lutz Herkenrath"
+                },
+                {
+                  "rolle" : "Mrs. Fox",
+                  "sprecher" : "Susan Jarling"
+                },
+                {
+                  "rolle" : "Inspektor Cotta",
+                  "sprecher" : "Holger Mahlich"
+                },
+                {
+                  "rolle" : "Mr. Shaw",
+                  "sprecher" : "Rasmus Borowski"
+                },
+                {
+                  "rolle" : "Shannon",
+                  "sprecher" : "Kerstin Draeger"
+                },
+                {
+                  "rolle" : "Mr. Mosley",
+                  "sprecher" : "Neil Malik Abdullah"
+                },
+                {
+                  "rolle" : "Mann",
+                  "sprecher" : "Thor W. Müller"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/1/metadata.json",
@@ -67,27 +67,27 @@
               "autor" : "Marco Sonnleitner",
               "beschreibung" : "Das neuste Hobby von Justus Jonas ist die Ahnenforschung.\nUnd dabei macht er eines Tages eine unglaubliche Entdeckung …",
               "veröffentlichungsdatum" : "2011-12-04",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Cowboy",
-                  "Achim Schülke"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Cowboy",
+                  "sprecher" : "Achim Schülke"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/2/metadata.json",
@@ -100,35 +100,35 @@
               "autor" : "Marco Sonnleitner",
               "beschreibung" : "Peter erhält eine E-Mail: Kelly ist entführt worden! Den drei ??? bleibt weniger als eine Stunde Zeit, sie zu finden und zu befreien …",
               "veröffentlichungsdatum" : "2011-12-06",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Patricia",
-                  "Rhea Harder"
-                ],
-                [
-                  "Peter Shawn",
-                  "Leonhard Mahlich"
-                ],
-                [
-                  "Mann",
-                  "Helgo Liebig"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Patricia",
+                  "sprecher" : "Rhea Harder-Vennewald"
+                },
+                {
+                  "rolle" : "Peter Shawn",
+                  "sprecher" : "Leonhard Mahlich"
+                },
+                {
+                  "rolle" : "Mann",
+                  "sprecher" : "Helgo Liebig"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/3/metadata.json",
@@ -141,11 +141,11 @@
               "autor" : "Hendrik Buchna",
               "beschreibung" : "Auf dem Autorasthof \"Eagle Ranch\" geschehen merkwürdige Dinge und die drei ??? erhalten den Auftrag, herauszufinden, was es damit auf sich hat …",
               "veröffentlichungsdatum" : "2011-12-08",
-              "sprecher" : [
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/4/metadata.json",
@@ -190,39 +190,39 @@
               "autor" : "Marco Sonnleitner",
               "beschreibung" : "Als die drei ??? vom Strand kommen und auf dem Weg nach Hause sind, sehen sie ein SOS-Signal, das aus einem Haus gesendet wird. Eigentlich steht das Haus leer …",
               "veröffentlichungsdatum" : "2011-12-10",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Marty",
-                  "Philipp Draeger"
-                ],
-                [
-                  "Fred",
-                  "Guido Bernadotte"
-                ],
-                [
-                  "1. Mann",
-                  "Rasmus Rakete"
-                ],
-                [
-                  "2. Mann",
-                  "Patrick Perales"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Marty",
+                  "sprecher" : "Philipp Draeger"
+                },
+                {
+                  "rolle" : "Fred",
+                  "sprecher" : "Guido Bernadotte"
+                },
+                {
+                  "rolle" : "Mann 1",
+                  "sprecher" : "Rasmus Rakete"
+                },
+                {
+                  "rolle" : "Mann 2",
+                  "sprecher" : "Patrick Perales"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/5/metadata.json",
@@ -235,11 +235,11 @@
               "autor" : "Hendrik Buchna",
               "beschreibung" : "Auf dem Weg nach Hause wird Peter plötzlich von einem unheimlichen, grauen Dämon verfolgt. Ihm bleibt nur noch ein Ausweg: Die Flucht …",
               "veröffentlichungsdatum" : "2011-12-12",
-              "sprecher" : [
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/6/metadata.json",
@@ -252,27 +252,27 @@
               "autor" : "Kari Erlhoff",
               "beschreibung" : "Peters ehemalige Klavierlehrerin, Mrs. Floyd, engagiert die drei ???, um herauszufinden, wo ihre verstorbene Mutter ihr Erbe versteckt haben könnte …",
               "veröffentlichungsdatum" : "2011-12-14",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Mrs. Floyd",
-                  "Gabriele Libbach"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Mrs. Floyd",
+                  "sprecher" : "Gabriele Libbach"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/7/metadata.json",
@@ -285,31 +285,31 @@
               "autor" : "Hendrik Buchna",
               "beschreibung" : "Die drei ??? erhalten den Auftrag, bei der Übergabe einer schwarzen Nadel dabei zu sein. Aber geht es dabei wirklich nur um das Schmuckstück?",
               "veröffentlichungsdatum" : "2011-12-16",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda Jonas",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Vincent Grimes",
-                  "Konstantin Graudus"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Vincent Grimes",
+                  "sprecher" : "Konstantin Graudus"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/8/metadata.json",
@@ -354,43 +354,44 @@
               "autor" : "Kari Erlhoff",
               "beschreibung" : "Blacky, der Papagei der drei ???, benimmt sich seit ein paar Tagen höchst sonderbar.\nWas ist der Grund für die merkwürdigen Sprüche, die der Vogel plötzlich zitiert …",
               "veröffentlichungsdatum" : "2011-12-18",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda Jonas",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Blacky/Mynah",
-                  "Heikedine Körting"
-                ],
-                [
-                  "Juliet",
-                  "Anne Moll"
-                ],
-                [
-                  "Scott",
-                  "Tommaso Cacciapuoti"
-                ],
-                [
-                  "John",
-                  "Martin Sichel"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Blacky",
+                  "sprecher" : "Heikedine Körting"
+                },
+                {
+                  "rolle" : "Juliet",
+                  "sprecher" : "Anne Moll"
+                },
+                {
+                  "rolle" : "Scott",
+                  "sprecher" : "Tommaso Cacciapuoti"
+                },
+                {
+                  "rolle" : "John",
+                  "sprecher" : "Sascha Draeger",
+                  "pseudonym" : "Martin Sichel"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/9/metadata.json",
@@ -403,11 +404,11 @@
               "autor" : "Marco Sonnleitner",
               "beschreibung" : "Die drei ??? sollen von der Stadt Rocky Beach für ihr Lebenswerk geehrt werden. Und prompt sitzen sie gleich wieder mitten in einem neuen Fall …",
               "veröffentlichungsdatum" : "2011-12-20",
-              "sprecher" : [
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/10/metadata.json",
@@ -420,35 +421,35 @@
               "autor" : "Kari Erlhoff",
               "beschreibung" : "Kellys Tante wird erpresst und die drei ??? sollen bei der Übergabe des Geldes behilflich sein. Aber in dem Motel, in dem Peter und Kelly absteigen, passieren merkwürdige Dinge …",
               "veröffentlichungsdatum" : "2011-12-22",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Kelly",
-                  "Juliane Szalay"
-                ],
-                [
-                  "Norman",
-                  "Eckart Dux"
-                ],
-                [
-                  "Frau",
-                  "Anja Topf"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Kelly",
+                  "sprecher" : "Juliane Szalay"
+                },
+                {
+                  "rolle" : "Norman",
+                  "sprecher" : "Eckart Dux"
+                },
+                {
+                  "rolle" : "Frau",
+                  "sprecher" : "Anja Topf"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/11/metadata.json",
@@ -461,43 +462,43 @@
               "autor" : "Hendrik Buchna",
               "beschreibung" : "Rocky Beach versinkt im Schnee. Und zu allem Überfluss treibt gerade jetzt, wo die Polizei mehr oder weniger handlungsunfähig ist, ein krimineller Weihnachtsmann in der Stadt sein Unwesen …",
               "veröffentlichungsdatum" : "2011-12-24",
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Inspektor Cotta",
-                  "Holger Mahlich"
-                ],
-                [
-                  "Mr. Darrow",
-                  "Joachim Kappl"
-                ],
-                [
-                  "1. Mann",
-                  "Patrick Bach"
-                ],
-                [
-                  "2. Mann",
-                  "Frank Meyer-Brockmann"
-                ],
-                [
-                  "3. Mann",
-                  "Roy Martens"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Inspektor Cotta",
+                  "sprecher" : "Holger Mahlich"
+                },
+                {
+                  "rolle" : "Mr. Darrow",
+                  "sprecher" : "Joachim Kappl"
+                },
+                {
+                  "rolle" : "Mann 1",
+                  "sprecher" : "Patrick Bach"
+                },
+                {
+                  "rolle" : "Mann 2",
+                  "sprecher" : "Frank Meyer-Brockmann"
+                },
+                {
+                  "rolle" : "Mann 3",
+                  "sprecher" : "Roy Martens"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/12/metadata.json",
@@ -570,51 +571,52 @@
                   "end" : 1596747
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Emily White",
-                  "Sabine Hahn"
-                ],
-                [
-                  "Judy Fradkin",
-                  "Ursula Heyer"
-                ],
-                [
-                  "Aladin",
-                  "Heidi Schaffrath"
-                ],
-                [
-                  "Aschenputtel",
-                  "Regina Lemnitz"
-                ],
-                [
-                  "Prinzessin",
-                  "Renate Pichler"
-                ],
-                [
-                  "Rotkäppchen",
-                  "Angela Stresemann"
-                ],
-                [
-                  "Meerjungfrau",
-                  "Pamela Punti"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Emily White",
+                  "sprecher" : "Sabine Hahn"
+                },
+                {
+                  "rolle" : "Judy Fradkin",
+                  "sprecher" : "Ursula Heyer"
+                },
+                {
+                  "rolle" : "Aladin",
+                  "sprecher" : "Heidi Schaffrath"
+                },
+                {
+                  "rolle" : "Aschenputtel",
+                  "sprecher" : "Regina Lemnitz"
+                },
+                {
+                  "rolle" : "Prinzessin",
+                  "sprecher" : "Renate Pichler"
+                },
+                {
+                  "rolle" : "Rotkäppchen",
+                  "sprecher" : "Angela Stresemann"
+                },
+                {
+                  "rolle" : "Meerjungfrau",
+                  "sprecher" : "Heikedine Körting",
+                  "pseudonym" : "Pamela Punti"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/metadata.json",
@@ -643,43 +645,43 @@
                   "end" : 1477173
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Mr. Andrews",
-                  "Henry König"
-                ],
-                [
-                  "Mrs. Andrews",
-                  "Konstanze Ullmer"
-                ],
-                [
-                  "Arzt",
-                  "Erik Schäffler"
-                ],
-                [
-                  "Mrs. Wallace",
-                  "Angela Stresemann"
-                ],
-                [
-                  "Bobby",
-                  "Merete Brettschneider"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Mr. Andrews",
+                  "sprecher" : "Henry König"
+                },
+                {
+                  "rolle" : "Mrs. Andrews",
+                  "sprecher" : "Konstanze Ullmer"
+                },
+                {
+                  "rolle" : "Arzt",
+                  "sprecher" : "Erik Schäffler"
+                },
+                {
+                  "rolle" : "Mrs. Wallace",
+                  "sprecher" : "Angela Stresemann"
+                },
+                {
+                  "rolle" : "Bobby",
+                  "sprecher" : "Merete Brettschneider"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/metadata.json",
@@ -749,31 +751,32 @@
                   "end" : 1574187
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda Jonas",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Onkel Titus Jonas",
-                  "Hans Meinhardt"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/metadata.json",
@@ -802,47 +805,47 @@
                   "end" : 1174080
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Croupier",
-                  "Gosta Liptow"
-                ],
-                [
-                  "Carl Hopkins, Physiker",
-                  "Ben Hecker"
-                ],
-                [
-                  "Miller, Schiffsdetektiv",
-                  "Michael Grimm"
-                ],
-                [
-                  "Kapitän Sherwood",
-                  "Horst Naumann"
-                ],
-                [
-                  "Theodore Quaid",
-                  "Dietrich Adam"
-                ],
-                [
-                  "Jamie Peterson, Barmann",
-                  "Patrick Bach"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Croupier",
+                  "sprecher" : "Gosta Liptow"
+                },
+                {
+                  "rolle" : "Carl Hopkins, Physiker",
+                  "sprecher" : "Ben Hecker"
+                },
+                {
+                  "rolle" : "Miller, Schiffsdetektiv",
+                  "sprecher" : "Michael Grimm"
+                },
+                {
+                  "rolle" : "Kapitän Sherwood",
+                  "sprecher" : "Horst Naumann"
+                },
+                {
+                  "rolle" : "Theodore Quaid",
+                  "sprecher" : "Dietrich Adam"
+                },
+                {
+                  "rolle" : "Jamie Peterson, Barmann",
+                  "sprecher" : "Patrick Bach"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/metadata.json",
@@ -912,43 +915,45 @@
                   "end" : 1389800
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Onkel Titus Jonas",
-                  "Hans Meinhardt"
-                ],
-                [
-                  "Tante Mathilda Jonas",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Handerson",
-                  "Wolfgang Rositzka"
-                ],
-                [
-                  "Diego",
-                  "Stefan Benson"
-                ],
-                [
-                  "Mercedes",
-                  "Wanda Osten"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Handerson",
+                  "sprecher" : "Wolfgang Rositzka"
+                },
+                {
+                  "rolle" : "Diego",
+                  "sprecher" : "Stephan Benson"
+                },
+                {
+                  "rolle" : "Mercedes",
+                  "sprecher" : "Hella von der Osten-Sacken",
+                  "pseudonym" : "Wanda Osten"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/metadata.json",
@@ -977,39 +982,40 @@
                   "end" : 1409027
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Nayeli",
-                  "Stefan Brönneke"
-                ],
-                [
-                  "Barker",
-                  "Ben Hecker"
-                ],
-                [
-                  "Onkel Titus Jonas",
-                  "Hans Meinhardt"
-                ],
-                [
-                  "Off-Sprecherin",
-                  "Claudia Stocksieker"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Nayeli",
+                  "sprecher" : "Stefan Brönneke"
+                },
+                {
+                  "rolle" : "Barker",
+                  "sprecher" : "Ben Hecker"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                },
+                {
+                  "rolle" : "Off-Sprecherin",
+                  "sprecher" : "Claudia Stocksieker"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/metadata.json",
@@ -1038,35 +1044,36 @@
                   "end" : 1099640
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda Jonas",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Onkel Titus Jonas",
-                  "Hans Meinhardt"
-                ],
-                [
-                  "Ian Carew",
-                  "Sascha Draeger"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                },
+                {
+                  "rolle" : "Ian Carew",
+                  "sprecher" : "Sascha Draeger"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/metadata.json",
@@ -1163,31 +1170,31 @@
                   "end" : 950800
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Hüne",
-                  "Johannes Semm"
-                ],
-                [
-                  "Marvin Gray",
-                  "Horst Stark"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Hüne",
+                  "sprecher" : "Johannes Semm"
+                },
+                {
+                  "rolle" : "Marvin Gray",
+                  "sprecher" : "Horst Stark"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/1/metadata.json",
@@ -1216,51 +1223,51 @@
                   "end" : 1198507
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Nancy McMonigal",
-                  "Gerlinde Dilge"
-                ],
-                [
-                  "Tom",
-                  "Wolfgang Rositzka"
-                ],
-                [
-                  "Rod",
-                  "Herbert Tennigkeit"
-                ],
-                [
-                  "Joe",
-                  "Oliver Reichmann"
-                ],
-                [
-                  "Ben",
-                  "Stephan Chrzescinski"
-                ],
-                [
-                  "Mariann",
-                  "Simone Ritscher"
-                ],
-                [
-                  "TV-Sprecher",
-                  "Holger Wemhoff"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Nancy McMonigal",
+                  "sprecher" : "Gerlinde Dillge"
+                },
+                {
+                  "rolle" : "Tom",
+                  "sprecher" : "Wolfgang Rositzka"
+                },
+                {
+                  "rolle" : "Rod",
+                  "sprecher" : "Herbert Tennigkeit"
+                },
+                {
+                  "rolle" : "Joe",
+                  "sprecher" : "Olaf Reichmann"
+                },
+                {
+                  "rolle" : "Ben",
+                  "sprecher" : "Stephan Chrzescinski"
+                },
+                {
+                  "rolle" : "Mariann",
+                  "sprecher" : "Simone Ritscher"
+                },
+                {
+                  "rolle" : "TV-Sprecher",
+                  "sprecher" : "Holger Wemhoff"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/2/metadata.json",
@@ -1284,31 +1291,31 @@
                   "end" : 1502960
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Malcolm Fever",
-                  "Tilo Schmitz"
-                ],
-                [
-                  "Lucy Hopkins",
-                  "Topsy Küppers"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Malcolm Fever",
+                  "sprecher" : "Tilo Schmitz"
+                },
+                {
+                  "rolle" : "Lucy Hopkins",
+                  "sprecher" : "Topsy Küppers"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/3/metadata.json",
@@ -1388,51 +1395,52 @@
                   "end" : 1748867
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Onkel Titus Jonas",
-                  "Hans Meinhardt"
-                ],
-                [
-                  "Tante Mathilda Jonas",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Professor Selby",
-                  "Claus Wilcke"
-                ],
-                [
-                  "Oberpriesterin",
-                  "Elga Schütz"
-                ],
-                [
-                  "Kevin",
-                  "Patrick Mölleken"
-                ],
-                [
-                  "Mann in Kutte",
-                  "Rüdiger Hellmann"
-                ],
-                [
-                  "Radio",
-                  "Wilhelm Wieben"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Onkel Titus",
+                  "sprecher" : "Andreas E. Beurmann",
+                  "pseudonym" : "Hans Meinhardt"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Professor Selby",
+                  "sprecher" : "Claus Wilcke"
+                },
+                {
+                  "rolle" : "Oberpriesterin",
+                  "sprecher" : "Elga Schütz"
+                },
+                {
+                  "rolle" : "Kevin",
+                  "sprecher" : "Patrick Mölleken"
+                },
+                {
+                  "rolle" : "Mann in Kutte",
+                  "sprecher" : "Rüdiger Hellmann"
+                },
+                {
+                  "rolle" : "Radio",
+                  "sprecher" : "Wilhelm Wieben"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/4/metadata.json",
@@ -1461,31 +1469,31 @@
                   "end" : 1136386
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Mr. Tilton",
-                  "Christian Senger"
-                ],
-                [
-                  "Mr. Walsh",
-                  "Christian Rudolf"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Mr. Tilton",
+                  "sprecher" : "Christian Senger"
+                },
+                {
+                  "rolle" : "Mr. Walsh",
+                  "sprecher" : "Christian Rudolf"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/5/metadata.json",
@@ -1519,51 +1527,51 @@
                   "end" : 1684120
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Thomas Fritsch"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Weise Frau",
-                  "Dorothea Hagena"
-                ],
-                [
-                  "Kelly",
-                  "Juliane Szalay-Pracht"
-                ],
-                [
-                  "Patrick",
-                  "Nicolas König"
-                ],
-                [
-                  "Samuel",
-                  "Johannes Semm"
-                ],
-                [
-                  "Kenneth",
-                  "Olaf Reichmann"
-                ],
-                [
-                  "Liz Zapata",
-                  "Merete Brettschneider"
-                ],
-                [
-                  "Skinny Norris",
-                  "Michael Harck"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Thomas Fritsch"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Weise Frau",
+                  "sprecher" : "Dorothea Hagena"
+                },
+                {
+                  "rolle" : "Kelly",
+                  "sprecher" : "Juliane Szalay"
+                },
+                {
+                  "rolle" : "Patrick",
+                  "sprecher" : "Nicolas König"
+                },
+                {
+                  "rolle" : "Samuel",
+                  "sprecher" : "Johannes Semm"
+                },
+                {
+                  "rolle" : "Kenneth",
+                  "sprecher" : "Olaf Reichmann"
+                },
+                {
+                  "rolle" : "Liz Zapata",
+                  "sprecher" : "Merete Brettschneider"
+                },
+                {
+                  "rolle" : "Skinny Norris",
+                  "sprecher" : "Michael Harck"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/6/metadata.json",
@@ -1665,19 +1673,19 @@
                   "end" : 2240920
                 }
               ],
-              "sprecher" : [
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/metadata.json",
@@ -1706,35 +1714,36 @@
                   "end" : 1855920
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Helen",
-                  "Balancinha Blanc (Dorette Hugo)"
-                ],
-                [
-                  "Ellen",
-                  "Dorette Hugo"
-                ],
-                [
-                  "Vater",
-                  "Douglas Welbat"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Helen",
+                  "sprecher" : "Dorette Hugo",
+                  "pseudonym" : "Balancinha Blanc"
+                },
+                {
+                  "rolle" : "Ellen",
+                  "sprecher" : "Dorette Hugo"
+                },
+                {
+                  "rolle" : "Vater",
+                  "sprecher" : "Douglas Welbat"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/metadata.json",
@@ -1804,43 +1813,47 @@
                   "end" : 1889653
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tante Mathilda Jonas",
-                  "Karin Lieneweg"
-                ],
-                [
-                  "Skinny Norris",
-                  "Michael Harck"
-                ],
-                [
-                  "Marc Kingstone",
-                  "Rainer Brandt"
-                ],
-                [
-                  "Aaron Kingstone",
-                  "Tommi Piper"
-                ],
-                [
-                  "Sarah",
-                  "Christiane Leuchtmann"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tante Mathilda",
+                  "sprecher" : "Karin Lieneweg"
+                },
+                {
+                  "rolle" : "Skinny Norris",
+                  "sprecher" : "Michael Harck"
+                },
+                {
+                  "rolle" : "Marc Kingstone",
+                  "sprecher" : "Rainer Brandt"
+                },
+                {
+                  "rolle" : "Aaron Kingstone",
+                  "sprecher" : "Tommi Piper"
+                },
+                {
+                  "rolle" : "Sarah",
+                  "sprecher" : "Christiane Leuchtmann"
+                },
+                {
+                  "rolle" : "Albert",
+                  "sprecher" : "Franzisko Löwe"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/metadata.json",
@@ -1869,59 +1882,59 @@
                   "end" : 1767387
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Kelly Madigan",
-                  "Juliane Szalay"
-                ],
-                [
-                  "Mrs. McGee",
-                  "Alice Krimmel"
-                ],
-                [
-                  "Toby",
-                  "A. Stengelin"
-                ],
-                [
-                  "Mrs. Wells",
-                  "Heidi Schaffrath"
-                ],
-                [
-                  "Junge",
-                  "Linus Tauber"
-                ],
-                [
-                  "Mädchen",
-                  "Katinka Jaekel"
-                ],
-                [
-                  "Ericsson",
-                  "Detlev Tams"
-                ],
-                [
-                  "Sprecher/Moderator",
-                  "Oliver Böttcher"
-                ],
-                [
-                  "Tarek Shabana",
-                  "Werner Wilkening"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Kelly Madigan",
+                  "sprecher" : "Juliane Szalay"
+                },
+                {
+                  "rolle" : "Mrs. McGee",
+                  "sprecher" : "Alice Krimmel"
+                },
+                {
+                  "rolle" : "Toby",
+                  "sprecher" : "A. Stengelin"
+                },
+                {
+                  "rolle" : "Mrs. Wells",
+                  "sprecher" : "Heidi Schaffrath"
+                },
+                {
+                  "rolle" : "Junge",
+                  "sprecher" : "Linus Tauber"
+                },
+                {
+                  "rolle" : "Mädchen",
+                  "sprecher" : "Katinka Jaekel"
+                },
+                {
+                  "rolle" : "Ericsson",
+                  "sprecher" : "Detlef Tams"
+                },
+                {
+                  "rolle" : "Sprecher/Moderator",
+                  "sprecher" : "Oliver Böttcher"
+                },
+                {
+                  "rolle" : "Tarek Shabana",
+                  "sprecher" : "Werner Wilkening"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/metadata.json",
@@ -1991,55 +2004,55 @@
                   "end" : 2256800
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Tasha",
-                  "Victoria Zöller"
-                ],
-                [
-                  "Domino Laverna",
-                  "Sabine Hahn"
-                ],
-                [
-                  "Biff Rodgers, Reporter",
-                  "Daniel Schütter"
-                ],
-                [
-                  "Lesley Dimple",
-                  "Ann Montenbruck"
-                ],
-                [
-                  "Zeus Zenon Johnson",
-                  "Michael Prelle"
-                ],
-                [
-                  "Computer",
-                  "Peter Bayer"
-                ],
-                [
-                  "Off-Sprecher",
-                  "Frank Roder"
-                ],
-                [
-                  "Sprecher",
-                  "Andreas Birnbaum"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Tasha",
+                  "sprecher" : "Victoria Zöller"
+                },
+                {
+                  "rolle" : "Domino Laverna",
+                  "sprecher" : "Sabine Hahn"
+                },
+                {
+                  "rolle" : "Biff Rodgers, Reporter",
+                  "sprecher" : "Daniel Schütter"
+                },
+                {
+                  "rolle" : "Lesley Dimple",
+                  "sprecher" : "Ann Montenbruck"
+                },
+                {
+                  "rolle" : "Zeus Zenon Johnson",
+                  "sprecher" : "Michael Prelle"
+                },
+                {
+                  "rolle" : "Computer",
+                  "sprecher" : "Peter Bayer"
+                },
+                {
+                  "rolle" : "Off-Sprecher",
+                  "sprecher" : "Frank Roder"
+                },
+                {
+                  "rolle" : "Sprecher",
+                  "sprecher" : "Andreas Birnbaum"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/metadata.json",
@@ -2068,35 +2081,36 @@
                   "end" : 1718507
                 }
               ],
-              "sprecher" : [
-                [
-                  "Erzähler",
-                  "Axel Milberg"
-                ],
-                [
-                  "Justus Jonas",
-                  "Oliver Rohrbeck"
-                ],
-                [
-                  "Peter Shaw",
-                  "Jens Wawrczeck"
-                ],
-                [
-                  "Bob Andrews",
-                  "Andreas Fröhlich"
-                ],
-                [
-                  "Blacky",
-                  "Pamela Punti"
-                ],
-                [
-                  "Kassiererin",
-                  "Angela Stresemann"
-                ],
-                [
-                  "Inspektor Cotta",
-                  "Holger Mahlich"
-                ]
+              "sprechrollen" : [
+                {
+                  "rolle" : "Erzähler",
+                  "sprecher" : "Axel Milberg"
+                },
+                {
+                  "rolle" : "Justus Jonas, Erster Detektiv",
+                  "sprecher" : "Oliver Rohrbeck"
+                },
+                {
+                  "rolle" : "Peter Shaw, Zweiter Detektiv",
+                  "sprecher" : "Jens Wawrczeck"
+                },
+                {
+                  "rolle" : "Bob Andrews, Recherchen und Archiv",
+                  "sprecher" : "Andreas Fröhlich"
+                },
+                {
+                  "rolle" : "Blacky",
+                  "sprecher" : "Heikedine Körting",
+                  "pseudonym" : "Pamela Punti"
+                },
+                {
+                  "rolle" : "Kassiererin",
+                  "sprecher" : "Angela Stresemann"
+                },
+                {
+                  "rolle" : "Inspektor Cotta",
+                  "sprecher" : "Holger Mahlich"
+                }
               ],
               "links" : {
                 "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/metadata.json
@@ -20,51 +20,52 @@
       "end" : 1596747
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Emily White",
-      "Sabine Hahn"
-    ],
-    [
-      "Judy Fradkin",
-      "Ursula Heyer"
-    ],
-    [
-      "Aladin",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Aschenputtel",
-      "Regina Lemnitz"
-    ],
-    [
-      "Prinzessin",
-      "Renate Pichler"
-    ],
-    [
-      "Rotkäppchen",
-      "Angela Stresemann"
-    ],
-    [
-      "Meerjungfrau",
-      "Pamela Punti"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Emily White",
+      "sprecher" : "Sabine Hahn"
+    },
+    {
+      "rolle" : "Judy Fradkin",
+      "sprecher" : "Ursula Heyer"
+    },
+    {
+      "rolle" : "Aladin",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Aschenputtel",
+      "sprecher" : "Regina Lemnitz"
+    },
+    {
+      "rolle" : "Prinzessin",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Rotkäppchen",
+      "sprecher" : "Angela Stresemann"
+    },
+    {
+      "rolle" : "Meerjungfrau",
+      "sprecher" : "Heikedine Körting",
+      "pseudonym" : "Pamela Punti"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/metadata.json
@@ -20,43 +20,43 @@
       "end" : 1477173
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Mrs. Andrews",
-      "Konstanze Ullmer"
-    ],
-    [
-      "Arzt",
-      "Erik Schäffler"
-    ],
-    [
-      "Mrs. Wallace",
-      "Angela Stresemann"
-    ],
-    [
-      "Bobby",
-      "Merete Brettschneider"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Mrs. Andrews",
+      "sprecher" : "Konstanze Ullmer"
+    },
+    {
+      "rolle" : "Arzt",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Mrs. Wallace",
+      "sprecher" : "Angela Stresemann"
+    },
+    {
+      "rolle" : "Bobby",
+      "sprecher" : "Merete Brettschneider"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/metadata.json
@@ -22,51 +22,52 @@
           "end" : 1596747
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Emily White",
-          "Sabine Hahn"
-        ],
-        [
-          "Judy Fradkin",
-          "Ursula Heyer"
-        ],
-        [
-          "Aladin",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Aschenputtel",
-          "Regina Lemnitz"
-        ],
-        [
-          "Prinzessin",
-          "Renate Pichler"
-        ],
-        [
-          "Rotkäppchen",
-          "Angela Stresemann"
-        ],
-        [
-          "Meerjungfrau",
-          "Pamela Punti"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Emily White",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Judy Fradkin",
+          "sprecher" : "Ursula Heyer"
+        },
+        {
+          "rolle" : "Aladin",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Aschenputtel",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Prinzessin",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Rotkäppchen",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Meerjungfrau",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/metadata.json",
@@ -95,43 +96,43 @@
           "end" : 1477173
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Mrs. Andrews",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Arzt",
-          "Erik Schäffler"
-        ],
-        [
-          "Mrs. Wallace",
-          "Angela Stresemann"
-        ],
-        [
-          "Bobby",
-          "Merete Brettschneider"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Arzt",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Mrs. Wallace",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Bobby",
+          "sprecher" : "Merete Brettschneider"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/metadata.json
@@ -20,31 +20,32 @@
       "end" : 1574187
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/metadata.json
@@ -20,47 +20,47 @@
       "end" : 1174080
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Croupier",
-      "Gosta Liptow"
-    ],
-    [
-      "Carl Hopkins, Physiker",
-      "Ben Hecker"
-    ],
-    [
-      "Miller, Schiffsdetektiv",
-      "Michael Grimm"
-    ],
-    [
-      "Kapitän Sherwood",
-      "Horst Naumann"
-    ],
-    [
-      "Theodore Quaid",
-      "Dietrich Adam"
-    ],
-    [
-      "Jamie Peterson, Barmann",
-      "Patrick Bach"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Croupier",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Carl Hopkins, Physiker",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Miller, Schiffsdetektiv",
+      "sprecher" : "Michael Grimm"
+    },
+    {
+      "rolle" : "Kapitän Sherwood",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Theodore Quaid",
+      "sprecher" : "Dietrich Adam"
+    },
+    {
+      "rolle" : "Jamie Peterson, Barmann",
+      "sprecher" : "Patrick Bach"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/metadata.json
@@ -22,31 +22,32 @@
           "end" : 1574187
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/metadata.json",
@@ -75,47 +76,47 @@
           "end" : 1174080
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Croupier",
-          "Gosta Liptow"
-        ],
-        [
-          "Carl Hopkins, Physiker",
-          "Ben Hecker"
-        ],
-        [
-          "Miller, Schiffsdetektiv",
-          "Michael Grimm"
-        ],
-        [
-          "Kapitän Sherwood",
-          "Horst Naumann"
-        ],
-        [
-          "Theodore Quaid",
-          "Dietrich Adam"
-        ],
-        [
-          "Jamie Peterson, Barmann",
-          "Patrick Bach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Croupier",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Carl Hopkins, Physiker",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Miller, Schiffsdetektiv",
+          "sprecher" : "Michael Grimm"
+        },
+        {
+          "rolle" : "Kapitän Sherwood",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Theodore Quaid",
+          "sprecher" : "Dietrich Adam"
+        },
+        {
+          "rolle" : "Jamie Peterson, Barmann",
+          "sprecher" : "Patrick Bach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/metadata.json
@@ -20,43 +20,45 @@
       "end" : 1389800
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Handerson",
-      "Wolfgang Rositzka"
-    ],
-    [
-      "Diego",
-      "Stefan Benson"
-    ],
-    [
-      "Mercedes",
-      "Wanda Osten"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Handerson",
+      "sprecher" : "Wolfgang Rositzka"
+    },
+    {
+      "rolle" : "Diego",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Mercedes",
+      "sprecher" : "Hella von der Osten-Sacken",
+      "pseudonym" : "Wanda Osten"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/metadata.json
@@ -20,39 +20,40 @@
       "end" : 1409027
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Nayeli",
-      "Stefan Brönneke"
-    ],
-    [
-      "Barker",
-      "Ben Hecker"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Off-Sprecherin",
-      "Claudia Stocksieker"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Nayeli",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Barker",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Off-Sprecherin",
+      "sprecher" : "Claudia Stocksieker"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/metadata.json
@@ -20,35 +20,36 @@
       "end" : 1099640
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Ian Carew",
-      "Sascha Draeger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Ian Carew",
+      "sprecher" : "Sascha Draeger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/metadata.json
@@ -22,43 +22,45 @@
           "end" : 1389800
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Handerson",
-          "Wolfgang Rositzka"
-        ],
-        [
-          "Diego",
-          "Stefan Benson"
-        ],
-        [
-          "Mercedes",
-          "Wanda Osten"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Handerson",
+          "sprecher" : "Wolfgang Rositzka"
+        },
+        {
+          "rolle" : "Diego",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Mercedes",
+          "sprecher" : "Hella von der Osten-Sacken",
+          "pseudonym" : "Wanda Osten"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/metadata.json",
@@ -87,39 +89,40 @@
           "end" : 1409027
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Nayeli",
-          "Stefan Brönneke"
-        ],
-        [
-          "Barker",
-          "Ben Hecker"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Off-Sprecherin",
-          "Claudia Stocksieker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Nayeli",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Barker",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Off-Sprecherin",
+          "sprecher" : "Claudia Stocksieker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/metadata.json",
@@ -148,35 +151,36 @@
           "end" : 1099640
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Ian Carew",
-          "Sascha Draeger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Ian Carew",
+          "sprecher" : "Sascha Draeger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/metadata.json",

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/metadata.json
@@ -24,51 +24,52 @@
               "end" : 1596747
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Emily White",
-              "Sabine Hahn"
-            ],
-            [
-              "Judy Fradkin",
-              "Ursula Heyer"
-            ],
-            [
-              "Aladin",
-              "Heidi Schaffrath"
-            ],
-            [
-              "Aschenputtel",
-              "Regina Lemnitz"
-            ],
-            [
-              "Prinzessin",
-              "Renate Pichler"
-            ],
-            [
-              "Rotkäppchen",
-              "Angela Stresemann"
-            ],
-            [
-              "Meerjungfrau",
-              "Pamela Punti"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Emily White",
+              "sprecher" : "Sabine Hahn"
+            },
+            {
+              "rolle" : "Judy Fradkin",
+              "sprecher" : "Ursula Heyer"
+            },
+            {
+              "rolle" : "Aladin",
+              "sprecher" : "Heidi Schaffrath"
+            },
+            {
+              "rolle" : "Aschenputtel",
+              "sprecher" : "Regina Lemnitz"
+            },
+            {
+              "rolle" : "Prinzessin",
+              "sprecher" : "Renate Pichler"
+            },
+            {
+              "rolle" : "Rotkäppchen",
+              "sprecher" : "Angela Stresemann"
+            },
+            {
+              "rolle" : "Meerjungfrau",
+              "sprecher" : "Heikedine Körting",
+              "pseudonym" : "Pamela Punti"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/metadata.json",
@@ -97,43 +98,43 @@
               "end" : 1477173
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Mr. Andrews",
-              "Henry König"
-            ],
-            [
-              "Mrs. Andrews",
-              "Konstanze Ullmer"
-            ],
-            [
-              "Arzt",
-              "Erik Schäffler"
-            ],
-            [
-              "Mrs. Wallace",
-              "Angela Stresemann"
-            ],
-            [
-              "Bobby",
-              "Merete Brettschneider"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Mrs. Andrews",
+              "sprecher" : "Konstanze Ullmer"
+            },
+            {
+              "rolle" : "Arzt",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Mrs. Wallace",
+              "sprecher" : "Angela Stresemann"
+            },
+            {
+              "rolle" : "Bobby",
+              "sprecher" : "Merete Brettschneider"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/metadata.json",
@@ -203,31 +204,32 @@
               "end" : 1574187
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Onkel Titus Jonas",
-              "Hans Meinhardt"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/metadata.json",
@@ -256,47 +258,47 @@
               "end" : 1174080
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Croupier",
-              "Gosta Liptow"
-            ],
-            [
-              "Carl Hopkins, Physiker",
-              "Ben Hecker"
-            ],
-            [
-              "Miller, Schiffsdetektiv",
-              "Michael Grimm"
-            ],
-            [
-              "Kapitän Sherwood",
-              "Horst Naumann"
-            ],
-            [
-              "Theodore Quaid",
-              "Dietrich Adam"
-            ],
-            [
-              "Jamie Peterson, Barmann",
-              "Patrick Bach"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Croupier",
+              "sprecher" : "Gosta Liptow"
+            },
+            {
+              "rolle" : "Carl Hopkins, Physiker",
+              "sprecher" : "Ben Hecker"
+            },
+            {
+              "rolle" : "Miller, Schiffsdetektiv",
+              "sprecher" : "Michael Grimm"
+            },
+            {
+              "rolle" : "Kapitän Sherwood",
+              "sprecher" : "Horst Naumann"
+            },
+            {
+              "rolle" : "Theodore Quaid",
+              "sprecher" : "Dietrich Adam"
+            },
+            {
+              "rolle" : "Jamie Peterson, Barmann",
+              "sprecher" : "Patrick Bach"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/metadata.json",
@@ -366,43 +368,45 @@
               "end" : 1389800
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Onkel Titus Jonas",
-              "Hans Meinhardt"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Handerson",
-              "Wolfgang Rositzka"
-            ],
-            [
-              "Diego",
-              "Stefan Benson"
-            ],
-            [
-              "Mercedes",
-              "Wanda Osten"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Handerson",
+              "sprecher" : "Wolfgang Rositzka"
+            },
+            {
+              "rolle" : "Diego",
+              "sprecher" : "Stephan Benson"
+            },
+            {
+              "rolle" : "Mercedes",
+              "sprecher" : "Hella von der Osten-Sacken",
+              "pseudonym" : "Wanda Osten"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/metadata.json",
@@ -431,39 +435,40 @@
               "end" : 1409027
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Nayeli",
-              "Stefan Brönneke"
-            ],
-            [
-              "Barker",
-              "Ben Hecker"
-            ],
-            [
-              "Onkel Titus Jonas",
-              "Hans Meinhardt"
-            ],
-            [
-              "Off-Sprecherin",
-              "Claudia Stocksieker"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Nayeli",
+              "sprecher" : "Stefan Brönneke"
+            },
+            {
+              "rolle" : "Barker",
+              "sprecher" : "Ben Hecker"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Off-Sprecherin",
+              "sprecher" : "Claudia Stocksieker"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/metadata.json",
@@ -492,35 +497,36 @@
               "end" : 1099640
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Onkel Titus Jonas",
-              "Hans Meinhardt"
-            ],
-            [
-              "Ian Carew",
-              "Sascha Draeger"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Ian Carew",
+              "sprecher" : "Sascha Draeger"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/1/1/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/1/1/metadata.json
@@ -20,31 +20,31 @@
       "end" : 950800
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Hüne",
-      "Johannes Semm"
-    ],
-    [
-      "Marvin Gray",
-      "Horst Stark"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Hüne",
+      "sprecher" : "Johannes Semm"
+    },
+    {
+      "rolle" : "Marvin Gray",
+      "sprecher" : "Horst Stark"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/1/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/1/2/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/1/2/metadata.json
@@ -20,51 +20,51 @@
       "end" : 1198507
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Nancy McMonigal",
-      "Gerlinde Dilge"
-    ],
-    [
-      "Tom",
-      "Wolfgang Rositzka"
-    ],
-    [
-      "Rod",
-      "Herbert Tennigkeit"
-    ],
-    [
-      "Joe",
-      "Oliver Reichmann"
-    ],
-    [
-      "Ben",
-      "Stephan Chrzescinski"
-    ],
-    [
-      "Mariann",
-      "Simone Ritscher"
-    ],
-    [
-      "TV-Sprecher",
-      "Holger Wemhoff"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Nancy McMonigal",
+      "sprecher" : "Gerlinde Dillge"
+    },
+    {
+      "rolle" : "Tom",
+      "sprecher" : "Wolfgang Rositzka"
+    },
+    {
+      "rolle" : "Rod",
+      "sprecher" : "Herbert Tennigkeit"
+    },
+    {
+      "rolle" : "Joe",
+      "sprecher" : "Olaf Reichmann"
+    },
+    {
+      "rolle" : "Ben",
+      "sprecher" : "Stephan Chrzescinski"
+    },
+    {
+      "rolle" : "Mariann",
+      "sprecher" : "Simone Ritscher"
+    },
+    {
+      "rolle" : "TV-Sprecher",
+      "sprecher" : "Holger Wemhoff"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/2/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/1/3/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/1/3/metadata.json
@@ -15,31 +15,31 @@
       "end" : 1502960
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Malcolm Fever",
-      "Tilo Schmitz"
-    ],
-    [
-      "Lucy Hopkins",
-      "Topsy Küppers"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Malcolm Fever",
+      "sprecher" : "Tilo Schmitz"
+    },
+    {
+      "rolle" : "Lucy Hopkins",
+      "sprecher" : "Topsy Küppers"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/3/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/1/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/1/metadata.json
@@ -22,31 +22,31 @@
           "end" : 950800
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Hüne",
-          "Johannes Semm"
-        ],
-        [
-          "Marvin Gray",
-          "Horst Stark"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Hüne",
+          "sprecher" : "Johannes Semm"
+        },
+        {
+          "rolle" : "Marvin Gray",
+          "sprecher" : "Horst Stark"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/1/metadata.json",
@@ -75,51 +75,51 @@
           "end" : 1198507
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Nancy McMonigal",
-          "Gerlinde Dilge"
-        ],
-        [
-          "Tom",
-          "Wolfgang Rositzka"
-        ],
-        [
-          "Rod",
-          "Herbert Tennigkeit"
-        ],
-        [
-          "Joe",
-          "Oliver Reichmann"
-        ],
-        [
-          "Ben",
-          "Stephan Chrzescinski"
-        ],
-        [
-          "Mariann",
-          "Simone Ritscher"
-        ],
-        [
-          "TV-Sprecher",
-          "Holger Wemhoff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Nancy McMonigal",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Tom",
+          "sprecher" : "Wolfgang Rositzka"
+        },
+        {
+          "rolle" : "Rod",
+          "sprecher" : "Herbert Tennigkeit"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Olaf Reichmann"
+        },
+        {
+          "rolle" : "Ben",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Mariann",
+          "sprecher" : "Simone Ritscher"
+        },
+        {
+          "rolle" : "TV-Sprecher",
+          "sprecher" : "Holger Wemhoff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/2/metadata.json",
@@ -143,31 +143,31 @@
           "end" : 1502960
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Malcolm Fever",
-          "Tilo Schmitz"
-        ],
-        [
-          "Lucy Hopkins",
-          "Topsy Küppers"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Malcolm Fever",
+          "sprecher" : "Tilo Schmitz"
+        },
+        {
+          "rolle" : "Lucy Hopkins",
+          "sprecher" : "Topsy Küppers"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/3/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/2/4/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/2/4/metadata.json
@@ -20,51 +20,52 @@
       "end" : 1748867
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Professor Selby",
-      "Claus Wilcke"
-    ],
-    [
-      "Oberpriesterin",
-      "Elga Schütz"
-    ],
-    [
-      "Kevin",
-      "Patrick Mölleken"
-    ],
-    [
-      "Mann in Kutte",
-      "Rüdiger Hellmann"
-    ],
-    [
-      "Radio",
-      "Wilhelm Wieben"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Professor Selby",
+      "sprecher" : "Claus Wilcke"
+    },
+    {
+      "rolle" : "Oberpriesterin",
+      "sprecher" : "Elga Schütz"
+    },
+    {
+      "rolle" : "Kevin",
+      "sprecher" : "Patrick Mölleken"
+    },
+    {
+      "rolle" : "Mann in Kutte",
+      "sprecher" : "Rüdiger Hellmann"
+    },
+    {
+      "rolle" : "Radio",
+      "sprecher" : "Wilhelm Wieben"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/4/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/2/5/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/2/5/metadata.json
@@ -20,31 +20,31 @@
       "end" : 1136386
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Tilton",
-      "Christian Senger"
-    ],
-    [
-      "Mr. Walsh",
-      "Christian Rudolf"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Tilton",
+      "sprecher" : "Christian Senger"
+    },
+    {
+      "rolle" : "Mr. Walsh",
+      "sprecher" : "Christian Rudolf"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/5/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/2/6/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/2/6/metadata.json
@@ -25,51 +25,51 @@
       "end" : 1684120
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Weise Frau",
-      "Dorothea Hagena"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay-Pracht"
-    ],
-    [
-      "Patrick",
-      "Nicolas König"
-    ],
-    [
-      "Samuel",
-      "Johannes Semm"
-    ],
-    [
-      "Kenneth",
-      "Olaf Reichmann"
-    ],
-    [
-      "Liz Zapata",
-      "Merete Brettschneider"
-    ],
-    [
-      "Skinny Norris",
-      "Michael Harck"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Weise Frau",
+      "sprecher" : "Dorothea Hagena"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Patrick",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Samuel",
+      "sprecher" : "Johannes Semm"
+    },
+    {
+      "rolle" : "Kenneth",
+      "sprecher" : "Olaf Reichmann"
+    },
+    {
+      "rolle" : "Liz Zapata",
+      "sprecher" : "Merete Brettschneider"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Michael Harck"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/6/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/2/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/2/metadata.json
@@ -22,51 +22,52 @@
           "end" : 1748867
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Professor Selby",
-          "Claus Wilcke"
-        ],
-        [
-          "Oberpriesterin",
-          "Elga Schütz"
-        ],
-        [
-          "Kevin",
-          "Patrick Mölleken"
-        ],
-        [
-          "Mann in Kutte",
-          "Rüdiger Hellmann"
-        ],
-        [
-          "Radio",
-          "Wilhelm Wieben"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Professor Selby",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Oberpriesterin",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "Kevin",
+          "sprecher" : "Patrick Mölleken"
+        },
+        {
+          "rolle" : "Mann in Kutte",
+          "sprecher" : "Rüdiger Hellmann"
+        },
+        {
+          "rolle" : "Radio",
+          "sprecher" : "Wilhelm Wieben"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/4/metadata.json",
@@ -95,31 +96,31 @@
           "end" : 1136386
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Tilton",
-          "Christian Senger"
-        ],
-        [
-          "Mr. Walsh",
-          "Christian Rudolf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Tilton",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Mr. Walsh",
+          "sprecher" : "Christian Rudolf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/5/metadata.json",
@@ -153,51 +154,51 @@
           "end" : 1684120
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Weise Frau",
-          "Dorothea Hagena"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay-Pracht"
-        ],
-        [
-          "Patrick",
-          "Nicolas König"
-        ],
-        [
-          "Samuel",
-          "Johannes Semm"
-        ],
-        [
-          "Kenneth",
-          "Olaf Reichmann"
-        ],
-        [
-          "Liz Zapata",
-          "Merete Brettschneider"
-        ],
-        [
-          "Skinny Norris",
-          "Michael Harck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Weise Frau",
+          "sprecher" : "Dorothea Hagena"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Samuel",
+          "sprecher" : "Johannes Semm"
+        },
+        {
+          "rolle" : "Kenneth",
+          "sprecher" : "Olaf Reichmann"
+        },
+        {
+          "rolle" : "Liz Zapata",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Michael Harck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/6/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/metadata.json
@@ -24,31 +24,31 @@
               "end" : 950800
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Hüne",
-              "Johannes Semm"
-            ],
-            [
-              "Marvin Gray",
-              "Horst Stark"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Hüne",
+              "sprecher" : "Johannes Semm"
+            },
+            {
+              "rolle" : "Marvin Gray",
+              "sprecher" : "Horst Stark"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/1/metadata.json",
@@ -77,51 +77,51 @@
               "end" : 1198507
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Nancy McMonigal",
-              "Gerlinde Dilge"
-            ],
-            [
-              "Tom",
-              "Wolfgang Rositzka"
-            ],
-            [
-              "Rod",
-              "Herbert Tennigkeit"
-            ],
-            [
-              "Joe",
-              "Oliver Reichmann"
-            ],
-            [
-              "Ben",
-              "Stephan Chrzescinski"
-            ],
-            [
-              "Mariann",
-              "Simone Ritscher"
-            ],
-            [
-              "TV-Sprecher",
-              "Holger Wemhoff"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Nancy McMonigal",
+              "sprecher" : "Gerlinde Dillge"
+            },
+            {
+              "rolle" : "Tom",
+              "sprecher" : "Wolfgang Rositzka"
+            },
+            {
+              "rolle" : "Rod",
+              "sprecher" : "Herbert Tennigkeit"
+            },
+            {
+              "rolle" : "Joe",
+              "sprecher" : "Olaf Reichmann"
+            },
+            {
+              "rolle" : "Ben",
+              "sprecher" : "Stephan Chrzescinski"
+            },
+            {
+              "rolle" : "Mariann",
+              "sprecher" : "Simone Ritscher"
+            },
+            {
+              "rolle" : "TV-Sprecher",
+              "sprecher" : "Holger Wemhoff"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/2/metadata.json",
@@ -145,31 +145,31 @@
               "end" : 1502960
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Malcolm Fever",
-              "Tilo Schmitz"
-            ],
-            [
-              "Lucy Hopkins",
-              "Topsy Küppers"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Malcolm Fever",
+              "sprecher" : "Tilo Schmitz"
+            },
+            {
+              "rolle" : "Lucy Hopkins",
+              "sprecher" : "Topsy Küppers"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/3/metadata.json",
@@ -249,51 +249,52 @@
               "end" : 1748867
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Onkel Titus Jonas",
-              "Hans Meinhardt"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Professor Selby",
-              "Claus Wilcke"
-            ],
-            [
-              "Oberpriesterin",
-              "Elga Schütz"
-            ],
-            [
-              "Kevin",
-              "Patrick Mölleken"
-            ],
-            [
-              "Mann in Kutte",
-              "Rüdiger Hellmann"
-            ],
-            [
-              "Radio",
-              "Wilhelm Wieben"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Professor Selby",
+              "sprecher" : "Claus Wilcke"
+            },
+            {
+              "rolle" : "Oberpriesterin",
+              "sprecher" : "Elga Schütz"
+            },
+            {
+              "rolle" : "Kevin",
+              "sprecher" : "Patrick Mölleken"
+            },
+            {
+              "rolle" : "Mann in Kutte",
+              "sprecher" : "Rüdiger Hellmann"
+            },
+            {
+              "rolle" : "Radio",
+              "sprecher" : "Wilhelm Wieben"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/4/metadata.json",
@@ -322,31 +323,31 @@
               "end" : 1136386
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Mr. Tilton",
-              "Christian Senger"
-            ],
-            [
-              "Mr. Walsh",
-              "Christian Rudolf"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mr. Tilton",
+              "sprecher" : "Christian Senger"
+            },
+            {
+              "rolle" : "Mr. Walsh",
+              "sprecher" : "Christian Rudolf"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/5/metadata.json",
@@ -380,51 +381,51 @@
               "end" : 1684120
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Weise Frau",
-              "Dorothea Hagena"
-            ],
-            [
-              "Kelly",
-              "Juliane Szalay-Pracht"
-            ],
-            [
-              "Patrick",
-              "Nicolas König"
-            ],
-            [
-              "Samuel",
-              "Johannes Semm"
-            ],
-            [
-              "Kenneth",
-              "Olaf Reichmann"
-            ],
-            [
-              "Liz Zapata",
-              "Merete Brettschneider"
-            ],
-            [
-              "Skinny Norris",
-              "Michael Harck"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Weise Frau",
+              "sprecher" : "Dorothea Hagena"
+            },
+            {
+              "rolle" : "Kelly",
+              "sprecher" : "Juliane Szalay"
+            },
+            {
+              "rolle" : "Patrick",
+              "sprecher" : "Nicolas König"
+            },
+            {
+              "rolle" : "Samuel",
+              "sprecher" : "Johannes Semm"
+            },
+            {
+              "rolle" : "Kenneth",
+              "sprecher" : "Olaf Reichmann"
+            },
+            {
+              "rolle" : "Liz Zapata",
+              "sprecher" : "Merete Brettschneider"
+            },
+            {
+              "rolle" : "Skinny Norris",
+              "sprecher" : "Michael Harck"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/6/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/metadata.json
@@ -20,19 +20,19 @@
       "end" : 2240920
     }
   ],
-  "sprecher" : [
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/metadata.json
@@ -20,35 +20,36 @@
       "end" : 1855920
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Helen",
-      "Balancinha Blanc (Dorette Hugo)"
-    ],
-    [
-      "Ellen",
-      "Dorette Hugo"
-    ],
-    [
-      "Vater",
-      "Douglas Welbat"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Helen",
+      "sprecher" : "Dorette Hugo",
+      "pseudonym" : "Balancinha Blanc"
+    },
+    {
+      "rolle" : "Ellen",
+      "sprecher" : "Dorette Hugo"
+    },
+    {
+      "rolle" : "Vater",
+      "sprecher" : "Douglas Welbat"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/1/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/1/metadata.json
@@ -22,19 +22,19 @@
           "end" : 2240920
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/metadata.json",
@@ -63,35 +63,36 @@
           "end" : 1855920
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Helen",
-          "Balancinha Blanc (Dorette Hugo)"
-        ],
-        [
-          "Ellen",
-          "Dorette Hugo"
-        ],
-        [
-          "Vater",
-          "Douglas Welbat"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Helen",
+          "sprecher" : "Dorette Hugo",
+          "pseudonym" : "Balancinha Blanc"
+        },
+        {
+          "rolle" : "Ellen",
+          "sprecher" : "Dorette Hugo"
+        },
+        {
+          "rolle" : "Vater",
+          "sprecher" : "Douglas Welbat"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/metadata.json
@@ -20,43 +20,47 @@
       "end" : 1889653
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Skinny Norris",
-      "Michael Harck"
-    ],
-    [
-      "Marc Kingstone",
-      "Rainer Brandt"
-    ],
-    [
-      "Aaron Kingstone",
-      "Tommi Piper"
-    ],
-    [
-      "Sarah",
-      "Christiane Leuchtmann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Michael Harck"
+    },
+    {
+      "rolle" : "Marc Kingstone",
+      "sprecher" : "Rainer Brandt"
+    },
+    {
+      "rolle" : "Aaron Kingstone",
+      "sprecher" : "Tommi Piper"
+    },
+    {
+      "rolle" : "Sarah",
+      "sprecher" : "Christiane Leuchtmann"
+    },
+    {
+      "rolle" : "Albert",
+      "sprecher" : "Franzisko Löwe"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/metadata.json
@@ -20,59 +20,59 @@
       "end" : 1767387
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kelly Madigan",
-      "Juliane Szalay"
-    ],
-    [
-      "Mrs. McGee",
-      "Alice Krimmel"
-    ],
-    [
-      "Toby",
-      "A. Stengelin"
-    ],
-    [
-      "Mrs. Wells",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Junge",
-      "Linus Tauber"
-    ],
-    [
-      "Mädchen",
-      "Katinka Jaekel"
-    ],
-    [
-      "Ericsson",
-      "Detlev Tams"
-    ],
-    [
-      "Sprecher/Moderator",
-      "Oliver Böttcher"
-    ],
-    [
-      "Tarek Shabana",
-      "Werner Wilkening"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kelly Madigan",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Mrs. McGee",
+      "sprecher" : "Alice Krimmel"
+    },
+    {
+      "rolle" : "Toby",
+      "sprecher" : "A. Stengelin"
+    },
+    {
+      "rolle" : "Mrs. Wells",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "Linus Tauber"
+    },
+    {
+      "rolle" : "Mädchen",
+      "sprecher" : "Katinka Jaekel"
+    },
+    {
+      "rolle" : "Ericsson",
+      "sprecher" : "Detlef Tams"
+    },
+    {
+      "rolle" : "Sprecher/Moderator",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Tarek Shabana",
+      "sprecher" : "Werner Wilkening"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/2/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/2/metadata.json
@@ -22,43 +22,47 @@
           "end" : 1889653
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Skinny Norris",
-          "Michael Harck"
-        ],
-        [
-          "Marc Kingstone",
-          "Rainer Brandt"
-        ],
-        [
-          "Aaron Kingstone",
-          "Tommi Piper"
-        ],
-        [
-          "Sarah",
-          "Christiane Leuchtmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Marc Kingstone",
+          "sprecher" : "Rainer Brandt"
+        },
+        {
+          "rolle" : "Aaron Kingstone",
+          "sprecher" : "Tommi Piper"
+        },
+        {
+          "rolle" : "Sarah",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Albert",
+          "sprecher" : "Franzisko Löwe"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/metadata.json",
@@ -87,59 +91,59 @@
           "end" : 1767387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly Madigan",
-          "Juliane Szalay"
-        ],
-        [
-          "Mrs. McGee",
-          "Alice Krimmel"
-        ],
-        [
-          "Toby",
-          "A. Stengelin"
-        ],
-        [
-          "Mrs. Wells",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Junge",
-          "Linus Tauber"
-        ],
-        [
-          "Mädchen",
-          "Katinka Jaekel"
-        ],
-        [
-          "Ericsson",
-          "Detlev Tams"
-        ],
-        [
-          "Sprecher/Moderator",
-          "Oliver Böttcher"
-        ],
-        [
-          "Tarek Shabana",
-          "Werner Wilkening"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly Madigan",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Mrs. McGee",
+          "sprecher" : "Alice Krimmel"
+        },
+        {
+          "rolle" : "Toby",
+          "sprecher" : "A. Stengelin"
+        },
+        {
+          "rolle" : "Mrs. Wells",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Linus Tauber"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Katinka Jaekel"
+        },
+        {
+          "rolle" : "Ericsson",
+          "sprecher" : "Detlef Tams"
+        },
+        {
+          "rolle" : "Sprecher/Moderator",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Tarek Shabana",
+          "sprecher" : "Werner Wilkening"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/metadata.json
@@ -20,55 +20,55 @@
       "end" : 2256800
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tasha",
-      "Victoria Zöller"
-    ],
-    [
-      "Domino Laverna",
-      "Sabine Hahn"
-    ],
-    [
-      "Biff Rodgers, Reporter",
-      "Daniel Schütter"
-    ],
-    [
-      "Lesley Dimple",
-      "Ann Montenbruck"
-    ],
-    [
-      "Zeus Zenon Johnson",
-      "Michael Prelle"
-    ],
-    [
-      "Computer",
-      "Peter Bayer"
-    ],
-    [
-      "Off-Sprecher",
-      "Frank Roder"
-    ],
-    [
-      "Sprecher",
-      "Andreas Birnbaum"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tasha",
+      "sprecher" : "Victoria Zöller"
+    },
+    {
+      "rolle" : "Domino Laverna",
+      "sprecher" : "Sabine Hahn"
+    },
+    {
+      "rolle" : "Biff Rodgers, Reporter",
+      "sprecher" : "Daniel Schütter"
+    },
+    {
+      "rolle" : "Lesley Dimple",
+      "sprecher" : "Ann Montenbruck"
+    },
+    {
+      "rolle" : "Zeus Zenon Johnson",
+      "sprecher" : "Michael Prelle"
+    },
+    {
+      "rolle" : "Computer",
+      "sprecher" : "Peter Bayer"
+    },
+    {
+      "rolle" : "Off-Sprecher",
+      "sprecher" : "Frank Roder"
+    },
+    {
+      "rolle" : "Sprecher",
+      "sprecher" : "Andreas Birnbaum"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/metadata.json
@@ -20,35 +20,36 @@
       "end" : 1718507
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Blacky",
-      "Pamela Punti"
-    ],
-    [
-      "Kassiererin",
-      "Angela Stresemann"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting",
+      "pseudonym" : "Pamela Punti"
+    },
+    {
+      "rolle" : "Kassiererin",
+      "sprecher" : "Angela Stresemann"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/3/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/3/metadata.json
@@ -22,55 +22,55 @@
           "end" : 2256800
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tasha",
-          "Victoria Zöller"
-        ],
-        [
-          "Domino Laverna",
-          "Sabine Hahn"
-        ],
-        [
-          "Biff Rodgers, Reporter",
-          "Daniel Schütter"
-        ],
-        [
-          "Lesley Dimple",
-          "Ann Montenbruck"
-        ],
-        [
-          "Zeus Zenon Johnson",
-          "Michael Prelle"
-        ],
-        [
-          "Computer",
-          "Peter Bayer"
-        ],
-        [
-          "Off-Sprecher",
-          "Frank Roder"
-        ],
-        [
-          "Sprecher",
-          "Andreas Birnbaum"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tasha",
+          "sprecher" : "Victoria Zöller"
+        },
+        {
+          "rolle" : "Domino Laverna",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Biff Rodgers, Reporter",
+          "sprecher" : "Daniel Schütter"
+        },
+        {
+          "rolle" : "Lesley Dimple",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Zeus Zenon Johnson",
+          "sprecher" : "Michael Prelle"
+        },
+        {
+          "rolle" : "Computer",
+          "sprecher" : "Peter Bayer"
+        },
+        {
+          "rolle" : "Off-Sprecher",
+          "sprecher" : "Frank Roder"
+        },
+        {
+          "rolle" : "Sprecher",
+          "sprecher" : "Andreas Birnbaum"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/metadata.json",
@@ -99,35 +99,36 @@
           "end" : 1718507
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Blacky",
-          "Pamela Punti"
-        ],
-        [
-          "Kassiererin",
-          "Angela Stresemann"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Kassiererin",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/metadata.json",

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/metadata.json
@@ -24,19 +24,19 @@
               "end" : 2240920
             }
           ],
-          "sprecher" : [
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/metadata.json",
@@ -65,35 +65,36 @@
               "end" : 1855920
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Axel Milberg"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Helen",
-              "Balancinha Blanc (Dorette Hugo)"
-            ],
-            [
-              "Ellen",
-              "Dorette Hugo"
-            ],
-            [
-              "Vater",
-              "Douglas Welbat"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Helen",
+              "sprecher" : "Dorette Hugo",
+              "pseudonym" : "Balancinha Blanc"
+            },
+            {
+              "rolle" : "Ellen",
+              "sprecher" : "Dorette Hugo"
+            },
+            {
+              "rolle" : "Vater",
+              "sprecher" : "Douglas Welbat"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/metadata.json",
@@ -163,43 +164,47 @@
               "end" : 1889653
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Axel Milberg"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Skinny Norris",
-              "Michael Harck"
-            ],
-            [
-              "Marc Kingstone",
-              "Rainer Brandt"
-            ],
-            [
-              "Aaron Kingstone",
-              "Tommi Piper"
-            ],
-            [
-              "Sarah",
-              "Christiane Leuchtmann"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Skinny Norris",
+              "sprecher" : "Michael Harck"
+            },
+            {
+              "rolle" : "Marc Kingstone",
+              "sprecher" : "Rainer Brandt"
+            },
+            {
+              "rolle" : "Aaron Kingstone",
+              "sprecher" : "Tommi Piper"
+            },
+            {
+              "rolle" : "Sarah",
+              "sprecher" : "Christiane Leuchtmann"
+            },
+            {
+              "rolle" : "Albert",
+              "sprecher" : "Franzisko Löwe"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/metadata.json",
@@ -228,59 +233,59 @@
               "end" : 1767387
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Axel Milberg"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Kelly Madigan",
-              "Juliane Szalay"
-            ],
-            [
-              "Mrs. McGee",
-              "Alice Krimmel"
-            ],
-            [
-              "Toby",
-              "A. Stengelin"
-            ],
-            [
-              "Mrs. Wells",
-              "Heidi Schaffrath"
-            ],
-            [
-              "Junge",
-              "Linus Tauber"
-            ],
-            [
-              "Mädchen",
-              "Katinka Jaekel"
-            ],
-            [
-              "Ericsson",
-              "Detlev Tams"
-            ],
-            [
-              "Sprecher/Moderator",
-              "Oliver Böttcher"
-            ],
-            [
-              "Tarek Shabana",
-              "Werner Wilkening"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Kelly Madigan",
+              "sprecher" : "Juliane Szalay"
+            },
+            {
+              "rolle" : "Mrs. McGee",
+              "sprecher" : "Alice Krimmel"
+            },
+            {
+              "rolle" : "Toby",
+              "sprecher" : "A. Stengelin"
+            },
+            {
+              "rolle" : "Mrs. Wells",
+              "sprecher" : "Heidi Schaffrath"
+            },
+            {
+              "rolle" : "Junge",
+              "sprecher" : "Linus Tauber"
+            },
+            {
+              "rolle" : "Mädchen",
+              "sprecher" : "Katinka Jaekel"
+            },
+            {
+              "rolle" : "Ericsson",
+              "sprecher" : "Detlef Tams"
+            },
+            {
+              "rolle" : "Sprecher/Moderator",
+              "sprecher" : "Oliver Böttcher"
+            },
+            {
+              "rolle" : "Tarek Shabana",
+              "sprecher" : "Werner Wilkening"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/metadata.json",
@@ -350,55 +355,55 @@
               "end" : 2256800
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Axel Milberg"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tasha",
-              "Victoria Zöller"
-            ],
-            [
-              "Domino Laverna",
-              "Sabine Hahn"
-            ],
-            [
-              "Biff Rodgers, Reporter",
-              "Daniel Schütter"
-            ],
-            [
-              "Lesley Dimple",
-              "Ann Montenbruck"
-            ],
-            [
-              "Zeus Zenon Johnson",
-              "Michael Prelle"
-            ],
-            [
-              "Computer",
-              "Peter Bayer"
-            ],
-            [
-              "Off-Sprecher",
-              "Frank Roder"
-            ],
-            [
-              "Sprecher",
-              "Andreas Birnbaum"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tasha",
+              "sprecher" : "Victoria Zöller"
+            },
+            {
+              "rolle" : "Domino Laverna",
+              "sprecher" : "Sabine Hahn"
+            },
+            {
+              "rolle" : "Biff Rodgers, Reporter",
+              "sprecher" : "Daniel Schütter"
+            },
+            {
+              "rolle" : "Lesley Dimple",
+              "sprecher" : "Ann Montenbruck"
+            },
+            {
+              "rolle" : "Zeus Zenon Johnson",
+              "sprecher" : "Michael Prelle"
+            },
+            {
+              "rolle" : "Computer",
+              "sprecher" : "Peter Bayer"
+            },
+            {
+              "rolle" : "Off-Sprecher",
+              "sprecher" : "Frank Roder"
+            },
+            {
+              "rolle" : "Sprecher",
+              "sprecher" : "Andreas Birnbaum"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/metadata.json",
@@ -427,35 +432,36 @@
               "end" : 1718507
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Axel Milberg"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Blacky",
-              "Pamela Punti"
-            ],
-            [
-              "Kassiererin",
-              "Angela Stresemann"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Blacky",
+              "sprecher" : "Heikedine Körting",
+              "pseudonym" : "Pamela Punti"
+            },
+            {
+              "rolle" : "Kassiererin",
+              "sprecher" : "Angela Stresemann"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/1/1/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/1/1/metadata.json
@@ -4,51 +4,51 @@
   "autor" : "Kari Erlhoff",
   "beschreibung" : "Mr. Vancura ist Schauspieler und sammelt alles, was mit dem Orient zu tun hat. Sein ganzer Stolz ist eine Wunderlampe, in der ein richtiger Dschinn lebt. Aber der Dschinn ist verschwunden …",
   "veröffentlichungsdatum" : "2011-12-02",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Vancura",
-      "Lutz Herkenrath"
-    ],
-    [
-      "Mrs. Fox",
-      "Susan Jarling"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mr. Shaw",
-      "Rasmus Borowski"
-    ],
-    [
-      "Shannon",
-      "Kerstin Draeger"
-    ],
-    [
-      "Mr. Mosley",
-      "Neil Malik Abdullah"
-    ],
-    [
-      "Mann",
-      "Thor W. Müller"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Vancura",
+      "sprecher" : "Lutz Herkenrath"
+    },
+    {
+      "rolle" : "Mrs. Fox",
+      "sprecher" : "Susan Jarling"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mr. Shaw",
+      "sprecher" : "Rasmus Borowski"
+    },
+    {
+      "rolle" : "Shannon",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "Mr. Mosley",
+      "sprecher" : "Neil Malik Abdullah"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Thor W. Müller"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/1/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/1/2/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/1/2/metadata.json
@@ -4,27 +4,27 @@
   "autor" : "Marco Sonnleitner",
   "beschreibung" : "Das neuste Hobby von Justus Jonas ist die Ahnenforschung.\nUnd dabei macht er eines Tages eine unglaubliche Entdeckung …",
   "veröffentlichungsdatum" : "2011-12-04",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Cowboy",
-      "Achim Schülke"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Cowboy",
+      "sprecher" : "Achim Schülke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/2/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/1/3/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/1/3/metadata.json
@@ -4,35 +4,35 @@
   "autor" : "Marco Sonnleitner",
   "beschreibung" : "Peter erhält eine E-Mail: Kelly ist entführt worden! Den drei ??? bleibt weniger als eine Stunde Zeit, sie zu finden und zu befreien …",
   "veröffentlichungsdatum" : "2011-12-06",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Patricia",
-      "Rhea Harder"
-    ],
-    [
-      "Peter Shawn",
-      "Leonhard Mahlich"
-    ],
-    [
-      "Mann",
-      "Helgo Liebig"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Patricia",
+      "sprecher" : "Rhea Harder-Vennewald"
+    },
+    {
+      "rolle" : "Peter Shawn",
+      "sprecher" : "Leonhard Mahlich"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Helgo Liebig"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/3/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/1/4/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/1/4/metadata.json
@@ -4,11 +4,11 @@
   "autor" : "Hendrik Buchna",
   "beschreibung" : "Auf dem Autorasthof \"Eagle Ranch\" geschehen merkwürdige Dinge und die drei ??? erhalten den Auftrag, herauszufinden, was es damit auf sich hat …",
   "veröffentlichungsdatum" : "2011-12-08",
-  "sprecher" : [
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/4/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/1/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/1/metadata.json
@@ -6,51 +6,51 @@
       "autor" : "Kari Erlhoff",
       "beschreibung" : "Mr. Vancura ist Schauspieler und sammelt alles, was mit dem Orient zu tun hat. Sein ganzer Stolz ist eine Wunderlampe, in der ein richtiger Dschinn lebt. Aber der Dschinn ist verschwunden …",
       "veröffentlichungsdatum" : "2011-12-02",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Vancura",
-          "Lutz Herkenrath"
-        ],
-        [
-          "Mrs. Fox",
-          "Susan Jarling"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Shaw",
-          "Rasmus Borowski"
-        ],
-        [
-          "Shannon",
-          "Kerstin Draeger"
-        ],
-        [
-          "Mr. Mosley",
-          "Neil Malik Abdullah"
-        ],
-        [
-          "Mann",
-          "Thor W. Müller"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Vancura",
+          "sprecher" : "Lutz Herkenrath"
+        },
+        {
+          "rolle" : "Mrs. Fox",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Shannon",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Mr. Mosley",
+          "sprecher" : "Neil Malik Abdullah"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Thor W. Müller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/1/metadata.json",
@@ -63,27 +63,27 @@
       "autor" : "Marco Sonnleitner",
       "beschreibung" : "Das neuste Hobby von Justus Jonas ist die Ahnenforschung.\nUnd dabei macht er eines Tages eine unglaubliche Entdeckung …",
       "veröffentlichungsdatum" : "2011-12-04",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Cowboy",
-          "Achim Schülke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Cowboy",
+          "sprecher" : "Achim Schülke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/2/metadata.json",
@@ -96,35 +96,35 @@
       "autor" : "Marco Sonnleitner",
       "beschreibung" : "Peter erhält eine E-Mail: Kelly ist entführt worden! Den drei ??? bleibt weniger als eine Stunde Zeit, sie zu finden und zu befreien …",
       "veröffentlichungsdatum" : "2011-12-06",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Patricia",
-          "Rhea Harder"
-        ],
-        [
-          "Peter Shawn",
-          "Leonhard Mahlich"
-        ],
-        [
-          "Mann",
-          "Helgo Liebig"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Patricia",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Peter Shawn",
+          "sprecher" : "Leonhard Mahlich"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Helgo Liebig"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/3/metadata.json",
@@ -137,11 +137,11 @@
       "autor" : "Hendrik Buchna",
       "beschreibung" : "Auf dem Autorasthof \"Eagle Ranch\" geschehen merkwürdige Dinge und die drei ??? erhalten den Auftrag, herauszufinden, was es damit auf sich hat …",
       "veröffentlichungsdatum" : "2011-12-08",
-      "sprecher" : [
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/4/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/2/5/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/2/5/metadata.json
@@ -4,39 +4,39 @@
   "autor" : "Marco Sonnleitner",
   "beschreibung" : "Als die drei ??? vom Strand kommen und auf dem Weg nach Hause sind, sehen sie ein SOS-Signal, das aus einem Haus gesendet wird. Eigentlich steht das Haus leer …",
   "veröffentlichungsdatum" : "2011-12-10",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Marty",
-      "Philipp Draeger"
-    ],
-    [
-      "Fred",
-      "Guido Bernadotte"
-    ],
-    [
-      "1. Mann",
-      "Rasmus Rakete"
-    ],
-    [
-      "2. Mann",
-      "Patrick Perales"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Marty",
+      "sprecher" : "Philipp Draeger"
+    },
+    {
+      "rolle" : "Fred",
+      "sprecher" : "Guido Bernadotte"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Rasmus Rakete"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Patrick Perales"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/5/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/2/6/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/2/6/metadata.json
@@ -4,11 +4,11 @@
   "autor" : "Hendrik Buchna",
   "beschreibung" : "Auf dem Weg nach Hause wird Peter plötzlich von einem unheimlichen, grauen Dämon verfolgt. Ihm bleibt nur noch ein Ausweg: Die Flucht …",
   "veröffentlichungsdatum" : "2011-12-12",
-  "sprecher" : [
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/6/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/2/7/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/2/7/metadata.json
@@ -4,27 +4,27 @@
   "autor" : "Kari Erlhoff",
   "beschreibung" : "Peters ehemalige Klavierlehrerin, Mrs. Floyd, engagiert die drei ???, um herauszufinden, wo ihre verstorbene Mutter ihr Erbe versteckt haben könnte …",
   "veröffentlichungsdatum" : "2011-12-14",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Floyd",
-      "Gabriele Libbach"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Floyd",
+      "sprecher" : "Gabriele Libbach"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/7/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/2/8/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/2/8/metadata.json
@@ -4,31 +4,31 @@
   "autor" : "Hendrik Buchna",
   "beschreibung" : "Die drei ??? erhalten den Auftrag, bei der Übergabe einer schwarzen Nadel dabei zu sein. Aber geht es dabei wirklich nur um das Schmuckstück?",
   "veröffentlichungsdatum" : "2011-12-16",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Vincent Grimes",
-      "Konstantin Graudus"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Vincent Grimes",
+      "sprecher" : "Konstantin Graudus"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/8/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/2/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/2/metadata.json
@@ -6,39 +6,39 @@
       "autor" : "Marco Sonnleitner",
       "beschreibung" : "Als die drei ??? vom Strand kommen und auf dem Weg nach Hause sind, sehen sie ein SOS-Signal, das aus einem Haus gesendet wird. Eigentlich steht das Haus leer …",
       "veröffentlichungsdatum" : "2011-12-10",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Marty",
-          "Philipp Draeger"
-        ],
-        [
-          "Fred",
-          "Guido Bernadotte"
-        ],
-        [
-          "1. Mann",
-          "Rasmus Rakete"
-        ],
-        [
-          "2. Mann",
-          "Patrick Perales"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Marty",
+          "sprecher" : "Philipp Draeger"
+        },
+        {
+          "rolle" : "Fred",
+          "sprecher" : "Guido Bernadotte"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Rasmus Rakete"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Patrick Perales"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/5/metadata.json",
@@ -51,11 +51,11 @@
       "autor" : "Hendrik Buchna",
       "beschreibung" : "Auf dem Weg nach Hause wird Peter plötzlich von einem unheimlichen, grauen Dämon verfolgt. Ihm bleibt nur noch ein Ausweg: Die Flucht …",
       "veröffentlichungsdatum" : "2011-12-12",
-      "sprecher" : [
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/6/metadata.json",
@@ -68,27 +68,27 @@
       "autor" : "Kari Erlhoff",
       "beschreibung" : "Peters ehemalige Klavierlehrerin, Mrs. Floyd, engagiert die drei ???, um herauszufinden, wo ihre verstorbene Mutter ihr Erbe versteckt haben könnte …",
       "veröffentlichungsdatum" : "2011-12-14",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Floyd",
-          "Gabriele Libbach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Floyd",
+          "sprecher" : "Gabriele Libbach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/7/metadata.json",
@@ -101,31 +101,31 @@
       "autor" : "Hendrik Buchna",
       "beschreibung" : "Die drei ??? erhalten den Auftrag, bei der Übergabe einer schwarzen Nadel dabei zu sein. Aber geht es dabei wirklich nur um das Schmuckstück?",
       "veröffentlichungsdatum" : "2011-12-16",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Vincent Grimes",
-          "Konstantin Graudus"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Vincent Grimes",
+          "sprecher" : "Konstantin Graudus"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/8/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/3/10/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/3/10/metadata.json
@@ -4,11 +4,11 @@
   "autor" : "Marco Sonnleitner",
   "beschreibung" : "Die drei ??? sollen von der Stadt Rocky Beach für ihr Lebenswerk geehrt werden. Und prompt sitzen sie gleich wieder mitten in einem neuen Fall …",
   "veröffentlichungsdatum" : "2011-12-20",
-  "sprecher" : [
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/10/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/3/11/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/3/11/metadata.json
@@ -4,35 +4,35 @@
   "autor" : "Kari Erlhoff",
   "beschreibung" : "Kellys Tante wird erpresst und die drei ??? sollen bei der Übergabe des Geldes behilflich sein. Aber in dem Motel, in dem Peter und Kelly absteigen, passieren merkwürdige Dinge …",
   "veröffentlichungsdatum" : "2011-12-22",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "Norman",
-      "Eckart Dux"
-    ],
-    [
-      "Frau",
-      "Anja Topf"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Norman",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Frau",
+      "sprecher" : "Anja Topf"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/11/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/3/12/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/3/12/metadata.json
@@ -4,43 +4,43 @@
   "autor" : "Hendrik Buchna",
   "beschreibung" : "Rocky Beach versinkt im Schnee. Und zu allem Überfluss treibt gerade jetzt, wo die Polizei mehr oder weniger handlungsunfähig ist, ein krimineller Weihnachtsmann in der Stadt sein Unwesen …",
   "veröffentlichungsdatum" : "2011-12-24",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mr. Darrow",
-      "Joachim Kappl"
-    ],
-    [
-      "1. Mann",
-      "Patrick Bach"
-    ],
-    [
-      "2. Mann",
-      "Frank Meyer-Brockmann"
-    ],
-    [
-      "3. Mann",
-      "Roy Martens"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mr. Darrow",
+      "sprecher" : "Joachim Kappl"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Frank Meyer-Brockmann"
+    },
+    {
+      "rolle" : "Mann 3",
+      "sprecher" : "Roy Martens"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/12/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/3/9/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/3/9/metadata.json
@@ -4,43 +4,44 @@
   "autor" : "Kari Erlhoff",
   "beschreibung" : "Blacky, der Papagei der drei ???, benimmt sich seit ein paar Tagen höchst sonderbar.\nWas ist der Grund für die merkwürdigen Sprüche, die der Vogel plötzlich zitiert …",
   "veröffentlichungsdatum" : "2011-12-18",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Blacky/Mynah",
-      "Heikedine Körting"
-    ],
-    [
-      "Juliet",
-      "Anne Moll"
-    ],
-    [
-      "Scott",
-      "Tommaso Cacciapuoti"
-    ],
-    [
-      "John",
-      "Martin Sichel"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Juliet",
+      "sprecher" : "Anne Moll"
+    },
+    {
+      "rolle" : "Scott",
+      "sprecher" : "Tommaso Cacciapuoti"
+    },
+    {
+      "rolle" : "John",
+      "sprecher" : "Sascha Draeger",
+      "pseudonym" : "Martin Sichel"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/9/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/3/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/3/metadata.json
@@ -6,43 +6,44 @@
       "autor" : "Kari Erlhoff",
       "beschreibung" : "Blacky, der Papagei der drei ???, benimmt sich seit ein paar Tagen höchst sonderbar.\nWas ist der Grund für die merkwürdigen Sprüche, die der Vogel plötzlich zitiert …",
       "veröffentlichungsdatum" : "2011-12-18",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Blacky/Mynah",
-          "Heikedine Körting"
-        ],
-        [
-          "Juliet",
-          "Anne Moll"
-        ],
-        [
-          "Scott",
-          "Tommaso Cacciapuoti"
-        ],
-        [
-          "John",
-          "Martin Sichel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Juliet",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Scott",
+          "sprecher" : "Tommaso Cacciapuoti"
+        },
+        {
+          "rolle" : "John",
+          "sprecher" : "Sascha Draeger",
+          "pseudonym" : "Martin Sichel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/9/metadata.json",
@@ -55,11 +56,11 @@
       "autor" : "Marco Sonnleitner",
       "beschreibung" : "Die drei ??? sollen von der Stadt Rocky Beach für ihr Lebenswerk geehrt werden. Und prompt sitzen sie gleich wieder mitten in einem neuen Fall …",
       "veröffentlichungsdatum" : "2011-12-20",
-      "sprecher" : [
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/10/metadata.json",
@@ -72,35 +73,35 @@
       "autor" : "Kari Erlhoff",
       "beschreibung" : "Kellys Tante wird erpresst und die drei ??? sollen bei der Übergabe des Geldes behilflich sein. Aber in dem Motel, in dem Peter und Kelly absteigen, passieren merkwürdige Dinge …",
       "veröffentlichungsdatum" : "2011-12-22",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Norman",
-          "Eckart Dux"
-        ],
-        [
-          "Frau",
-          "Anja Topf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Norman",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Anja Topf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/11/metadata.json",
@@ -113,43 +114,43 @@
       "autor" : "Hendrik Buchna",
       "beschreibung" : "Rocky Beach versinkt im Schnee. Und zu allem Überfluss treibt gerade jetzt, wo die Polizei mehr oder weniger handlungsunfähig ist, ein krimineller Weihnachtsmann in der Stadt sein Unwesen …",
       "veröffentlichungsdatum" : "2011-12-24",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Darrow",
-          "Joachim Kappl"
-        ],
-        [
-          "1. Mann",
-          "Patrick Bach"
-        ],
-        [
-          "2. Mann",
-          "Frank Meyer-Brockmann"
-        ],
-        [
-          "3. Mann",
-          "Roy Martens"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Darrow",
+          "sprecher" : "Joachim Kappl"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Frank Meyer-Brockmann"
+        },
+        {
+          "rolle" : "Mann 3",
+          "sprecher" : "Roy Martens"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/12/metadata.json",

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/metadata.json
@@ -8,51 +8,51 @@
           "autor" : "Kari Erlhoff",
           "beschreibung" : "Mr. Vancura ist Schauspieler und sammelt alles, was mit dem Orient zu tun hat. Sein ganzer Stolz ist eine Wunderlampe, in der ein richtiger Dschinn lebt. Aber der Dschinn ist verschwunden …",
           "veröffentlichungsdatum" : "2011-12-02",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Mr. Vancura",
-              "Lutz Herkenrath"
-            ],
-            [
-              "Mrs. Fox",
-              "Susan Jarling"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Mr. Shaw",
-              "Rasmus Borowski"
-            ],
-            [
-              "Shannon",
-              "Kerstin Draeger"
-            ],
-            [
-              "Mr. Mosley",
-              "Neil Malik Abdullah"
-            ],
-            [
-              "Mann",
-              "Thor W. Müller"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mr. Vancura",
+              "sprecher" : "Lutz Herkenrath"
+            },
+            {
+              "rolle" : "Mrs. Fox",
+              "sprecher" : "Susan Jarling"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Mr. Shaw",
+              "sprecher" : "Rasmus Borowski"
+            },
+            {
+              "rolle" : "Shannon",
+              "sprecher" : "Kerstin Draeger"
+            },
+            {
+              "rolle" : "Mr. Mosley",
+              "sprecher" : "Neil Malik Abdullah"
+            },
+            {
+              "rolle" : "Mann",
+              "sprecher" : "Thor W. Müller"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/1/metadata.json",
@@ -65,27 +65,27 @@
           "autor" : "Marco Sonnleitner",
           "beschreibung" : "Das neuste Hobby von Justus Jonas ist die Ahnenforschung.\nUnd dabei macht er eines Tages eine unglaubliche Entdeckung …",
           "veröffentlichungsdatum" : "2011-12-04",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Cowboy",
-              "Achim Schülke"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Cowboy",
+              "sprecher" : "Achim Schülke"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/2/metadata.json",
@@ -98,35 +98,35 @@
           "autor" : "Marco Sonnleitner",
           "beschreibung" : "Peter erhält eine E-Mail: Kelly ist entführt worden! Den drei ??? bleibt weniger als eine Stunde Zeit, sie zu finden und zu befreien …",
           "veröffentlichungsdatum" : "2011-12-06",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Patricia",
-              "Rhea Harder"
-            ],
-            [
-              "Peter Shawn",
-              "Leonhard Mahlich"
-            ],
-            [
-              "Mann",
-              "Helgo Liebig"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Patricia",
+              "sprecher" : "Rhea Harder-Vennewald"
+            },
+            {
+              "rolle" : "Peter Shawn",
+              "sprecher" : "Leonhard Mahlich"
+            },
+            {
+              "rolle" : "Mann",
+              "sprecher" : "Helgo Liebig"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/3/metadata.json",
@@ -139,11 +139,11 @@
           "autor" : "Hendrik Buchna",
           "beschreibung" : "Auf dem Autorasthof \"Eagle Ranch\" geschehen merkwürdige Dinge und die drei ??? erhalten den Auftrag, herauszufinden, was es damit auf sich hat …",
           "veröffentlichungsdatum" : "2011-12-08",
-          "sprecher" : [
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/4/metadata.json",
@@ -188,39 +188,39 @@
           "autor" : "Marco Sonnleitner",
           "beschreibung" : "Als die drei ??? vom Strand kommen und auf dem Weg nach Hause sind, sehen sie ein SOS-Signal, das aus einem Haus gesendet wird. Eigentlich steht das Haus leer …",
           "veröffentlichungsdatum" : "2011-12-10",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Marty",
-              "Philipp Draeger"
-            ],
-            [
-              "Fred",
-              "Guido Bernadotte"
-            ],
-            [
-              "1. Mann",
-              "Rasmus Rakete"
-            ],
-            [
-              "2. Mann",
-              "Patrick Perales"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Marty",
+              "sprecher" : "Philipp Draeger"
+            },
+            {
+              "rolle" : "Fred",
+              "sprecher" : "Guido Bernadotte"
+            },
+            {
+              "rolle" : "Mann 1",
+              "sprecher" : "Rasmus Rakete"
+            },
+            {
+              "rolle" : "Mann 2",
+              "sprecher" : "Patrick Perales"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/5/metadata.json",
@@ -233,11 +233,11 @@
           "autor" : "Hendrik Buchna",
           "beschreibung" : "Auf dem Weg nach Hause wird Peter plötzlich von einem unheimlichen, grauen Dämon verfolgt. Ihm bleibt nur noch ein Ausweg: Die Flucht …",
           "veröffentlichungsdatum" : "2011-12-12",
-          "sprecher" : [
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/6/metadata.json",
@@ -250,27 +250,27 @@
           "autor" : "Kari Erlhoff",
           "beschreibung" : "Peters ehemalige Klavierlehrerin, Mrs. Floyd, engagiert die drei ???, um herauszufinden, wo ihre verstorbene Mutter ihr Erbe versteckt haben könnte …",
           "veröffentlichungsdatum" : "2011-12-14",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Mrs. Floyd",
-              "Gabriele Libbach"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mrs. Floyd",
+              "sprecher" : "Gabriele Libbach"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/7/metadata.json",
@@ -283,31 +283,31 @@
           "autor" : "Hendrik Buchna",
           "beschreibung" : "Die drei ??? erhalten den Auftrag, bei der Übergabe einer schwarzen Nadel dabei zu sein. Aber geht es dabei wirklich nur um das Schmuckstück?",
           "veröffentlichungsdatum" : "2011-12-16",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Vincent Grimes",
-              "Konstantin Graudus"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Vincent Grimes",
+              "sprecher" : "Konstantin Graudus"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/8/metadata.json",
@@ -352,43 +352,44 @@
           "autor" : "Kari Erlhoff",
           "beschreibung" : "Blacky, der Papagei der drei ???, benimmt sich seit ein paar Tagen höchst sonderbar.\nWas ist der Grund für die merkwürdigen Sprüche, die der Vogel plötzlich zitiert …",
           "veröffentlichungsdatum" : "2011-12-18",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Blacky/Mynah",
-              "Heikedine Körting"
-            ],
-            [
-              "Juliet",
-              "Anne Moll"
-            ],
-            [
-              "Scott",
-              "Tommaso Cacciapuoti"
-            ],
-            [
-              "John",
-              "Martin Sichel"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Blacky",
+              "sprecher" : "Heikedine Körting"
+            },
+            {
+              "rolle" : "Juliet",
+              "sprecher" : "Anne Moll"
+            },
+            {
+              "rolle" : "Scott",
+              "sprecher" : "Tommaso Cacciapuoti"
+            },
+            {
+              "rolle" : "John",
+              "sprecher" : "Sascha Draeger",
+              "pseudonym" : "Martin Sichel"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/9/metadata.json",
@@ -401,11 +402,11 @@
           "autor" : "Marco Sonnleitner",
           "beschreibung" : "Die drei ??? sollen von der Stadt Rocky Beach für ihr Lebenswerk geehrt werden. Und prompt sitzen sie gleich wieder mitten in einem neuen Fall …",
           "veröffentlichungsdatum" : "2011-12-20",
-          "sprecher" : [
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/10/metadata.json",
@@ -418,35 +419,35 @@
           "autor" : "Kari Erlhoff",
           "beschreibung" : "Kellys Tante wird erpresst und die drei ??? sollen bei der Übergabe des Geldes behilflich sein. Aber in dem Motel, in dem Peter und Kelly absteigen, passieren merkwürdige Dinge …",
           "veröffentlichungsdatum" : "2011-12-22",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Kelly",
-              "Juliane Szalay"
-            ],
-            [
-              "Norman",
-              "Eckart Dux"
-            ],
-            [
-              "Frau",
-              "Anja Topf"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Kelly",
+              "sprecher" : "Juliane Szalay"
+            },
+            {
+              "rolle" : "Norman",
+              "sprecher" : "Eckart Dux"
+            },
+            {
+              "rolle" : "Frau",
+              "sprecher" : "Anja Topf"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/11/metadata.json",
@@ -459,43 +460,43 @@
           "autor" : "Hendrik Buchna",
           "beschreibung" : "Rocky Beach versinkt im Schnee. Und zu allem Überfluss treibt gerade jetzt, wo die Polizei mehr oder weniger handlungsunfähig ist, ein krimineller Weihnachtsmann in der Stadt sein Unwesen …",
           "veröffentlichungsdatum" : "2011-12-24",
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Mr. Darrow",
-              "Joachim Kappl"
-            ],
-            [
-              "1. Mann",
-              "Patrick Bach"
-            ],
-            [
-              "2. Mann",
-              "Frank Meyer-Brockmann"
-            ],
-            [
-              "3. Mann",
-              "Roy Martens"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Mr. Darrow",
+              "sprecher" : "Joachim Kappl"
+            },
+            {
+              "rolle" : "Mann 1",
+              "sprecher" : "Patrick Bach"
+            },
+            {
+              "rolle" : "Mann 2",
+              "sprecher" : "Frank Meyer-Brockmann"
+            },
+            {
+              "rolle" : "Mann 3",
+              "sprecher" : "Roy Martens"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/12/metadata.json",

--- a/web/data/Serie.json
+++ b/web/data/Serie.json
@@ -49,55 +49,57 @@
           "end" : 3144160
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Fentriss, Schriftsteller",
-          "Richard Lauffen"
-        ],
-        [
-          "Mr. Claudius, Kunsthändler",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Mrs. Claudius",
-          "Ingrid Andree"
-        ],
-        [
-          "Miss Waggoner",
-          "Katharina Brauren"
-        ],
-        [
-          "Carlos",
-          "Stefan Brönneke"
-        ],
-        [
-          "Onkel Ramos",
-          "Juan Perez [Karl-Ulrich Meves]"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro [Wolfgang Kubach]"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Fentriss, Schriftsteller",
+          "sprecher" : "Richard Lauffen"
+        },
+        {
+          "rolle" : "Mr. Claudius, Kunsthändler",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Mrs. Claudius",
+          "sprecher" : "Ingrid Andree"
+        },
+        {
+          "rolle" : "Miss Waggoner",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Carlos",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Onkel Ramos",
+          "sprecher" : "Karl-Ulrich Meves",
+          "pseudonym" : "Juan Perez"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/001/metadata.json",
@@ -156,63 +158,66 @@
           "end" : 2738933
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Patrick Kenneth",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Java-Jim",
-          "Heinz Überreiter [Gottfried Kramer]"
-        ],
-        [
-          "Mrs. Flora Gunn",
-          "Veronika Weckler"
-        ],
-        [
-          "Cluny Gunn",
-          "Fabian Harloff"
-        ],
-        [
-          "Rory",
-          "Klaus-Peter Reisch [Peter Buchholz]"
-        ],
-        [
-          "Stebins",
-          "Hans Meinhardt [Karl-Ulrich Meves]"
-        ],
-        [
-          "Mr. Widner",
-          "Ernst von Klipstein"
-        ],
-        [
-          "Verwalter von Powder Gulch",
-          "Reiner Brönneke"
-        ],
-        [
-          "Bibliothekarin",
-          "Katharina Brauren"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Patrick Kenneth",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Java-Jim",
+          "sprecher" : "Gottfried Kramer",
+          "pseudonym" : "Heinz Überreiter"
+        },
+        {
+          "rolle" : "Mrs. Flora Gunn",
+          "sprecher" : "Veronika Weckler"
+        },
+        {
+          "rolle" : "Cluny Gunn",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Rory",
+          "sprecher" : "Peter Buchholz",
+          "pseudonym" : "Klaus-Peter Reisch"
+        },
+        {
+          "rolle" : "Stebins",
+          "sprecher" : "Karl-Ulrich Meves",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Mr. Widner",
+          "sprecher" : "Ernst von Klipstein"
+        },
+        {
+          "rolle" : "Verwalter von Powder Gulch",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Bibliothekarin",
+          "sprecher" : "Katharina Brauren"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/002/metadata.json",
@@ -271,59 +276,62 @@
           "end" : 2748440
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Prentice",
-          "Hans Hessling"
-        ],
-        [
-          "Niedland",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Pfarrer",
-          "Ernst von Klipstein"
-        ],
-        [
-          "Mrs. Boogle",
-          "Katharina Brauren"
-        ],
-        [
-          "Sonny Elmquist",
-          "Philip Kunzmann [Gernot Endemann]"
-        ],
-        [
-          "Mr. Murphy",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "Miss Chalmers",
-          "Pamela Punti"
-        ],
-        [
-          "Mr. Hassel",
-          "Rolf Hundertwasser"
-        ],
-        [
-          "Polizist",
-          "Rolf Mamero"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Prentice",
+          "sprecher" : "Hans Hessling"
+        },
+        {
+          "rolle" : "Niedland",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Pfarrer",
+          "sprecher" : "Ernst von Klipstein"
+        },
+        {
+          "rolle" : "Mrs. Boogle",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Sonny Elmquist",
+          "sprecher" : "Gernot Endemann",
+          "pseudonym" : "Philip Kunzmann"
+        },
+        {
+          "rolle" : "Mr. Murphy",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "Miss Chalmers",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Mr. Hassel",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Rolf Hundertwasser"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Rolf Mamero"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/003/metadata.json",
@@ -382,71 +390,74 @@
           "end" : 2662960
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Andy Carson",
-          "Stefan Schwade"
-        ],
-        [
-          "Mr. Carson",
-          "Reiner Brönneke"
-        ],
-        [
-          "Khan, der Kraftmensch",
-          "René Genesis"
-        ],
-        [
-          "Einzigartiger Gabbo",
-          "Iwan Raszinsky [Karl-Ulrich Meves]"
-        ],
-        [
-          "Iwan",
-          "Boris Stepin [Wolfgang Kubach]"
-        ],
-        [
-          "Junge",
-          "Philip Baader"
-        ],
-        [
-          "Hauptkommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Der alte Mann",
-          "Lothar Grützner"
-        ],
-        [
-          "Wachmann",
-          "Peter Buchholz"
-        ],
-        [
-          "Jungen",
-          "Stefan Brönneke, Alexander Körting"
-        ],
-        [
-          "Jahrmarktfrau",
-          "Heikedine Körting"
-        ],
-        [
-          "Funksprecher",
-          "Gernot Endemann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Andy Carson",
+          "sprecher" : "Stefan Schwade"
+        },
+        {
+          "rolle" : "Mr. Carson",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Khan, der Kraftmensch",
+          "sprecher" : "René Genesis"
+        },
+        {
+          "rolle" : "Einzigartiger Gabbo",
+          "sprecher" : "Karl-Ulrich Meves",
+          "pseudonym" : "Iwan Raszinsky"
+        },
+        {
+          "rolle" : "Iwan",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Boris Stepin"
+        },
+        {
+          "rolle" : "Junge 1",
+          "sprecher" : "Stefan Brönneke",
+          "pseudonym" : "Philip Baader"
+        },
+        {
+          "rolle" : "Junge 2",
+          "sprecher" : "Alexander Körting"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Der alte Mann",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Jahrmarktfrau",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Funksprecher",
+          "sprecher" : "Gernot Endemann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/004/metadata.json",
@@ -505,59 +516,59 @@
           "end" : 2960987
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "August August, genannt Gus",
-          "Stephan Chreszinski"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Dwiggins",
-          "Joachim Wolff"
-        ],
-        [
-          "Mr. Rhandur",
-          "Gottfried Kramer"
-        ],
-        [
-          "Joe",
-          "Peter Buchholz"
-        ],
-        [
-          "Lisa",
-          "Madeleine Stolze"
-        ],
-        [
-          "Mutter",
-          "Renate Pichler"
-        ],
-        [
-          "Patrick Kenneth",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Bauarbeiter",
-          "Gernot Endemann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "August August, genannt Gus",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Dwiggins",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Mr. Rhandur",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Lisa",
+          "sprecher" : "Madeleine Stolze"
+        },
+        {
+          "rolle" : "Mutter",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Patrick Kenneth",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Bauarbeiter",
+          "sprecher" : "Gernot Endemann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/005/metadata.json",
@@ -617,67 +628,69 @@
           "end" : 2752640
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Patrick Kenneth",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Gulliver",
-          "Joachim Wolff"
-        ],
-        [
-          "Mr. Maximillian",
-          "Richard Lauffen"
-        ],
-        [
-          "Hauptkommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Mrs. Miller",
-          "Marianne Wolters [Marianne Kehlau]"
-        ],
-        [
-          "Mr. Grant",
-          "Hans Meinhardt [Lothar Grützner]"
-        ],
-        [
-          "Auktionator",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Fred Brown",
-          "Peter Buchholz"
-        ],
-        [
-          "Hauswirt",
-          "Reiner Brönneke"
-        ],
-        [
-          "Mann",
-          "Karl-Ulrich Meves"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Patrick Kenneth",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Gulliver",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Mr. Maximillian",
+          "sprecher" : "Richard Lauffen"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Mrs. Miller",
+          "sprecher" : "Marianne Kehlau",
+          "pseudonym" : "Marianne Wolters"
+        },
+        {
+          "rolle" : "Mr. Grant",
+          "sprecher" : "Lothar Grützner",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Auktionator",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Fred Brown",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Hauswirt",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Karl-Ulrich Meves"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/006/metadata.json",
@@ -736,47 +749,48 @@
           "end" : 2721773
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "H. H. Allen",
-          "Werner Cartano"
-        ],
-        [
-          "Mr. Shelby",
-          "Richard Lauffen"
-        ],
-        [
-          "Mr. Carter",
-          "F. J. Steffens"
-        ],
-        [
-          "Jack Morgan",
-          "Klaus Klein [Wolfgang Kubach]"
-        ],
-        [
-          "Harry Morgan",
-          "Reiner Brönneke"
-        ],
-        [
-          "Telephonistin",
-          "Reinhild Schneider"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "H. H. Allen",
+          "sprecher" : "Werner Cartano"
+        },
+        {
+          "rolle" : "Mr. Shelby",
+          "sprecher" : "Richard Lauffen"
+        },
+        {
+          "rolle" : "Mr. Carter",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Jack Morgan",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Klaus Klein"
+        },
+        {
+          "rolle" : "Harry Morgan",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Telephonistin",
+          "sprecher" : "Reinhilt Schneider"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/007/metadata.json",
@@ -835,67 +849,69 @@
           "end" : 3203720
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Chang",
-          "Torsten Sense"
-        ],
-        [
-          "Patrick Kenneth",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Miss Lydia Green",
-          "Marianne Kehlau"
-        ],
-        [
-          "Harold Carlson",
-          "Alexander Stubbe [Peter Kirchberger]"
-        ],
-        [
-          "Hauptkommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Jensen",
-          "Rolf Mamero"
-        ],
-        [
-          "Won",
-          "Victor Bernard [Ernst von Klipstein]"
-        ],
-        [
-          "Wongs Diener",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "Li",
-          "Renate Pichler"
-        ],
-        [
-          "Männer bei Greens Haus",
-          "Reiner Brönneke, Gernot Endemann"
-        ],
-        [
-          "Polizist",
-          "Peter Buchholz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Chang",
+          "sprecher" : "Torsten Sense"
+        },
+        {
+          "rolle" : "Patrick Kenneth",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Miss Lydia Green",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Harold Carlson",
+          "sprecher" : "Peter Kirchberger",
+          "pseudonym" : "Alexander Stubbe"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Jensen",
+          "sprecher" : "Rolf Mamero"
+        },
+        {
+          "rolle" : "Won",
+          "sprecher" : "Ernst von Klipstein",
+          "pseudonym" : "Victor Bernard"
+        },
+        {
+          "rolle" : "Wongs Diener",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "Li",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Männer bei Greens Haus",
+          "sprecher" : "Reiner Brönneke, Gernot Endemann"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Peter Buchholz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/008/metadata.json",
@@ -954,63 +970,66 @@
           "end" : 2832680
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Professor Carswell",
-          "Theodor Anzinger"
-        ],
-        [
-          "Hal Carswell",
-          "Oliver Mink"
-        ],
-        [
-          "Gräfin",
-          "Henriette Bischoff [Gisela Trowe]"
-        ],
-        [
-          "Armand Marechal",
-          "Joachim Wolff"
-        ],
-        [
-          "De Groot",
-          "René Genesis"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Maxwell James",
-          "Werner Cartano"
-        ],
-        [
-          "Hauptkommissar Reynolds",
-          "Horst Frank"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Professor Carswell",
+          "sprecher" : "Volker Bogdan",
+          "pseudonym" : "Theodor Anzinger"
+        },
+        {
+          "rolle" : "Hal Carswell",
+          "sprecher" : "Oliver Mink"
+        },
+        {
+          "rolle" : "Gräfin",
+          "sprecher" : "Gisela Trowe",
+          "pseudonym" : "Henriette Bischoff"
+        },
+        {
+          "rolle" : "Armand Marechal",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "De Groot",
+          "sprecher" : "René Genesis"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Maxwell James",
+          "sprecher" : "Werner Cartano"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/009/metadata.json",
@@ -1069,63 +1088,65 @@
           "end" : 3043693
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Patrick",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Professor Yarborough",
-          "Karl Walter Diess"
-        ],
-        [
-          "Wilkins, sein Butler",
-          "Ulrich Matschoss"
-        ],
-        [
-          "Professor Freeman",
-          "Joachim Wolff [Klaus Stieringer]"
-        ],
-        [
-          "Achmed",
-          "Ali Branowitch [Joachim Wolff]"
-        ],
-        [
-          "Hamid",
-          "Alexander Körting"
-        ],
-        [
-          "Harry",
-          "Peter Buchholz"
-        ],
-        [
-          "Joe",
-          "Reiner Brönneke"
-        ],
-        [
-          "Uhrenmacher",
-          "Gernot Endemann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Professor Yarborough",
+          "sprecher" : "Karl Walter Diess"
+        },
+        {
+          "rolle" : "Wilkins, sein Butler",
+          "sprecher" : "Ulrich Matschoss"
+        },
+        {
+          "rolle" : "Professor Freeman",
+          "sprecher" : "Klaus Stieringer",
+          "pseudonym" : "Viktor Bramer"
+        },
+        {
+          "rolle" : "Achmed",
+          "sprecher" : "Joachim Wolff",
+          "pseudonym" : "Ali Branowitch"
+        },
+        {
+          "rolle" : "Hamid",
+          "sprecher" : "Alexander Körting"
+        },
+        {
+          "rolle" : "Harry",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Uhrenmacher",
+          "sprecher" : "Gernot Endemann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/010/metadata.json",
@@ -1184,43 +1205,43 @@
           "end" : 2894907
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Stephen Terrill",
-          "Wolf Rahtjen"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mr. Grant",
-          "Horst Breiter"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Stephen Terrill",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mr. Grant",
+          "sprecher" : "Horst Breiter"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/011/metadata.json",
@@ -1280,71 +1301,75 @@
           "end" : 2736347
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Felix",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "Mrs. Smith",
-          "Maria Benders"
-        ],
-        [
-          "Harry",
-          "Marco Beddis"
-        ],
-        [
-          "Mrs. King",
-          "Helga Bammert"
-        ],
-        [
-          "Julie Taylor",
-          "Renate Pichler"
-        ],
-        [
-          "Martha Harris",
-          "Marga Maasberg"
-        ],
-        [
-          "Carlos",
-          "Hans-Werner Kuhn [Günter Heising]"
-        ],
-        [
-          "Gerald Cramer",
-          "Volker Brandt"
-        ],
-        [
-          "Gerald Watson",
-          "Werner van Thiel [Werner Cartano]"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro [Wolfgang Kubach]"
-        ],
-        [
-          "Hauptkommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Mr Jankins",
-          "Lothar Zibell"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Felix",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "Mrs. Smith",
+          "sprecher" : "Brigitte Alexis",
+          "pseudonym" : "Maria Benders"
+        },
+        {
+          "rolle" : "Harry",
+          "sprecher" : "Marco Beddies"
+        },
+        {
+          "rolle" : "Mrs. King",
+          "sprecher" : "Helga Bammert"
+        },
+        {
+          "rolle" : "Julie Taylor",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Martha Harris",
+          "sprecher" : "Eva Gelb"
+        },
+        {
+          "rolle" : "Carlos",
+          "sprecher" : "Günther Heising",
+          "pseudonym" : "Hans-Werner Kuhn"
+        },
+        {
+          "rolle" : "Gerald Cramer",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Gerald Watson",
+          "sprecher" : "Werner Cartano",
+          "pseudonym" : "Werner van Thiel"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Mr. Jankins",
+          "sprecher" : "Lothar Zibell"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/012/metadata.json",
@@ -1403,67 +1428,68 @@
           "end" : 2640320
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Harris",
-          "Günter Heising"
-        ],
-        [
-          "Miss Sanchez",
-          "Marlene Lindner [Ursula Vogel]"
-        ],
-        [
-          "Ted Sanchez",
-          "Nikolas Körting"
-        ],
-        [
-          "Sanders",
-          "Torsten Sense"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Natches",
-          "Gernot Endermann"
-        ],
-        [
-          "Hauptkommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Prof. Meeker",
-          "Josef Dahmen"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Polizist",
-          "Joachim Wolff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Harris",
+          "sprecher" : "Günther Heising"
+        },
+        {
+          "rolle" : "Miss Sanchez",
+          "sprecher" : "Cordula Hubrich",
+          "pseudonym" : "Marlene Lindner"
+        },
+        {
+          "rolle" : "Ted Sanchez",
+          "sprecher" : "Nicolas Körting"
+        },
+        {
+          "rolle" : "Sanders",
+          "sprecher" : "Torsten Sense"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Natches",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Prof. Meeker",
+          "sprecher" : "Josef Dahmen"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Joachim Wolff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/013/metadata.json",
@@ -1522,63 +1548,63 @@
           "end" : 2550187
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Smathers",
-          "Josef Dahmen"
-        ],
-        [
-          "Mr. Jensen",
-          "Wolf Rahtjen"
-        ],
-        [
-          "Patrick",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Kenneth",
-          "Lutz Mackensy"
-        ],
-        [
-          "Kathleen",
-          "Brigitte Alexis"
-        ],
-        [
-          "Mr. Joe Hammond",
-          "Volker Brandt"
-        ],
-        [
-          "Mrs. Hammond",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Richardsen",
-          "Joachim Wolff"
-        ],
-        [
-          "Polizist",
-          "Horst Stark"
-        ],
-        [
-          "Lieferant",
-          "F.-J. Steffens"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Smathers",
+          "sprecher" : "Josef Dahmen"
+        },
+        {
+          "rolle" : "Mr. Jensen",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Kenneth",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Kathleen",
+          "sprecher" : "Brigitte Alexis"
+        },
+        {
+          "rolle" : "Mr. Joe Hammond",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Mrs. Hammond",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Richardsen",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Lieferant",
+          "sprecher" : "Franz-Josef Steffens"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/014/metadata.json",
@@ -1637,67 +1663,68 @@
           "end" : 2385253
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Miss Larson",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Jim Hall",
-          "Horst Stark"
-        ],
-        [
-          "Mike Hall",
-          "Mathias Lorenz"
-        ],
-        [
-          "Eastland",
-          "Karl Walter Diess"
-        ],
-        [
-          "Olsen",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "Hank Murphy",
-          "Harald Pages"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Doc Dawson",
-          "Wolfgang Jürgen"
-        ],
-        [
-          "Dobbsie",
-          "Joachim Wolff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Miss Larson",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Jim Hall",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Mike Hall",
+          "sprecher" : "Mathias Lorenz"
+        },
+        {
+          "rolle" : "Eastland",
+          "sprecher" : "Karl Walter Diess"
+        },
+        {
+          "rolle" : "Olsen",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "Hank Murphy",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Doc Dawson",
+          "sprecher" : "Wolfgang Jürgen"
+        },
+        {
+          "rolle" : "Dobbsie",
+          "sprecher" : "Joachim Wolff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/015/metadata.json",
@@ -1756,55 +1783,56 @@
           "end" : 2551347
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Darnley",
-          "Gisela Trowe"
-        ],
-        [
-          "Jeff Darnley",
-          "Mike Henning"
-        ],
-        [
-          "Jenny Darnley",
-          "Marlen Krause"
-        ],
-        [
-          "Senior Santora",
-          "Jürgen Thormann"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Gomez",
-          "Karl-Heinz Gerdesmann"
-        ],
-        [
-          "Brotverkäufer",
-          "Harald Pages"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Darnley",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Jeff Darnley",
+          "sprecher" : "Mike Henning"
+        },
+        {
+          "rolle" : "Jenny Darnley",
+          "sprecher" : "Marlen Krause"
+        },
+        {
+          "rolle" : "Senior Santora",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Gomez",
+          "sprecher" : "Karl-Heinz Gerdesmann"
+        },
+        {
+          "rolle" : "Brotverkäufer",
+          "sprecher" : "Harald Pages"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/016/metadata.json",
@@ -1863,59 +1891,60 @@
           "end" : 2524840
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Hauptkommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Nelly Towne",
-          "Pamela Punti [Heikedine Körting]"
-        ],
-        [
-          "Billy Towne",
-          "Peer Siegel"
-        ],
-        [
-          "Ordner",
-          "Lothar Grützner"
-        ],
-        [
-          "Lopez",
-          "Hans Irle"
-        ],
-        [
-          "Dillon",
-          "Gottfried Kramer"
-        ],
-        [
-          "Roger Callow",
-          "Hans Daniel"
-        ],
-        [
-          "Kellnerin",
-          "Heidi Schaffrath"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Nelly Towne",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Billy Towne",
+          "sprecher" : "Peer Siegel"
+        },
+        {
+          "rolle" : "Ordner",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Lopez",
+          "sprecher" : "Hans Irle"
+        },
+        {
+          "rolle" : "Dillon",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Roger Callow",
+          "sprecher" : "Hans Daniel"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Heidi Schaffrath"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/017/metadata.json",
@@ -1973,67 +2002,68 @@
           "end" : 2606493
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sam",
-          "Joachim Wolff"
-        ],
-        [
-          "Chris Markos",
-          "Stephan Chrzeszinski"
-        ],
-        [
-          "Kommissar Nostigon",
-          "Volker Brandt"
-        ],
-        [
-          "Mr. Shaw",
-          "Joachim Richert"
-        ],
-        [
-          "Denton",
-          "Karl-Heinz Gerdesmann"
-        ],
-        [
-          "Farraday",
-          "Gottfried Kramer"
-        ],
-        [
-          "Jeff",
-          "Harald Pages"
-        ],
-        [
-          "Bill Ballinger",
-          "Günter Flesh"
-        ],
-        [
-          "Jim Ballinger",
-          "Heinz Werder"
-        ],
-        [
-          "Mr. Norris",
-          "Horst Schick"
-        ],
-        [
-          "Mrs. Barton",
-          "Marianne Kehlau"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sam",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Chris Markos",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Kommissar Nostigon",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Denton",
+          "sprecher" : "Karl-Heinz Gerdesmann"
+        },
+        {
+          "rolle" : "Farraday",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Jeff",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Bill Ballinger",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Jim Ballinger",
+          "sprecher" : "Hans Irle",
+          "pseudonym" : "Heinz Werder"
+        },
+        {
+          "rolle" : "Mr. Norris",
+          "sprecher" : "Horst Schick"
+        },
+        {
+          "rolle" : "Mrs. Barton",
+          "sprecher" : "Marianne Kehlau"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/018/metadata.json",
@@ -2092,59 +2122,59 @@
           "end" : 2676573
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dalton",
-          "Jürgen Thormann"
-        ],
-        [
-          "Mrs. Dalton",
-          "Helga Bammert"
-        ],
-        [
-          "Hardin",
-          "Christian Mey"
-        ],
-        [
-          "Prof. Walsh",
-          "Joachim Rake"
-        ],
-        [
-          "Ben Jackson",
-          "Günter Flesh"
-        ],
-        [
-          "Wreston",
-          "Ulrich Benthin"
-        ],
-        [
-          "Cardigo",
-          "Harald Pages"
-        ],
-        [
-          "Waldo Turner",
-          "Lothar Grützner"
-        ],
-        [
-          "Taucher",
-          "Joachim Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dalton",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Mrs. Dalton",
+          "sprecher" : "Helga Bammert"
+        },
+        {
+          "rolle" : "Hardin",
+          "sprecher" : "Christian Mey"
+        },
+        {
+          "rolle" : "Prof. Walsh",
+          "sprecher" : "Joachim Rake"
+        },
+        {
+          "rolle" : "Ben Jackson",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Wreston",
+          "sprecher" : "Ulrich Benthien"
+        },
+        {
+          "rolle" : "Cardigo",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Waldo Turner",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Taucher",
+          "sprecher" : "Joachim Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/019/metadata.json",
@@ -2203,63 +2233,63 @@
           "end" : 2816907
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Hauptkommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mihai Eftimin",
-          "Volker Brandt"
-        ],
-        [
-          "Dr. Radulescu",
-          "Günter Flesh"
-        ],
-        [
-          "Potter",
-          "Karl-Heinz Gerdesmann"
-        ],
-        [
-          "Mrs. Dobson",
-          "Marianne Kehlau"
-        ],
-        [
-          "Tom Dobson",
-          "Alexander Körting"
-        ],
-        [
-          "Farrier",
-          "Gottfried Kramer"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Polizist",
-          "Hans Irle"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mihai Eftimin",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Dr. Radulescu",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Potter",
+          "sprecher" : "Karl-Heinz Gerdesmann"
+        },
+        {
+          "rolle" : "Mrs. Dobson",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Tom Dobson",
+          "sprecher" : "Alexander Körting"
+        },
+        {
+          "rolle" : "Farrier",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Hans Irle"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/020/metadata.json",
@@ -2318,67 +2348,70 @@
           "end" : 2547813
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Dalton",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Christina Dalton",
-          "Karina Leising [Heikedine Körting]"
-        ],
-        [
-          "Frankie Bender",
-          "Oliver Mink"
-        ],
-        [
-          "H. P. Clay",
-          "Lothar Grützner"
-        ],
-        [
-          "Jim Clay",
-          "Marcus Meiering"
-        ],
-        [
-          "Walter Quail",
-          "Christian Mey"
-        ],
-        [
-          "Trödler Hummer",
-          "Joachim Richert"
-        ],
-        [
-          "Jason Wilkes",
-          "Joachim Rake"
-        ],
-        [
-          "Chiang",
-          "Tom Barrows [Hans Irle]"
-        ],
-        [
-          "Diakon Kastner",
-          "Hans Irle"
-        ],
-        [
-          "Butler",
-          "Hans Daniel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Dalton",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Christina Dalton",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Karina Leising"
+        },
+        {
+          "rolle" : "Frankie Bender",
+          "sprecher" : "Oliver Mink"
+        },
+        {
+          "rolle" : "H. P. Clay",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Jim Clay",
+          "sprecher" : "Dieter B. Gerlach",
+          "pseudonym" : "Markus Meiering"
+        },
+        {
+          "rolle" : "Walter Quail",
+          "sprecher" : "Christian Mey"
+        },
+        {
+          "rolle" : "Trödler Hummer",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Jason Wilkes",
+          "sprecher" : "Joachim Rake"
+        },
+        {
+          "rolle" : "Chiang",
+          "sprecher" : "Jürgen Thormann",
+          "pseudonym" : "Tom Barrows"
+        },
+        {
+          "rolle" : "Diakon Kastner",
+          "sprecher" : "Hans Irle"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Hans Daniel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/021/metadata.json",
@@ -2437,71 +2470,74 @@
           "end" : 2635960
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Rawley",
-          "Horst Stark"
-        ],
-        [
-          "Mr. Frank",
-          "Siegfried Wald"
-        ],
-        [
-          "Mr. Togati",
-          "Reiner Brönnecke"
-        ],
-        [
-          "Taro",
-          "Stefan Brönnecke"
-        ],
-        [
-          "Patrick",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Miss Agawam",
-          "Ursula Vogel"
-        ],
-        [
-          "Jordan",
-          "Hans Meinhardt [Franz Josef Steffens]"
-        ],
-        [
-          "Chuck",
-          "Roland Fabricius [Edgar Bessen?]"
-        ],
-        [
-          "Liliputaner",
-          "Erich Büttner [Joachim Wolff]"
-        ],
-        [
-          "Wachmann im Museum",
-          "Gottfried Kramer"
-        ],
-        [
-          "Hafenpolizist",
-          "Peter Kirchberger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Rawley",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Mr. Frank",
+          "sprecher" : "Siegfried Wald"
+        },
+        {
+          "rolle" : "Mr. Togati",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Taro",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Miss Agawam",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Jordan",
+          "sprecher" : "Franz-Josef Steffens",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Chuck",
+          "sprecher" : "Wolfgang Kaven",
+          "pseudonym" : "Roland Fabricius"
+        },
+        {
+          "rolle" : "Liliputaner",
+          "sprecher" : "Joachim Wolff",
+          "pseudonym" : "Erich Büttner"
+        },
+        {
+          "rolle" : "Wachmann im Museum",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Hafenpolizist",
+          "sprecher" : "Peter Kirchberger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/022/metadata.json",
@@ -2560,67 +2596,73 @@
           "end" : 2565680
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny",
-          "Andreas von der Meden"
-        ],
-        [
-          "Cody",
-          "Simon Schuchadt [Wolfgang Kaven]"
-        ],
-        [
-          "Diego Alvaro",
-          "Jan Odle"
-        ],
-        [
-          "Pico Alvaro",
-          "Mathias Lorenz"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Assistent",
-          "Claes Holmcrantz [Gernot Endemann]"
-        ],
-        [
-          "Sheriff",
-          "F.J. Steffens"
-        ],
-        [
-          "Tulsa",
-          "Klaus Klein [F.J. Steffens]"
-        ],
-        [
-          "Cap",
-          "Fritz Wegely [Siegfried Wald]"
-        ],
-        [
-          "Pike",
-          "Philip Mehringer [Joachim Wolff]"
-        ],
-        [
-          "Mr. Shaw",
-          "F.J. Steffens"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Cody",
+          "sprecher" : "Wolfgang Kaven",
+          "pseudonym" : "Simon Schuchardt"
+        },
+        {
+          "rolle" : "Diego Alvaro",
+          "sprecher" : "Jan Odle"
+        },
+        {
+          "rolle" : "Pico Alvaro",
+          "sprecher" : "Mathias Lorenz"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Assistent",
+          "sprecher" : "Gernot Endemann",
+          "pseudonym" : "Claes Holmcrantz"
+        },
+        {
+          "rolle" : "Sheriff",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Tulsa",
+          "sprecher" : "Siegfried Wald",
+          "pseudonym" : "Klaus Klein"
+        },
+        {
+          "rolle" : "Cap",
+          "sprecher" : "Joachim Wolff",
+          "pseudonym" : "Fritz Wegely"
+        },
+        {
+          "rolle" : "Pike",
+          "sprecher" : "Franz-Josef Steffens",
+          "pseudonym" : "Philip Mehringer"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Franz-Josef Steffens"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/023/metadata.json",
@@ -2679,71 +2721,73 @@
           "end" : 2537893
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Bengt",
-          "Charles Regnier"
-        ],
-        [
-          "Britta",
-          "Ingeborg Kanstein"
-        ],
-        [
-          "Lars Holmqvist",
-          "Gernot Endemann"
-        ],
-        [
-          "Young",
-          "Horst Stark"
-        ],
-        [
-          "Forsborg",
-          "Richard Heelel [F.J. Steffens]"
-        ],
-        [
-          "Mann",
-          "Siegfried Wald"
-        ],
-        [
-          "Frau",
-          "Brigitte Alexis"
-        ],
-        [
-          "Köhler",
-          "Hans Meinhardt [Reiner Brönneke]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Wärter",
-          "Joachim Wolff"
-        ],
-        [
-          "Kellner",
-          "Peter Kirchberger"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Bengt",
+          "sprecher" : "Charles Regnier"
+        },
+        {
+          "rolle" : "Britta",
+          "sprecher" : "Ingeburg Kanstein"
+        },
+        {
+          "rolle" : "Lars Holmqvist",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Young",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Forsborg",
+          "sprecher" : "Franz-Josef Steffens",
+          "pseudonym" : "Richard Heelel"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Siegfried Wald"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Brigitte Alexis"
+        },
+        {
+          "rolle" : "Köhler",
+          "sprecher" : "Reiner Brönneke",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Wärter",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Kellner",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/024/metadata.json",
@@ -2802,67 +2846,67 @@
           "end" : 2782427
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Allie Jamison",
-          "Katrin Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Asmodi",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Dr. Shaitan",
-          "Lutz Mackensy"
-        ],
-        [
-          "Noxworth",
-          "Christian Rode"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Prof. Barrister",
-          "F. J. Steffens"
-        ],
-        [
-          "Marie",
-          "Susanne Wulkow"
-        ],
-        [
-          "der \"Clochard\"",
-          "Karl-Heinz Gerdesmann"
-        ],
-        [
-          "Patricia Osborne",
-          "Barbara Focke"
-        ],
-        [
-          "Mann am Grundstück",
-          "Wolfgang Kaven"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Allie Jamison",
+          "sprecher" : "Katrin Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Asmodi",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Dr. Shaitan",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Noxworth",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Prof. Barrister",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Marie",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "der \"Clochard\"",
+          "sprecher" : "Karl-Heinz Gerdesmann"
+        },
+        {
+          "rolle" : "Patricia Osborne",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Mann am Grundstück",
+          "sprecher" : "Wolfgang Kaven"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/025/metadata.json",
@@ -2921,55 +2965,55 @@
           "end" : 2628080
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Allie Jamison",
-          "Katrin Fröhlich"
-        ],
-        [
-          "Harrison Osborne",
-          "F.J. Steffens"
-        ],
-        [
-          "Thurgood",
-          "Jürgen Thormann"
-        ],
-        [
-          "Sheriff",
-          "Gottfried Kramer"
-        ],
-        [
-          "Mrs. Macomber",
-          "Gisela Trowe"
-        ],
-        [
-          "Atkinson",
-          "Klaus Stieringer"
-        ],
-        [
-          "Manny",
-          "Lothar Grützner"
-        ],
-        [
-          "Gasper",
-          "Rolf Mamero"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Allie Jamison",
+          "sprecher" : "Katrin Fröhlich"
+        },
+        {
+          "rolle" : "Harrison Osborne",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Thurgood",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Sheriff",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Mrs. Macomber",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Atkinson",
+          "sprecher" : "Klaus Stieringer"
+        },
+        {
+          "rolle" : "Manny",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Gasper",
+          "sprecher" : "Rolf Mamero"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/026/metadata.json",
@@ -3028,59 +3072,60 @@
           "end" : 3108893
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Horace Tremayne",
-          "Karl-Ulrich Meves"
-        ],
-        [
-          "William Tremayne",
-          "Günther Flesh"
-        ],
-        [
-          "Marvin Gray",
-          "Horst Stark"
-        ],
-        [
-          "Madeline Bainbridge",
-          "Ursula Vogel"
-        ],
-        [
-          "Mr. Thomas",
-          "Lothar Grützner"
-        ],
-        [
-          "Jefferson",
-          "Christian Rode"
-        ],
-        [
-          "Clara Adams",
-          "Ingeborg Kanstein"
-        ],
-        [
-          "Grean",
-          "Manuel Hümpel [Rüdiger Schulzki]"
-        ],
-        [
-          "Schrottplatzwart",
-          "Siegfried Wald"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Horace Tremayne",
+          "sprecher" : "Karl-Ulrich Meves"
+        },
+        {
+          "rolle" : "William Tremayne",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Marvin Gray",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Madeline Bainbridge",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Mr. Thomas",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Jefferson",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Clara Adams",
+          "sprecher" : "Ingeburg Kanstein"
+        },
+        {
+          "rolle" : "Grean",
+          "sprecher" : "Rüdiger Schulzki",
+          "pseudonym" : "Manuel Hümpel"
+        },
+        {
+          "rolle" : "Schrottplatzwart",
+          "sprecher" : "Siegfried Wald"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/027/metadata.json",
@@ -3139,67 +3184,70 @@
           "end" : 2875787
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Reporter",
-          "Peter Kirchberger"
-        ],
-        [
-          "Fred, Extremist",
-          "Heinrich Baum [Karl-Walter Diess]"
-        ],
-        [
-          "Walt, Extremist",
-          "Friedhelm Hubertus [Siegfried Wald]"
-        ],
-        [
-          "Gordon Mackenzie",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Adam Ndula",
-          "Hans Meinhardt [Henry Kielmann]"
-        ],
-        [
-          "Jan Carew",
-          "Sascha Draeger"
-        ],
-        [
-          "Polizist im Suchtrupp",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Hauswirt",
-          "Hubert Mittendorf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Fred, Extremist",
+          "sprecher" : "Karl-Walter Diess",
+          "pseudonym" : "Heinrich Baum"
+        },
+        {
+          "rolle" : "Walt, Extremist",
+          "sprecher" : "Siegfried Wald",
+          "pseudonym" : "Friedhelm Hubertus"
+        },
+        {
+          "rolle" : "Gordon Mackenzie",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Adam Ndula",
+          "sprecher" : "Henry Kielmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Jan Carew",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Polizist im Suchtrupp",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Hauswirt",
+          "sprecher" : "Hubert Mittendorf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/028/metadata.json",
@@ -3342,63 +3390,64 @@
           "end" : 2522293
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Joachim Richert"
-        ],
-        [
-          "Crowe",
-          "Henry Kielmann"
-        ],
-        [
-          "Käptn Jason",
-          "Karl Walter Diess"
-        ],
-        [
-          "MacGruder",
-          "Siegfried Wald"
-        ],
-        [
-          "Hanley",
-          "Lothar Grützner"
-        ],
-        [
-          "Torao",
-          "Joko Talmann [Rüdiger Schulzki]"
-        ],
-        [
-          "Berg",
-          "Andreas Beurmann / Wolfgang Draeger"
-        ],
-        [
-          "Yamura",
-          "Hubert Mittendorf"
-        ],
-        [
-          "Die Gebrüder Connors",
-          "Nicolas Körting, Lothar Grützner"
-        ],
-        [
-          "Weston",
-          "Joachim Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Crowe",
+          "sprecher" : "Henry Kielmann"
+        },
+        {
+          "rolle" : "Käptn Jason",
+          "sprecher" : "Karl Walter Diess"
+        },
+        {
+          "rolle" : "MacGruder",
+          "sprecher" : "Siegfried Wald"
+        },
+        {
+          "rolle" : "Hanley",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Torao",
+          "sprecher" : "Rüdiger Schulzki",
+          "pseudonym" : "Joko Talmann"
+        },
+        {
+          "rolle" : "Berg",
+          "sprecher" : "Andreas E. Beurmann / Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Yamura",
+          "sprecher" : "Hubert Mittendorf"
+        },
+        {
+          "rolle" : "Die Gebrüder Connors",
+          "sprecher" : "Nicolas Körting, Lothar Grützner"
+        },
+        {
+          "rolle" : "Weston",
+          "sprecher" : "Joachim Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/030/metadata.json",
@@ -3457,67 +3506,69 @@
           "end" : 2984573
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Shelby Tuckerman",
-          "Pinkas Braun"
-        ],
-        [
-          "Mr. Hitfield",
-          "Christian Riege [Manfred Steffen]"
-        ],
-        [
-          "Mr. Bonestell",
-          "Joachim Richert"
-        ],
-        [
-          "Mrs. Denicola",
-          "Katharina Brauren"
-        ],
-        [
-          "Eileen",
-          "Ruth Niehaus"
-        ],
-        [
-          "Ernie",
-          "Helmut Zierl"
-        ],
-        [
-          "Polizist",
-          "Harald Pages"
-        ],
-        [
-          "Hoang Van Dong",
-          "Chen Lung Chung [Volker Brandt]"
-        ],
-        [
-          "Frau an der Bushaltestelle",
-          "Ursula Vogel"
-        ],
-        [
-          "Nachrichtensprecher",
-          "Joachim Wolff"
-        ],
-        [
-          "Patrick",
-          "Joachim Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Shelby Tuckerman",
+          "sprecher" : "Pinkas Braun"
+        },
+        {
+          "rolle" : "Mr. Hitfield",
+          "sprecher" : "Manfred Steffen",
+          "pseudonym" : "Christian Riege"
+        },
+        {
+          "rolle" : "Mr. Bonestell",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Mrs. Denicola",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Eileen",
+          "sprecher" : "Ruth Niehaus"
+        },
+        {
+          "rolle" : "Ernie",
+          "sprecher" : "Helmut Zierl"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Hoang Van Dong",
+          "sprecher" : "Volker Brandt",
+          "pseudonym" : "Chen Lung Chung"
+        },
+        {
+          "rolle" : "Frau an der Bushaltestelle",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "Joachim Wolff"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Joachim Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/031/metadata.json",
@@ -3576,63 +3627,65 @@
           "end" : 2652653
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dr. Woolley",
-          "Manfred Steffen"
-        ],
-        [
-          "Larry Conklin",
-          "Sylvester Merten [Helmut Zierl]"
-        ],
-        [
-          "Letitia Radford",
-          "Marianne Kehlau"
-        ],
-        [
-          "Mrs. Chumley",
-          "Renate Pichler"
-        ],
-        [
-          "Mrs. Burroughs",
-          "Katharina Brauren"
-        ],
-        [
-          "Mr. Burroughs",
-          "Martin Fichte [Joachim Wolff]"
-        ],
-        [
-          "Gary Malz",
-          "Volker Brandt"
-        ],
-        [
-          "Mr. Agnier",
-          "Willem Fricke"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Patrick",
-          "Joachim Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dr. Woolley",
+          "sprecher" : "Manfred Steffen"
+        },
+        {
+          "rolle" : "Larry Conklin",
+          "sprecher" : "Helmut Zierl",
+          "pseudonym" : "Sylvester Merten"
+        },
+        {
+          "rolle" : "Letitia Radford",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Mrs. Chumley",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Mrs. Burroughs",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Mr. Burroughs",
+          "sprecher" : "Joachim Wolff",
+          "pseudonym" : "Martin Fichte"
+        },
+        {
+          "rolle" : "Gary Malz",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Mr. Agnier",
+          "sprecher" : "Willem Fricke"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Joachim Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/032/metadata.json",
@@ -3691,63 +3744,64 @@
           "end" : 2657067
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Patrick",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Peter Kirchberger"
-        ],
-        [
-          "Mr. Barron",
-          "Pinkas Braun"
-        ],
-        [
-          "Mrs. Barron",
-          "Monika Peitsch"
-        ],
-        [
-          "Hank Detweiler",
-          "Siegfried Wald"
-        ],
-        [
-          "Elsie Spratt",
-          "Pia Werfel [Barbara Focke]"
-        ],
-        [
-          "Leutnant Ferrante",
-          "Volkert Kraeft"
-        ],
-        [
-          "Bones",
-          "Siegfried Meyerheim [Helmut Zierl]"
-        ],
-        [
-          "vermeintlicher US-Präsident",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Mr. Barron",
+          "sprecher" : "Pinkas Braun"
+        },
+        {
+          "rolle" : "Mrs. Barron",
+          "sprecher" : "Monika Peitsch"
+        },
+        {
+          "rolle" : "Hank Detweiler",
+          "sprecher" : "Siegfried Wald"
+        },
+        {
+          "rolle" : "Elsie Spratt",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Leutnant Ferrante",
+          "sprecher" : "Volkert Kraeft"
+        },
+        {
+          "rolle" : "Bones",
+          "sprecher" : "Helmut Zierl",
+          "pseudonym" : "Siegfried Meyerheim"
+        },
+        {
+          "rolle" : "vermeintlicher US-Präsident",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/033/metadata.json",
@@ -3806,47 +3860,47 @@
           "end" : 2640213
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Shaw",
-          "Horst Schick"
-        ],
-        [
-          "Kapitän Joy",
-          "Helmut Ahner"
-        ],
-        [
-          "Jeremy Joy",
-          "Philip Siegel"
-        ],
-        [
-          "Joshua Evans",
-          "Douglas Welbat"
-        ],
-        [
-          "Major Karnes",
-          "Manfred Schermutzki"
-        ],
-        [
-          "Sam Davis",
-          "Utz Richter"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Horst Schick"
+        },
+        {
+          "rolle" : "Kapitän Joy",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Jeremy Joy",
+          "sprecher" : "Philip Siegel"
+        },
+        {
+          "rolle" : "Joshua Evans",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Major Karnes",
+          "sprecher" : "Manfred Schermutzki"
+        },
+        {
+          "rolle" : "Sam Davis",
+          "sprecher" : "Utz Richter"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/034/metadata.json",
@@ -3905,75 +3959,76 @@
           "end" : 3255933
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Eleonor",
-          "Susanne Wulkow"
-        ],
-        [
-          "Birkensteen",
-          "Oskar Kluge [Günter König]"
-        ],
-        [
-          "Terreano",
-          "Günter König"
-        ],
-        [
-          "Brandon",
-          "Douglas Welbat"
-        ],
-        [
-          "Hoffer",
-          "Eckart Dux"
-        ],
-        [
-          "McGee",
-          "Utz Richter"
-        ],
-        [
-          "Thalia",
-          "Ingeborg Kanstein"
-        ],
-        [
-          "Stefano",
-          "Andreas von der Meden"
-        ],
-        [
-          "John",
-          "Edgar Bessen"
-        ],
-        [
-          "Tankwart",
-          "F.-J. Steffens"
-        ],
-        [
-          "LKW-Fahrer",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mann am Bahnhof",
-          "Christian Rode"
-        ],
-        [
-          "Bürgermeister",
-          "Edgar Bessen"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Eleonor",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Birkensteen",
+          "sprecher" : "Günter König",
+          "pseudonym" : "Oskar Kluge"
+        },
+        {
+          "rolle" : "Terreano",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Brandon",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Hoffer",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "McGee",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Thalia",
+          "sprecher" : "Ingeburg Kanstein"
+        },
+        {
+          "rolle" : "Stefano",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "John",
+          "sprecher" : "Edgar Bessen"
+        },
+        {
+          "rolle" : "Tankwart",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "LKW-Fahrer",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mann am Bahnhof",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Bürgermeister",
+          "sprecher" : "Edgar Bessen"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/035/metadata.json",
@@ -4032,47 +4087,47 @@
           "end" : 2896187
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Constance",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Slater",
-          "Helmut Ahner"
-        ],
-        [
-          "Donner",
-          "Jürgen Thormann"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Horst Frank"
-        ],
-        [
-          "Fischer",
-          "F.-J. Steffens"
-        ],
-        [
-          "Ocean-World-Mitarbeiter",
-          "Peter Lakenmacher, Christian Rode"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Constance",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Slater",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Donner",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Horst Frank"
+        },
+        {
+          "rolle" : "Fischer",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Ocean-World-Mitarbeiter",
+          "sprecher" : "Peter Lakenmacher, Christian Rode"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/036/metadata.json",
@@ -4131,55 +4186,55 @@
           "end" : 3293027
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Regina",
-          "Ursela Monn"
-        ],
-        [
-          "Teddy",
-          "Simon Jäger"
-        ],
-        [
-          "Mrs. Peabody",
-          "Gisela Trowe"
-        ],
-        [
-          "Burton",
-          "Günther Pfitzmann"
-        ],
-        [
-          "Kommissar",
-          "Günther Flesh"
-        ],
-        [
-          "Mooch",
-          "Joachim Richert"
-        ],
-        [
-          "Mr. Conine",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Fergus",
-          "Günter Dockerill"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Regina",
+          "sprecher" : "Ursela Monn"
+        },
+        {
+          "rolle" : "Teddy",
+          "sprecher" : "Simon Jäger"
+        },
+        {
+          "rolle" : "Mrs. Peabody",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Burton",
+          "sprecher" : "Günter Pfitzmann"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Mooch",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Mr. Conine",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Fergus",
+          "sprecher" : "Günther Dockerill"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/037/metadata.json",
@@ -4238,47 +4293,47 @@
           "end" : 2552053
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Shaw",
-          "Marianne Kehlau"
-        ],
-        [
-          "Mr. Peck",
-          "Wolfgang Völz"
-        ],
-        [
-          "Ed Snabel",
-          "Horst Naumann"
-        ],
-        [
-          "Bartlett",
-          "Jochen Sehrndt"
-        ],
-        [
-          "FBI-Agent Anderson",
-          "Lutz Mackensy"
-        ],
-        [
-          "Passantin",
-          "Ingrid Andree"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Mr. Peck",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Ed Snabel",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Bartlett",
+          "sprecher" : "Jochen Sehrndt"
+        },
+        {
+          "rolle" : "FBI-Agent Anderson",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Passantin",
+          "sprecher" : "Ingrid Andree"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/038/metadata.json",
@@ -4337,35 +4392,35 @@
           "end" : 2873960
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Blinky",
-          "Günter König"
-        ],
-        [
-          "Miss Melody",
-          "Gisela Trowe"
-        ],
-        [
-          "Frisbee",
-          "Hans Paetsch"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Blinky",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Miss Melody",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Frisbee",
+          "sprecher" : "Hans Paetsch"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/039/metadata.json",
@@ -4424,75 +4479,75 @@
           "end" : 2821360
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Jacobs",
-          "Horst Naumann"
-        ],
-        [
-          "Paul Jacobs",
-          "Sascha Draeger"
-        ],
-        [
-          "Onkel Titus",
-          "Gottfried Kramer"
-        ],
-        [
-          "Tante Mathilda",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Mr. Temple",
-          "Jochen Sehrndt"
-        ],
-        [
-          "Sarah Temple",
-          "Svenja Pages"
-        ],
-        [
-          "Willard Temple",
-          "Ben Becker"
-        ],
-        [
-          "Polizeileutnant",
-          "Günter König"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Hauptkomm. Reynolds",
-          "Günter Flesch"
-        ],
-        [
-          "Margon",
-          "Henry Kielmann"
-        ],
-        [
-          "William Margon",
-          "Michael Grimm"
-        ],
-        [
-          "Passanten",
-          "Lothar Grützner, Hans Hessling"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Jacobs",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Paul Jacobs",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Gottfried Kramer"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Mr. Temple",
+          "sprecher" : "Jochen Sehrndt"
+        },
+        {
+          "rolle" : "Sarah Temple",
+          "sprecher" : "Svenja Pages"
+        },
+        {
+          "rolle" : "Willard Temple",
+          "sprecher" : "Ben Becker"
+        },
+        {
+          "rolle" : "Polizeileutnant",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Margon",
+          "sprecher" : "Henry Kielmann"
+        },
+        {
+          "rolle" : "William Margon",
+          "sprecher" : "Michael Grimm"
+        },
+        {
+          "rolle" : "Passanten",
+          "sprecher" : "Lothar Grützner, Hans Hessling"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/040/metadata.json",
@@ -4551,55 +4606,55 @@
           "end" : 3214520
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brewster",
-          "Horst Naumann"
-        ],
-        [
-          "Clifford",
-          "Douglas Welbat"
-        ],
-        [
-          "Marie",
-          "Svenja Pages"
-        ],
-        [
-          "Zindler",
-          "Karl Walter Diess"
-        ],
-        [
-          "Pamir",
-          "Manfred Steffen"
-        ],
-        [
-          "Martin",
-          "Frank-Dieter Tausch"
-        ],
-        [
-          "Botin",
-          "Beate Hasenau"
-        ],
-        [
-          "Kellner",
-          "Helmut Ahner"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brewster",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Clifford",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Marie",
+          "sprecher" : "Svenja Pages"
+        },
+        {
+          "rolle" : "Zindler",
+          "sprecher" : "Karl Walter Diess"
+        },
+        {
+          "rolle" : "Pamir",
+          "sprecher" : "Manfred Steffen"
+        },
+        {
+          "rolle" : "Martin",
+          "sprecher" : "Frank-Dieter Tausch"
+        },
+        {
+          "rolle" : "Botin",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Kellner",
+          "sprecher" : "Helmut Ahner"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/041/metadata.json",
@@ -4658,71 +4713,71 @@
           "end" : 2869227
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Michael Cross",
-          "Matthias Klimser"
-        ],
-        [
-          "Mrs. Cross",
-          "Marianne Kehlau"
-        ],
-        [
-          "Mr. Cross",
-          "Horst Naumann"
-        ],
-        [
-          "Grady Markels",
-          "Gerd Baltus"
-        ],
-        [
-          "Brackmann",
-          "F. J. Steffens"
-        ],
-        [
-          "Margie",
-          "Monika Gabriel"
-        ],
-        [
-          "Nachrichtensprecher",
-          "Diess Günter Flesh"
-        ],
-        [
-          "Sawyer",
-          "Jürgen Thormann"
-        ],
-        [
-          "Museumsbesucherin",
-          "Beate Hasenau"
-        ],
-        [
-          "Gärtner",
-          "Günter Dockerill"
-        ],
-        [
-          "Mr. Rossing",
-          "Eric Vaessen"
-        ],
-        [
-          "Rossings Assistentin",
-          "Claudia Schermutzki"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Michael Cross",
+          "sprecher" : "Matthias Klimsa"
+        },
+        {
+          "rolle" : "Mrs. Cross",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Mr. Cross",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Grady Markels",
+          "sprecher" : "Gerd Baltus"
+        },
+        {
+          "rolle" : "Brackmann",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Margie",
+          "sprecher" : "Monika Gabriel"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "Günther Flesch"
+        },
+        {
+          "rolle" : "Sawyer",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Museumsbesucherin",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Gärtner",
+          "sprecher" : "Günther Dockerill"
+        },
+        {
+          "rolle" : "Mr. Rossing",
+          "sprecher" : "Eric Vaessen"
+        },
+        {
+          "rolle" : "Rossings Assistentin",
+          "sprecher" : "Claudia Schermutzki"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/042/metadata.json",
@@ -4781,79 +4836,79 @@
           "end" : 3050920
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Lucille",
-          "Petra Kaminski"
-        ],
-        [
-          "Charles",
-          "Henry Kielmann"
-        ],
-        [
-          "McLain",
-          "Rolf Jülich"
-        ],
-        [
-          "Verleiher",
-          "Hartmut Kollakowsky"
-        ],
-        [
-          "Kellnerin",
-          "Beate Hasenau"
-        ],
-        [
-          "Sears",
-          "Manfred Liptow"
-        ],
-        [
-          "Evans",
-          "Bernd Fallske"
-        ],
-        [
-          "Pelzhändler",
-          "Eric Vaessen"
-        ],
-        [
-          "Kom. Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Lucilles Mutter",
-          "Astrid Kollex"
-        ],
-        [
-          "Sekretärin",
-          "Eva Gelb"
-        ],
-        [
-          "Mädchen",
-          "Veronika Neugebauer"
-        ],
-        [
-          "Junge 1",
-          "Manou Lubowski"
-        ],
-        [
-          "Junge 2",
-          "Niki Nowotny"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Lucille",
+          "sprecher" : "Petra Kaminski"
+        },
+        {
+          "rolle" : "Charles",
+          "sprecher" : "Henry Kielmann"
+        },
+        {
+          "rolle" : "McLain",
+          "sprecher" : "Rolf Jülich"
+        },
+        {
+          "rolle" : "Verleiher",
+          "sprecher" : "Hartmut Kollakowsky"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Sears",
+          "sprecher" : "Manfred Liptow"
+        },
+        {
+          "rolle" : "Evans",
+          "sprecher" : "Bernd Fallske"
+        },
+        {
+          "rolle" : "Pelzhändler",
+          "sprecher" : "Eric Vaessen"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Lucilles Mutter",
+          "sprecher" : "Astrid Kollex"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Eva Gelb"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Veronika Neugebauer"
+        },
+        {
+          "rolle" : "Junge 1",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Junge 2",
+          "sprecher" : "Niki Nowotny"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/043/metadata.json",
@@ -4912,55 +4967,56 @@
           "end" : 3012147
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Milton",
-          "Horst Naumann"
-        ],
-        [
-          "Bonehead",
-          "Sascha Draeger"
-        ],
-        [
-          "Peggy",
-          "Veronika Neugebauer"
-        ],
-        [
-          "Footsie",
-          "Niki Nowotny"
-        ],
-        [
-          "Bloodhound",
-          "Manou Lubowski"
-        ],
-        [
-          "Lomax",
-          "Peter Pantel [Wolf Rahtjen]"
-        ],
-        [
-          "Tante Mathilda",
-          "Dorothea Kaiser"
-        ],
-        [
-          "Gordon Harker",
-          "Stefan Brönneke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Milton",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Bonehead",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Peggy",
+          "sprecher" : "Veronika Neugebauer"
+        },
+        {
+          "rolle" : "Footsie",
+          "sprecher" : "Niki Nowotny"
+        },
+        {
+          "rolle" : "Bloodhound",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Lomax",
+          "sprecher" : "Wolf Rahtjen",
+          "pseudonym" : "Peter Pantel"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Dorothea Kaiser"
+        },
+        {
+          "rolle" : "Gordon Harker",
+          "sprecher" : "Stefan Brönneke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/044/metadata.json",
@@ -5019,59 +5075,62 @@
           "end" : 2827347
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ingmar Ragnarson",
-          "Rolf E. Schenker"
-        ],
-        [
-          "Karl Ragnarson",
-          "Utz Richter"
-        ],
-        [
-          "Sam Ragnarson",
-          "Marco Kröger"
-        ],
-        [
-          "Mr. Manning",
-          "Achim Schülke"
-        ],
-        [
-          "Mrs. Manning",
-          "Julia Mahnkopf"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mrs. Andrews",
-          "Renate Pichler"
-        ],
-        [
-          "Mr. Andrews",
-          "Manfred Bendixen"
-        ],
-        [
-          "Mathilda",
-          "Ursula Vogel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ingmar Ragnarson",
+          "sprecher" : "Rolf E. Schenker"
+        },
+        {
+          "rolle" : "Karl Ragnarson",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Sam Ragnarson",
+          "sprecher" : "Lutz Harder",
+          "pseudonym" : "Marco Kröger"
+        },
+        {
+          "rolle" : "Mr. Manning",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Mrs. Manning",
+          "sprecher" : "Micaëla Kreißler",
+          "pseudonym" : "Julia Mahnkopf"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Anne Schermutzki"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König",
+          "pseudonym" : "Manfred Bendixen"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Ursula Vogel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/045/metadata.json",
@@ -5130,63 +5189,63 @@
           "end" : 2853253
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Harry Burnside",
-          "Thomas Naumann"
-        ],
-        [
-          "Millionär Pilcher",
-          "Michael von Raspatt"
-        ],
-        [
-          "Marilyn Pilcher",
-          "Gabi Libbach"
-        ],
-        [
-          "Sekretär Sanchez",
-          "Walter Eltz"
-        ],
-        [
-          "Harald Durham",
-          "Ernst A. Frantz"
-        ],
-        [
-          "Frau Durham",
-          "Micaela Kreißler"
-        ],
-        [
-          "Jim Westerbrook",
-          "Michael Quiatkowski"
-        ],
-        [
-          "Mrs. Westerbrook",
-          "Gerlinde Dillge"
-        ],
-        [
-          "Dr. Gonzaga",
-          "Michael Liptow"
-        ],
-        [
-          "Ramon Navarro",
-          "Norbert Lange"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Harry Burnside",
+          "sprecher" : "Thomas Naumann"
+        },
+        {
+          "rolle" : "Millionär Pilcher",
+          "sprecher" : "Michael von Rospatt"
+        },
+        {
+          "rolle" : "Marilyn Pilcher",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Sekretär Sanchez",
+          "sprecher" : "Walter Eltz"
+        },
+        {
+          "rolle" : "Harald Durham",
+          "sprecher" : "Ernst A. Frantz"
+        },
+        {
+          "rolle" : "Frau Durham",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Jim Westerbrook",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "Mrs. Westerbrook",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Dr. Gonzaga",
+          "sprecher" : "Manfred Liptow"
+        },
+        {
+          "rolle" : "Ramon Navarro",
+          "sprecher" : "Norbert Lange"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/046/metadata.json",
@@ -5245,55 +5304,55 @@
           "end" : 2842373
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Kelly",
-          "Kerstin Draeger"
-        ],
-        [
-          "Julia Crown",
-          "Tessa Gasser"
-        ],
-        [
-          "Big Barney Crown",
-          "Wolfgang Völz"
-        ],
-        [
-          "Schwester Lazar",
-          "Hildegard Krekel"
-        ],
-        [
-          "Don Dellasandro",
-          "Jürgen Thormann"
-        ],
-        [
-          "Pandro Mischkin",
-          "Michael Hark"
-        ],
-        [
-          "Kranführer Dick",
-          "Ernst von Klippstein"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Julia Crown",
+          "sprecher" : "Tessa Gasser"
+        },
+        {
+          "rolle" : "Big Barney Crown",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Schwester Lazar",
+          "sprecher" : "Hildegard Krekel"
+        },
+        {
+          "rolle" : "Don Dellasandro",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Pandro Mischkin",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Kranführer Dick",
+          "sprecher" : "Ernst von Klipstein"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/047/metadata.json",
@@ -5352,55 +5411,55 @@
           "end" : 2878867
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Herr Andrews",
-          "Günter König"
-        ],
-        [
-          "Daniel",
-          "Gosta Liptow"
-        ],
-        [
-          "Mary",
-          "Anja Ziemer"
-        ],
-        [
-          "Häuptling Turner",
-          "Norbert Lange"
-        ],
-        [
-          "Schamane",
-          "Douglas Welbat"
-        ],
-        [
-          "Unternehmer Mancarrow",
-          "Holger Mahlich"
-        ],
-        [
-          "Ganove Biff",
-          "Lutz Harder"
-        ],
-        [
-          "Ganove George",
-          "Manfred Liptow"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Daniel",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Anja Ziemer"
+        },
+        {
+          "rolle" : "Häuptling Turner",
+          "sprecher" : "Norbert Lange"
+        },
+        {
+          "rolle" : "Schamane",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Unternehmer Mancarrow",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Ganove Biff",
+          "sprecher" : "Lutz Harder"
+        },
+        {
+          "rolle" : "Ganove George",
+          "sprecher" : "Manfred Liptow"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/048/metadata.json",
@@ -5459,51 +5518,52 @@
           "end" : 2670120
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Axel Griswold",
-          "Helgo Liebig"
-        ],
-        [
-          "Purvis",
-          "Heiner Kramm"
-        ],
-        [
-          "Dan DeMento",
-          "Peter Heinrich"
-        ],
-        [
-          "Leo Rottweiler",
-          "Rainer Brönneke"
-        ],
-        [
-          "Steve Trash",
-          "Thomas Naumann"
-        ],
-        [
-          "Rainey Fields",
-          "Xenia Hey"
-        ],
-        [
-          "Junge",
-          "Leonhard Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Axel Griswold",
+          "sprecher" : "Helgo Liebig"
+        },
+        {
+          "rolle" : "Purvis",
+          "sprecher" : "Michael Quiatkowsky",
+          "pseudonym" : "Heiner Kramm"
+        },
+        {
+          "rolle" : "Dan DeMento",
+          "sprecher" : "Peter Heinrich"
+        },
+        {
+          "rolle" : "Leo Rottweiler",
+          "sprecher" : "Reiner Brönneke"
+        },
+        {
+          "rolle" : "Steve Trash",
+          "sprecher" : "Michael Griem"
+        },
+        {
+          "rolle" : "Rainey Fields",
+          "sprecher" : "Xenia Hey"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Leonhard Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/049/metadata.json",
@@ -5563,51 +5623,51 @@
           "end" : 3435173
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jon Travis",
-          "Rolf Becker"
-        ],
-        [
-          "Marty Morningbaum",
-          "Helmut Ahner"
-        ],
-        [
-          "Diller Rourke",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "Marble Ackbourne-Smith",
-          "Wolf Rathjen"
-        ],
-        [
-          "Margo",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Kevin",
-          "Fred Maire"
-        ],
-        [
-          "Herr Andrews",
-          "Günter König"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jon Travis",
+          "sprecher" : "Rolf Becker"
+        },
+        {
+          "rolle" : "Marty Morningbaum",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Diller Rourke",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "Marble Ackbourne-Smith",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Margo",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Kevin",
+          "sprecher" : "Fred Maire"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/050/metadata.json",
@@ -5667,39 +5727,39 @@
           "end" : 3270107
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mercedes",
-          "Marianne Kehlau"
-        ],
-        [
-          "Brit",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Dusty Rice",
-          "Achim Schülke"
-        ],
-        [
-          "Ascension",
-          "Eckart Dux"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mercedes",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Brit",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Dusty Rice",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Ascension",
+          "sprecher" : "Eckart Dux"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/051/metadata.json",
@@ -5759,71 +5819,71 @@
           "end" : 3267773
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brick",
-          "Rainer Schmitt"
-        ],
-        [
-          "Thanom",
-          "Peter Heinrich"
-        ],
-        [
-          "Prem",
-          "Lutz Mackensy"
-        ],
-        [
-          "Butler",
-          "Gerd Baltus"
-        ],
-        [
-          "Sax",
-          "Andreas Mannkopff"
-        ],
-        [
-          "Celeste",
-          "Michaela Gröger"
-        ],
-        [
-          "Lara",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Rivers",
-          "Wolfgang Völz"
-        ],
-        [
-          "Hansen",
-          "Verena Wiet"
-        ],
-        [
-          "Maxi",
-          "Hildegard Krekel"
-        ],
-        [
-          "Quill",
-          "Matthias Bullach"
-        ],
-        [
-          "Tony",
-          "Michael Quiatkowsky"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brick",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Thanom",
+          "sprecher" : "Peter Heinrich"
+        },
+        {
+          "rolle" : "Prem",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Gerd Baltus"
+        },
+        {
+          "rolle" : "Sax Sandler",
+          "sprecher" : "Andreas Mannkopff"
+        },
+        {
+          "rolle" : "Celeste",
+          "sprecher" : "Michaela Gröger"
+        },
+        {
+          "rolle" : "Lara",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Rivers",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Hansen",
+          "sprecher" : "Verena Wiet"
+        },
+        {
+          "rolle" : "Maxi",
+          "sprecher" : "Hildegard Krekel"
+        },
+        {
+          "rolle" : "Quill",
+          "sprecher" : "Matthias Bullach"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Michael Quiatkowsky"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/052/metadata.json",
@@ -5883,59 +5943,59 @@
           "end" : 3203173
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Ty Cassey",
-          "Stefan Brönneke"
-        ],
-        [
-          "Inspektor Cole",
-          "Wolfgang Schimmelpfennig [Günter König]"
-        ],
-        [
-          "Kommissar Maxim",
-          "Peter Matic"
-        ],
-        [
-          "Gilbar",
-          "Rolf Becker"
-        ],
-        [
-          "Torres",
-          "Douglas Welbat"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Jake Hatch",
-          "Hans Barein"
-        ],
-        [
-          "Tiburon",
-          "Michael Quiatkowsky"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Ty Cassey",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Inspektor Cole",
+          "sprecher" : "Wolfgang Schimmelpfennig"
+        },
+        {
+          "rolle" : "Kommissar Maxim",
+          "sprecher" : "Peter Matić"
+        },
+        {
+          "rolle" : "Gilbar",
+          "sprecher" : "Rolf Becker"
+        },
+        {
+          "rolle" : "Torres",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Jake Hatch",
+          "sprecher" : "Hans Barein"
+        },
+        {
+          "rolle" : "Tiburon",
+          "sprecher" : "Michael Quiatkowsky"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/053/metadata.json",
@@ -5995,59 +6055,60 @@
           "end" : 3048040
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Buzz Newman",
-          "Manou Lubowski"
-        ],
-        [
-          "George Brandon",
-          "Fabian Harloff"
-        ],
-        [
-          "Jim Bernardie",
-          "Holger Mahlich"
-        ],
-        [
-          "Firestone",
-          "Peter Schiff"
-        ],
-        [
-          "Crocker",
-          "Lothar Grützner"
-        ],
-        [
-          "Lovell Madeira",
-          "Rainer Schmitt"
-        ],
-        [
-          "Vic Hammell",
-          "Ben Tappé"
-        ],
-        [
-          "Dan",
-          "Henry König"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Buzz Newman",
+          "sprecher" : "Manou Lubowski",
+          "pseudonym" : "Christian Weber"
+        },
+        {
+          "rolle" : "George Brandon",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Jim Bernardie",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Firestone",
+          "sprecher" : "Peter Schiff"
+        },
+        {
+          "rolle" : "Crocker",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Lovell Madeira",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Vic Hammell",
+          "sprecher" : "Ben Tappé"
+        },
+        {
+          "rolle" : "Dan",
+          "sprecher" : "Henry König"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/054/metadata.json",
@@ -6107,63 +6168,63 @@
           "end" : 3056533
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Trainer Tong",
-          "Michael Hark"
-        ],
-        [
-          "Trainer Duggan",
-          "Douglas Welbat"
-        ],
-        [
-          "Präsident Harper",
-          "Eric Vaessen"
-        ],
-        [
-          "Jerri",
-          "Samira Chanfir"
-        ],
-        [
-          "Nora",
-          "Ann Montenbruck"
-        ],
-        [
-          "Cory",
-          "Ben Tappé"
-        ],
-        [
-          "Norman",
-          "Henry König"
-        ],
-        [
-          "Powers",
-          "Hans Clarin"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Trainer Tong",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Trainer Duggan",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Präsident Harper",
+          "sprecher" : "Eric Vaessen"
+        },
+        {
+          "rolle" : "Jerri",
+          "sprecher" : "Samira Chanfir"
+        },
+        {
+          "rolle" : "Nora",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Cory",
+          "sprecher" : "Ben Tappé"
+        },
+        {
+          "rolle" : "Norman",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Powers",
+          "sprecher" : "Hans Clarin"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/055/metadata.json",
@@ -6223,63 +6284,63 @@
           "end" : 2967587
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Liz",
-          "Verena Großer"
-        ],
-        [
-          "Harold",
-          "Willi Röbke"
-        ],
-        [
-          "Dose",
-          "Jan-Friedrich Conrad"
-        ],
-        [
-          "Silas Ek",
-          "Hans Sievers"
-        ],
-        [
-          "Sekretär",
-          "Eckart Dux"
-        ],
-        [
-          "Jan",
-          "Stefan Brönneke"
-        ],
-        [
-          "Lys",
-          "Anika Pages"
-        ],
-        [
-          "Branson Barr",
-          "Michael Harck"
-        ],
-        [
-          "Norton Rome",
-          "Douglas Welbat"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Liz",
+          "sprecher" : "Verena Großer"
+        },
+        {
+          "rolle" : "Harold",
+          "sprecher" : "Willi Röbke"
+        },
+        {
+          "rolle" : "Dose",
+          "sprecher" : "Jan-Friedrich Conrad"
+        },
+        {
+          "rolle" : "Silas Ek",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Sekretär",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Jan",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Annika Pages"
+        },
+        {
+          "rolle" : "Branson Barr",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Norton Rome",
+          "sprecher" : "Douglas Welbat"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/056/metadata.json",
@@ -6339,55 +6400,55 @@
           "end" : 2605187
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mary, Artistin",
-          "Heidrun von Goessel"
-        ],
-        [
-          "Winkler, Zirkusdirektor",
-          "Helmut Ahner"
-        ],
-        [
-          "Pipo, Clown",
-          "Arthur Brauss"
-        ],
-        [
-          "Morton, Chauffeur",
-          "Andreas von der Meden"
-        ],
-        [
-          "Cotta, Polizeiinspektor",
-          "Michael Poelchau"
-        ],
-        [
-          "Alma",
-          "Eva Zlomitzky"
-        ],
-        [
-          "Schwester",
-          "Gerda Maria Jürgens"
-        ],
-        [
-          "[Shirley Kubinski]",
-          "Thea Frank"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mary, Artistin",
+          "sprecher" : "Heidrun von Goessel"
+        },
+        {
+          "rolle" : "Winkler, Zirkusdirektor",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Pipo, Clown",
+          "sprecher" : "Arthur Brauss"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Michael Poelchau"
+        },
+        {
+          "rolle" : "Alma",
+          "sprecher" : "Eva Zlonitzky"
+        },
+        {
+          "rolle" : "Schwester",
+          "sprecher" : "Gerda-Maria Jürgens"
+        },
+        {
+          "rolle" : "Shirley Kubinski",
+          "sprecher" : "Thea Frank"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/057/metadata.json",
@@ -6447,59 +6508,60 @@
           "end" : 2711893
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "William Ashley",
-          "Franz Rudnick"
-        ],
-        [
-          "Burt Ashley",
-          "Knut Basewitz"
-        ],
-        [
-          "Pecker, Angestellter",
-          "Lutz Büschken"
-        ],
-        [
-          "Axel",
-          "Tobias Pauls"
-        ],
-        [
-          "Lys",
-          "Kerstin Draeger"
-        ],
-        [
-          "Mrs. Bloomingdale",
-          "Eva Zlomitzky"
-        ],
-        [
-          "Stella",
-          "Rebecca Völz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "William Ashley",
+          "sprecher" : "Franz Rudnick"
+        },
+        {
+          "rolle" : "Burt Ashley",
+          "sprecher" : "Knut Basewitz"
+        },
+        {
+          "rolle" : "Pecker, Angestellter",
+          "sprecher" : "Lutz Büschken"
+        },
+        {
+          "rolle" : "Axel",
+          "sprecher" : "Tobias Pauls"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Mrs. Bloomingdale",
+          "sprecher" : "Eva Zlonitzky"
+        },
+        {
+          "rolle" : "Stella",
+          "sprecher" : "Rebecca Völz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/058/metadata.json",
@@ -6559,59 +6621,59 @@
           "end" : 2667307
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ruth, Zeitungs-Journalistin",
-          "Hansi Jochmann"
-        ],
-        [
-          "Jean Baxter, TV-Journalistin",
-          "Heidrun von Goessel"
-        ],
-        [
-          "Van Well, Pressechef",
-          "Ulrich Faulhaber"
-        ],
-        [
-          "Sinagua, Indianerin",
-          "Samira Chanfir"
-        ],
-        [
-          "Chosmo, Journalist",
-          "Mathias Bullach"
-        ],
-        [
-          "Monsieur Jaubert",
-          "Michael Poelchau"
-        ],
-        [
-          "René Hancock",
-          "Thomas Schüler"
-        ],
-        [
-          "Joan Brown",
-          "Rebecca Völz"
-        ],
-        [
-          "Hendrik Walton, Fabrikant",
-          "Karl Michael Mechel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ruth, Zeitungs-Journalistin",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Jean Baxter, TV-Journalistin",
+          "sprecher" : "Heidrun von Goessel"
+        },
+        {
+          "rolle" : "Van Well, Pressechef",
+          "sprecher" : "Ulrich Faulhaber"
+        },
+        {
+          "rolle" : "Sinagua, Indianerin",
+          "sprecher" : "Samira Chanfir"
+        },
+        {
+          "rolle" : "Chosmo, Journalist",
+          "sprecher" : "Matthias Bullach"
+        },
+        {
+          "rolle" : "Monsieur Jaubert",
+          "sprecher" : "Michael Poelchau"
+        },
+        {
+          "rolle" : "René Hancock",
+          "sprecher" : "Thomas Schüler"
+        },
+        {
+          "rolle" : "Joan Brown",
+          "sprecher" : "Rebecca Völz"
+        },
+        {
+          "rolle" : "Hendrik Walton, Fabrikant",
+          "sprecher" : "Michael Mechel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/059/metadata.json",
@@ -6671,63 +6733,64 @@
           "end" : 2826880
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Glenn Miles",
-          "Christian Stark"
-        ],
-        [
-          "Benny",
-          "Tobias Pauls"
-        ],
-        [
-          "Tom Descanso, Trainer",
-          "Prof. Justus Frantz"
-        ],
-        [
-          "Field, Lehrer",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "Hutchins, Sport-Reporter",
-          "Uwe Büschken"
-        ],
-        [
-          "Dr. Landman, Schuldirektor",
-          "Gerd Duwner"
-        ],
-        [
-          "Stan",
-          "Tilman Madaus"
-        ],
-        [
-          "Eleonore Sharp",
-          "Margot Linde"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Glenn Miles",
+          "sprecher" : "Christian Stark"
+        },
+        {
+          "rolle" : "Benny",
+          "sprecher" : "Tobias Pauls"
+        },
+        {
+          "rolle" : "Tom Descanso, Trainer",
+          "sprecher" : "Prof. Justus Frantz"
+        },
+        {
+          "rolle" : "Field, Lehrer",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "Hutchins, Sport-Reporter",
+          "sprecher" : "Uwe Büschken"
+        },
+        {
+          "rolle" : "Dr. Landman, Schuldirektor",
+          "sprecher" : "Gerd Duwner"
+        },
+        {
+          "rolle" : "Stan",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Eleonore Sharp",
+          "sprecher" : "Eva Maria Bauer",
+          "pseudonym" : "Margot Linde"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/060/metadata.json",
@@ -6787,63 +6850,63 @@
           "end" : 3569320
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Milton Mitchell",
-          "Holger Mahlich"
-        ],
-        [
-          "Fred Hall",
-          "Thomas Thomé"
-        ],
-        [
-          "Anne",
-          "Janina Richter"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Kellner",
-          "Thomas Stein"
-        ],
-        [
-          "Portland",
-          "Wolfgang Völz"
-        ],
-        [
-          "Inspektor Cotta",
-          "Willem Fricke"
-        ],
-        [
-          "Charlie",
-          "Anne Marr"
-        ],
-        [
-          "Kundin",
-          "Ursula Sieg"
-        ],
-        [
-          "Adams",
-          "Hans Hessling"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Milton Mitchell",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Fred Hall",
+          "sprecher" : "Thomas Thomé"
+        },
+        {
+          "rolle" : "Anne",
+          "sprecher" : "Janina Richter"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Kellner",
+          "sprecher" : "Thomas M. Stein"
+        },
+        {
+          "rolle" : "Portland",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Willem Fricke"
+        },
+        {
+          "rolle" : "Charlie",
+          "sprecher" : "Anne Marr"
+        },
+        {
+          "rolle" : "Kundin",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Adams",
+          "sprecher" : "Hans Hessling"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/061/metadata.json",
@@ -6903,63 +6966,63 @@
           "end" : 3563227
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Amanda Black",
-          "Beate Hasenau"
-        ],
-        [
-          "Mrs. Silverstone",
-          "Barbara Ratthay"
-        ],
-        [
-          "Mr. Garfield",
-          "Holger Mahlich [Utz Richter]"
-        ],
-        [
-          "Mr. Hartford",
-          "Hans Hessling"
-        ],
-        [
-          "Mrs. Hartford",
-          "Ursula Sieg"
-        ],
-        [
-          "Mrs. Green",
-          "Monika Werner"
-        ],
-        [
-          "Henry",
-          "Lutz Schnell"
-        ],
-        [
-          "Lys",
-          "Kerstin Draeger"
-        ],
-        [
-          "Linda",
-          "Janina Richter"
-        ],
-        [
-          "Inspektor Cotta",
-          "Willem Fricke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Amanda Black",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Mrs. Silverstone",
+          "sprecher" : "Barbara Ratthey"
+        },
+        {
+          "rolle" : "Mr. Garfield",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Mr. Hartford",
+          "sprecher" : "Hans Hessling"
+        },
+        {
+          "rolle" : "Mrs. Hartford",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Mrs. Green",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Henry",
+          "sprecher" : "Lutz Schnell"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Linda",
+          "sprecher" : "Janina Richter"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Willem Fricke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/062/metadata.json",
@@ -7019,63 +7082,64 @@
           "end" : 4014467
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Jimboy-Jonas",
-          "Frank Meyer-Brockmann"
-        ],
-        [
-          "Mr. Bow",
-          "Klaus Sonnenschein"
-        ],
-        [
-          "Eric Randolph",
-          "Achim Schülke"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Elizabeth",
-          "Verena Großer"
-        ],
-        [
-          "Lys",
-          "Kerstin Draeger"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Tamara Mostowsky",
-          "Astrid Kollex"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Jimboy-Jonas",
+          "sprecher" : "Frank Meyer-Brockmann"
+        },
+        {
+          "rolle" : "Mr. Bow",
+          "sprecher" : "Klaus Sonnenschein"
+        },
+        {
+          "rolle" : "Eric Randolph",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Elizabeth",
+          "sprecher" : "Verena Großer"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Tamara Mostowsky",
+          "sprecher" : "Astrid Kollex"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/063/metadata.json",
@@ -7135,63 +7199,64 @@
           "end" : 3969547
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Peter Pasetti"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Morton, Chauffeur",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Capistrano",
-          "Hans Sievers"
-        ],
-        [
-          "Sergeant Hawthrone",
-          "Jürgen Kopp"
-        ],
-        [
-          "Simon Oames",
-          "Peter Kirchberger"
-        ],
-        [
-          "Silvie Oames",
-          "Edith Hancke"
-        ],
-        [
-          "Michael Julius Oames",
-          "Günther Jerschke"
-        ],
-        [
-          "Mandy Taylor",
-          "Micaela Kreißler"
-        ],
-        [
-          "Deborah Street",
-          "Astrid Kollex"
-        ],
-        [
-          "Greenwater",
-          "Norman Messer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Peter Pasetti"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Capistrano",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Sergeant Hawthrone",
+          "sprecher" : "Jürgen Kopp"
+        },
+        {
+          "rolle" : "Simon Oames",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Silvie Oames",
+          "sprecher" : "Edith Hancke"
+        },
+        {
+          "rolle" : "Michael Julius Oames",
+          "sprecher" : "Günther Jerschke"
+        },
+        {
+          "rolle" : "Mandy Taylor",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Deborah Street",
+          "sprecher" : "Astrid Kollex"
+        },
+        {
+          "rolle" : "Greenwater",
+          "sprecher" : "André Minninger",
+          "pseudonym" : "Norman Messer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/064/metadata.json",
@@ -7251,71 +7316,71 @@
           "end" : 3579173
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Alex Burlington",
-          "Klaus Sonnenschein"
-        ],
-        [
-          "Richard Applebloome",
-          "Tilman Madaus"
-        ],
-        [
-          "Robert Applebloome",
-          "Franz Rudnick"
-        ],
-        [
-          "Mary",
-          "Edith Hancke"
-        ],
-        [
-          "Elizabeth",
-          "Marianne Kehlau"
-        ],
-        [
-          "John Smith",
-          "Dirk Anton"
-        ],
-        [
-          "Jenkins",
-          "Douglas Welbat"
-        ],
-        [
-          "Thomas",
-          "Stephan Chreszinsky"
-        ],
-        [
-          "Andrew",
-          "Michael Rospat"
-        ],
-        [
-          "Mrs. Rodriguez",
-          "Katja Brügger"
-        ],
-        [
-          "Hoteldirektor",
-          "Hans Sievers"
-        ],
-        [
-          "Blondine",
-          "Veronika Neugebauer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Alex Burlington",
+          "sprecher" : "Klaus Sonnenschein"
+        },
+        {
+          "rolle" : "Richard Applebloome",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Robert Applebloome",
+          "sprecher" : "Franz Rudnick"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Edith Hancke"
+        },
+        {
+          "rolle" : "Elizabeth",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "John Smith",
+          "sprecher" : "Dirk Anton"
+        },
+        {
+          "rolle" : "Jenkins",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Thomas",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Andrew",
+          "sprecher" : "Michael von Rospatt"
+        },
+        {
+          "rolle" : "Mrs. Rodriguez",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Hoteldirektor",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Blondine",
+          "sprecher" : "Veronika Neugebauer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/065/metadata.json",
@@ -7375,55 +7440,55 @@
           "end" : 3555013
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Alberto Bergamelli, Fotograf",
-          "Holger Mahlich"
-        ],
-        [
-          "Alexandra",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Ignazio, Pensionswirt",
-          "Leonardo Cuseneza"
-        ],
-        [
-          "Sofia, Pensionswirtin",
-          "Maria Chirivi"
-        ],
-        [
-          "Franca",
-          "Samira Chanfir"
-        ],
-        [
-          "Italienerin",
-          "Francesca Chiavon"
-        ],
-        [
-          "1. Italiener",
-          "Marcello Grassi"
-        ],
-        [
-          "2. Italiener",
-          "Luigi Pane"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Alberto Bergamelli, Fotograf",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Alexandra",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Ignazio, Pensionswirt",
+          "sprecher" : "Leonardo Cusenza"
+        },
+        {
+          "rolle" : "Sofia, Pensionswirtin",
+          "sprecher" : "Maria Chirivi"
+        },
+        {
+          "rolle" : "Franca",
+          "sprecher" : "Samira Chanfir"
+        },
+        {
+          "rolle" : "Italienerin",
+          "sprecher" : "Francesca Chiavon"
+        },
+        {
+          "rolle" : "Italiener 1",
+          "sprecher" : "Marcello Grassi"
+        },
+        {
+          "rolle" : "Italiener 2",
+          "sprecher" : "Luigi Pane"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/066/metadata.json",
@@ -7483,59 +7548,59 @@
           "end" : 3799320
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Babette Eberle",
-          "M. Rospat"
-        ],
-        [
-          "Bruder Benedikt",
-          "Tassilo Jelde"
-        ],
-        [
-          "Mylná",
-          "Utz Richter"
-        ],
-        [
-          "Alexandra",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Wirt",
-          "Hans Paetsch"
-        ],
-        [
-          "Wirtin",
-          "Ingeborg Ottmann"
-        ],
-        [
-          "Max",
-          "Lutz Schnell"
-        ],
-        [
-          "1. Polizist",
-          "Boris Sychowsky"
-        ],
-        [
-          "2. Polizist",
-          "Frank Meyer-Brockmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Babette Eberle",
+          "sprecher" : "Michael von Rospatt"
+        },
+        {
+          "rolle" : "Bruder Benedikt",
+          "sprecher" : "Tassilo Jelde"
+        },
+        {
+          "rolle" : "Mylná",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Alexandra",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Wirt",
+          "sprecher" : "Hans Paetsch"
+        },
+        {
+          "rolle" : "Wirtin",
+          "sprecher" : "Ingeborg Ottmann"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Lutz Schnell"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Boris von Sychowski"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Frank Meyer-Brockmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/067/metadata.json",
@@ -7595,39 +7660,39 @@
           "end" : 3581227
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jerzy",
-          "Michael Bideller"
-        ],
-        [
-          "Mariana",
-          "Antje Roosch"
-        ],
-        [
-          "1. Mann",
-          "Nico König"
-        ],
-        [
-          "2. Mann",
-          "Lutz Schnell"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jerzy",
+          "sprecher" : "Michael Bideller"
+        },
+        {
+          "rolle" : "Mariana",
+          "sprecher" : "Antje Roosch"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Lutz Schnell"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/068/metadata.json",
@@ -7687,71 +7752,72 @@
           "end" : 3942387
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Erna Fiedler",
-          "Ursula Gompf"
-        ],
-        [
-          "Dr. Ferguson",
-          "Antje Cornelius"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "John Brady",
-          "Dirk Anton"
-        ],
-        [
-          "Matt Brady",
-          "Volker Bogdan"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Mr. Shaw",
-          "Eberhard Haar"
-        ],
-        [
-          "Mrs. Shaw",
-          "Heikedine Körting"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Erna Fiedler",
+          "sprecher" : "Ursula Gompf"
+        },
+        {
+          "rolle" : "Dr. Ferguson",
+          "sprecher" : "Antje Cornelius"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "John Brady",
+          "sprecher" : "Dirk Anton"
+        },
+        {
+          "rolle" : "Matt Brady",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/069/metadata.json",
@@ -7811,63 +7877,63 @@
           "end" : 3784293
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Alan",
-          "Oliver Reinhardt"
-        ],
-        [
-          "Sally Samson",
-          "Cornelia Meinhardt"
-        ],
-        [
-          "Sofie Samson",
-          "Samira Chanfir"
-        ],
-        [
-          "Dr. Harris",
-          "Hansi Jochmann"
-        ],
-        [
-          "John Davis",
-          "Tim Wieck"
-        ],
-        [
-          "Homer Washington",
-          "Hans Sievers"
-        ],
-        [
-          "Fahrer",
-          "Klaus-Peter Kaehler"
-        ],
-        [
-          "Brenda",
-          "Micaela Kreißler"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Junge",
-          "Jona Mues"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Alan",
+          "sprecher" : "Oliver Reinhard"
+        },
+        {
+          "rolle" : "Sally Samson",
+          "sprecher" : "Cornelia Meinhardt"
+        },
+        {
+          "rolle" : "Sofie Samson",
+          "sprecher" : "Samira Chanfir"
+        },
+        {
+          "rolle" : "Dr. Harris",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "John Davis",
+          "sprecher" : "Tim Wieck"
+        },
+        {
+          "rolle" : "Homer Washington",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Fahrer",
+          "sprecher" : "Klaus-Peter Kaehler"
+        },
+        {
+          "rolle" : "Brenda",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Jona Mues"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/070/metadata.json",
@@ -7927,75 +7993,76 @@
           "end" : 3994440
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Lu Kwan",
-          "Susanne von Loessel"
-        ],
-        [
-          "Jefferson",
-          "Christian Redl"
-        ],
-        [
-          "Dimitrios, Bankdirektor",
-          "Wilhelm Wieben"
-        ],
-        [
-          "Dan Jordan, Reporter",
-          "Michael Lott"
-        ],
-        [
-          "Olivia",
-          "Eva Weißmann"
-        ],
-        [
-          "Santoria",
-          "Holger Ohlendieck"
-        ],
-        [
-          "Pertier",
-          "Johann Herstermann"
-        ],
-        [
-          "Sergeant",
-          "Ingvar Jensen"
-        ],
-        [
-          "Irma",
-          "Konstanze Ulmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Lu Kwan",
+          "sprecher" : "Susanne von Loessl"
+        },
+        {
+          "rolle" : "Jefferson",
+          "sprecher" : "Christian Redl"
+        },
+        {
+          "rolle" : "Dimitrios, Bankdirektor",
+          "sprecher" : "Wilhelm Wieben"
+        },
+        {
+          "rolle" : "Dan Jordan, Reporter",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Olivia",
+          "sprecher" : "Eva Weissmann"
+        },
+        {
+          "rolle" : "Santoria",
+          "sprecher" : "Dieter Ohlendiek"
+        },
+        {
+          "rolle" : "Pertier",
+          "sprecher" : "Johann Herstermann"
+        },
+        {
+          "rolle" : "Sergeant",
+          "sprecher" : "Ingvar Jensen"
+        },
+        {
+          "rolle" : "Irma",
+          "sprecher" : "Konstanze Ullmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/071/metadata.json",
@@ -8055,71 +8122,71 @@
           "end" : 3477893
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Laura McLaughin",
-          "Marianne Kehlau"
-        ],
-        [
-          "Malcolm King",
-          "Jörg Gillner"
-        ],
-        [
-          "Lansana King",
-          "Sabine Hahn"
-        ],
-        [
-          "Hester Dalton",
-          "Marianne Bernhardt"
-        ],
-        [
-          "Billie",
-          "Stefan Conradi"
-        ],
-        [
-          "Polizist",
-          "Oliver Reinhardt"
-        ],
-        [
-          "Wachmann",
-          "Dieter Ohlendieck"
-        ],
-        [
-          "2. Wächter",
-          "Michael Lott"
-        ],
-        [
-          "1. Polizist",
-          "Torben Liebrecht"
-        ],
-        [
-          "2. Polizist",
-          "Rene Spiegelberger"
-        ],
-        [
-          "Kellnerin",
-          "Doris Jahn"
-        ],
-        [
-          "Kundin",
-          "Susann Jarling"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Laura McLaughin",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Malcolm King",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Lansana King",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Hester Dalton",
+          "sprecher" : "Marianne Bernhardt"
+        },
+        {
+          "rolle" : "Billie",
+          "sprecher" : "Stefan Conradi"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Oliver Reinhard"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Dieter Ohlendiek"
+        },
+        {
+          "rolle" : "Wächter 2",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Torben Liebrecht"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Rene Spiegelberger"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Doris Jahn"
+        },
+        {
+          "rolle" : "Kundin",
+          "sprecher" : "Susan Jarling"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/072/metadata.json",
@@ -8179,55 +8246,55 @@
           "end" : 3997320
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Madigan",
-          "Anne Marks-Rocke"
-        ],
-        [
-          "Eathon Easton, ihr Untermieter",
-          "Helmo Liebig"
-        ],
-        [
-          "Mrs. Lydia Cartier",
-          "Gerda Gmelin"
-        ],
-        [
-          "Sigourney, ihr Dienstmädchen",
-          "Susanne Beck"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Inspektor Kershaw",
-          "Frank Felicetti"
-        ],
-        [
-          "Hugenay",
-          "Hans Irle"
-        ],
-        [
-          "Museumswärterin",
-          "Marianne Kehlau"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Madigan",
+          "sprecher" : "Annemarie Marks-Rocke"
+        },
+        {
+          "rolle" : "Eathon Easton, ihr Untermieter",
+          "sprecher" : "Helgo Liebig"
+        },
+        {
+          "rolle" : "Mrs. Lydia Cartier",
+          "sprecher" : "Gerda Gmelin"
+        },
+        {
+          "rolle" : "Sigourney, ihr Dienstmädchen",
+          "sprecher" : "Susanne Beck"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Inspektor Kershaw",
+          "sprecher" : "Frank Felicetti"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Hans Irle"
+        },
+        {
+          "rolle" : "Museumswärterin",
+          "sprecher" : "Marianne Kehlau"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/073/metadata.json",
@@ -8287,71 +8354,72 @@
           "end" : 4442107
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Whitehead",
-          "Uwe Friedrichsen"
-        ],
-        [
-          "Steven Robinshaw, Anwalt",
-          "Helmo Liebig"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mary",
-          "Victoria Voncampe"
-        ],
-        [
-          "Stan",
-          "Georg Tryphon"
-        ],
-        [
-          "Jeffrey",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "John",
-          "Andreas Martens"
-        ],
-        [
-          "Dr. Wright",
-          "Dietmar Mues"
-        ],
-        [
-          "Carrie Hanson",
-          "Helga Osten-Sacken"
-        ],
-        [
-          "Tim Conrad",
-          "Moritz Gentsch"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Whitehead",
+          "sprecher" : "Uwe Friedrichsen"
+        },
+        {
+          "rolle" : "Steven Robinshaw, Anwalt",
+          "sprecher" : "Helgo Liebig"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Victoria Voncampe"
+        },
+        {
+          "rolle" : "Stan",
+          "sprecher" : "Georg Tryphon"
+        },
+        {
+          "rolle" : "Jeffrey",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "John",
+          "sprecher" : "Andreas Martens"
+        },
+        {
+          "rolle" : "Dr. Wright",
+          "sprecher" : "Dietmar Mues"
+        },
+        {
+          "rolle" : "Carrie Hanson",
+          "sprecher" : "Hella von der Osten-Sacken"
+        },
+        {
+          "rolle" : "Tim Conrad",
+          "sprecher" : "Moritz Gentsch"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/074/metadata.json",
@@ -8411,51 +8479,51 @@
           "end" : 3339600
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Shaw",
-          "Heikedine Körting"
-        ],
-        [
-          "Amanda Black",
-          "Beate Hasenau"
-        ],
-        [
-          "Detective Gregston",
-          "Wolf-Dietrich Berg"
-        ],
-        [
-          "Nora Sethons",
-          "Ursula Sieg"
-        ],
-        [
-          "Mrs. Aston",
-          "J.S."
-        ],
-        [
-          "Mr. Krieger",
-          "Jörg Gillner"
-        ],
-        [
-          "Lisa Manninger",
-          "Katja Stichel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Amanda Black",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Detective Gregston",
+          "sprecher" : "Wolf-Dietrich Berg"
+        },
+        {
+          "rolle" : "Nora Sethons",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Mrs. Aston",
+          "sprecher" : "Joyceline Schmidt"
+        },
+        {
+          "rolle" : "Mr. Krieger",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Lisa Manninger",
+          "sprecher" : "Katja Stichel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/075/metadata.json",
@@ -8515,59 +8583,59 @@
           "end" : 4184827
         }
       ],
-      "sprecher" : [
-        [
-          "Hitchcock, Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Abigail Holligan",
-          "Katharina Brauren"
-        ],
-        [
-          "Metzla Holligan",
-          "Beate Hasenau"
-        ],
-        [
-          "Dr. Franklin",
-          "Judy Winter"
-        ],
-        [
-          "Dr. Miller",
-          "Marianne Kehlau"
-        ],
-        [
-          "Mrs. Petersen",
-          "Victoria Voncampe"
-        ],
-        [
-          "Sekretariat",
-          "\"Fettes Brot\""
-        ],
-        [
-          "Mr. Brian",
-          "Peter Schubert"
-        ],
-        [
-          "Mrs. Dream",
-          "Petra Ehlers"
-        ],
-        [
-          "Jack Cliffwater",
-          "Thomas Schüler"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Hitchcock, Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Abigail Holligan",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Metzla Holligan",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Clarissa Franklin",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Dr. Miller",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Mrs. Petersen",
+          "sprecher" : "Victoria Voncampe"
+        },
+        {
+          "rolle" : "Sekretariat",
+          "sprecher" : "\"Fettes Brot\""
+        },
+        {
+          "rolle" : "Mr. Brian",
+          "sprecher" : "Peter Schubert"
+        },
+        {
+          "rolle" : "Mrs. Dream",
+          "sprecher" : "Petra Ehlers"
+        },
+        {
+          "rolle" : "Jack Cliffwater",
+          "sprecher" : "Thomas Schüler"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/076/metadata.json",
@@ -8617,67 +8685,68 @@
           "end" : 3559333
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Karen Sulzenberger",
-          "Kristina von Welzin"
-        ],
-        [
-          "Nicola",
-          "Maria Fuchs"
-        ],
-        [
-          "McMannoman",
-          "Wolfgang Noack"
-        ],
-        [
-          "Tony",
-          "Martin Lohmann"
-        ],
-        [
-          "Mrs. Seven",
-          "Eva Gelb"
-        ],
-        [
-          "Trainer",
-          "Hans Sievers"
-        ],
-        [
-          "Roger",
-          "H. P. Kaehler"
-        ],
-        [
-          "1. Mann",
-          "Helmut Ahner"
-        ],
-        [
-          "2. Mann",
-          "Richard Ems"
-        ],
-        [
-          "Kellnerin",
-          "Micaela Kreißler"
-        ],
-        [
-          "Uli",
-          "Norman Messer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Karen Sulzenberger",
+          "sprecher" : "Kristina von Weltzien"
+        },
+        {
+          "rolle" : "Nicola",
+          "sprecher" : "Maria Fuchs"
+        },
+        {
+          "rolle" : "McMannoman",
+          "sprecher" : "Wolfgang Noack"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Martin Lohmann"
+        },
+        {
+          "rolle" : "Mrs. Seven",
+          "sprecher" : "Eva Gelb"
+        },
+        {
+          "rolle" : "Trainer",
+          "sprecher" : "Hans Sievers"
+        },
+        {
+          "rolle" : "Roger",
+          "sprecher" : "Klaus-Peter Kaehler"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Richard Ems"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Uli",
+          "sprecher" : "André Minninger",
+          "pseudonym" : "Norman Messer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/077/metadata.json",
@@ -8727,63 +8796,64 @@
           "end" : 3448987
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Albert Hitfield",
-          "Manfred Steffen"
-        ],
-        [
-          "Morton, Chauffeur",
-          "Andreas von der Meden"
-        ],
-        [
-          "Lys",
-          "Kerstin Draeger"
-        ],
-        [
-          "J.J.",
-          "Gregor Reisch"
-        ],
-        [
-          "Julius Jonas",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Catherine Jonas",
-          "Anne Moll"
-        ],
-        [
-          "Arturo",
-          "Carlos Goiach"
-        ],
-        [
-          "Autovermieter",
-          "Richard Ems"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Albert Hitfield",
+          "sprecher" : "Manfred Steffen"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Lys",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "J.J.",
+          "sprecher" : "Gregor Reisch"
+        },
+        {
+          "rolle" : "Julius Jonas",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Catherine Jonas",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Arturo",
+          "sprecher" : "Carlos Goiach"
+        },
+        {
+          "rolle" : "Autovermieter",
+          "sprecher" : "Richard Ems"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/078/metadata.json",
@@ -8843,67 +8913,70 @@
           "end" : 4612307
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Al Parker, Musikproduzent",
-          "Lennardt Krüger"
-        ],
-        [
-          "William Needle",
-          "Nico König"
-        ],
-        [
-          "Stevens",
-          "Lothar Behrendt"
-        ],
-        [
-          "Bart",
-          "Doktor Renz"
-        ],
-        [
-          "Luke",
-          "Schiffmeister"
-        ],
-        [
-          "Frank",
-          "König Boris"
-        ],
-        [
-          "Joan, Visagistin",
-          "Alida Gundlach"
-        ],
-        [
-          "Jeffrey",
-          "Niko Minninger"
-        ],
-        [
-          "Hank",
-          "Harvey Draeger"
-        ],
-        [
-          "Billy",
-          "Sven Stricker"
-        ],
-        [
-          "Angestellter",
-          "Jens Herrndorff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Al Parker, Musikproduzent",
+          "sprecher" : "Lennardt Krüger"
+        },
+        {
+          "rolle" : "William Needle",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Stevens",
+          "sprecher" : "Lothar Behrendt"
+        },
+        {
+          "rolle" : "Bart",
+          "sprecher" : "Martin Vandreier",
+          "pseudonym" : "Dokter Renz"
+        },
+        {
+          "rolle" : "Luke",
+          "sprecher" : "Björn Warns",
+          "pseudonym" : "Schiffmeister"
+        },
+        {
+          "rolle" : "Frank",
+          "sprecher" : "Boris Lauterbach",
+          "pseudonym" : "König Boris"
+        },
+        {
+          "rolle" : "Joan, Visagistin",
+          "sprecher" : "Alida Gundlach"
+        },
+        {
+          "rolle" : "Jeffrey",
+          "sprecher" : "Niko Minninger"
+        },
+        {
+          "rolle" : "Hank",
+          "sprecher" : "Harvey Draeger"
+        },
+        {
+          "rolle" : "Billy",
+          "sprecher" : "Sven Stricker"
+        },
+        {
+          "rolle" : "Angestellter",
+          "sprecher" : "Jens Herrndorff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/079/metadata.json",
@@ -8953,35 +9026,36 @@
           "end" : 3560667
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Cosma",
-          "Elke Reissert"
-        ],
-        [
-          "Vladimir Contreras",
-          "Gerhart Hinze"
-        ],
-        [
-          "Roger Carpenter",
-          "Igmar Frentzen"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Cosma",
+          "sprecher" : "Elke Reissert"
+        },
+        {
+          "rolle" : "Vladimir Contreras",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Roger Carpenter",
+          "sprecher" : "Gustav-Adolph Artz",
+          "pseudonym" : "Igmar Frenzen"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/080/metadata.json",
@@ -9031,59 +9105,59 @@
           "end" : 2983827
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kelly Madigan",
-          "Juliane Szalay"
-        ],
-        [
-          "DaElba",
-          "Ozanan Rocha"
-        ],
-        [
-          "Alberto",
-          "Antonio Luz"
-        ],
-        [
-          "Mr. Toll",
-          "Balduin Baas"
-        ],
-        [
-          "Franke",
-          "Wolfgang Noack"
-        ],
-        [
-          "Mr. Andrews",
-          "Günter König"
-        ],
-        [
-          "Mr. Burt",
-          "Gerd Baltus"
-        ],
-        [
-          "Boris",
-          "Carlos Goiach"
-        ],
-        [
-          "Papagei",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kelly Madigan",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "DaElba",
+          "sprecher" : "Ozanan Rocha"
+        },
+        {
+          "rolle" : "Alberto",
+          "sprecher" : "Antonio Luz"
+        },
+        {
+          "rolle" : "Mr. Toll",
+          "sprecher" : "Balduin Baas"
+        },
+        {
+          "rolle" : "Franke",
+          "sprecher" : "Wolfgang Noack"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Günter König"
+        },
+        {
+          "rolle" : "Mr. Burt",
+          "sprecher" : "Gerd Baltus"
+        },
+        {
+          "rolle" : "Boris",
+          "sprecher" : "Carlos Goiach"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/081/metadata.json",
@@ -9133,43 +9207,43 @@
           "end" : 4199867
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Milva Summer, Astrologin",
-          "Elizabeth Volkmann"
-        ],
-        [
-          "Professor Steed, Tiermediziner",
-          "Henning Schlüter"
-        ],
-        [
-          "Daniel Art, Bodyguard",
-          "Monty Arnold"
-        ],
-        [
-          "Mike Hanson, Reporter",
-          "Corny Littmann"
-        ],
-        [
-          "Nachrichtensprecher",
-          "Werner Pohlenz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Milva Summer, Astrologin",
+          "sprecher" : "Elisabeth Volkmann"
+        },
+        {
+          "rolle" : "Professor Steed, Tiermediziner",
+          "sprecher" : "Henning Schlüter"
+        },
+        {
+          "rolle" : "Daniel Art, Bodyguard",
+          "sprecher" : "Monty Arnold"
+        },
+        {
+          "rolle" : "Mike Hanson, Reporter",
+          "sprecher" : "Corny Littmann"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "Werner Pohlenz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/082/metadata.json",
@@ -9219,51 +9293,51 @@
           "end" : 3558427
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Käptn Jason",
-          "F.J. Steffens"
-        ],
-        [
-          "Professor Clark",
-          "Erich Krieg"
-        ],
-        [
-          "Carol Ford, Fernsehjournalistin",
-          "Claudia Schermutzki"
-        ],
-        [
-          "Dr. Helprin, Wissenschaftler",
-          "Rudolf Herget"
-        ],
-        [
-          "Mr. Evans",
-          "Peter Groß"
-        ],
-        [
-          "Enrique Serra",
-          "Jörg Gillner"
-        ],
-        [
-          "Mr. Andrews",
-          "Roland Becker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Käptn Jason",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Professor Clark",
+          "sprecher" : "Erich Krieg"
+        },
+        {
+          "rolle" : "Carol Ford, Fernsehjournalistin",
+          "sprecher" : "Claudia Schermutzki"
+        },
+        {
+          "rolle" : "Dr. Helprin, Wissenschaftler",
+          "sprecher" : "Rudolf H. Herget"
+        },
+        {
+          "rolle" : "Mr. Evans",
+          "sprecher" : "Peter Groß"
+        },
+        {
+          "rolle" : "Enrique Serra",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Roland Becker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/083/metadata.json",
@@ -9313,43 +9387,43 @@
           "end" : 3603107
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jelena",
-          "Alexandra Doerk"
-        ],
-        [
-          "Mr. Charkov, Jelenas Vater",
-          "Klaus Dittmann"
-        ],
-        [
-          "Vanderhell, Teufelsgeiger",
-          "Lutz Mackensy"
-        ],
-        [
-          "Mr. Andrews",
-          "Roland Becker"
-        ],
-        [
-          "Mrs. Andrews",
-          "Carola Lange"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Mr. Charkov",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Vanderhell, Teufelsgeiger",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Roland Becker"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Carola Lange"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/084/metadata.json",
@@ -9399,51 +9473,51 @@
           "end" : 3562000
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Walker",
-          "Lothar Grützner"
-        ],
-        [
-          "Monica",
-          "Hansi Jochmann"
-        ],
-        [
-          "Lady MacWeiden",
-          "Renate Pichler"
-        ],
-        [
-          "Mac George",
-          "Johann Schibli"
-        ],
-        [
-          "Chris",
-          "Daniel Kruth"
-        ],
-        [
-          "Campingwart",
-          "Helmut Ahner"
-        ],
-        [
-          "Frau des Campingwarts",
-          "Ingrid Weiß"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Walker",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Monica",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Lady MacWeiden",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Mac George",
+          "sprecher" : "Johann Schibli"
+        },
+        {
+          "rolle" : "Chris",
+          "sprecher" : "Daniel Kruth"
+        },
+        {
+          "rolle" : "Campingwart",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Frau des Campingwarts",
+          "sprecher" : "Ingrid Weiß"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/085/metadata.json",
@@ -9493,51 +9567,51 @@
           "end" : 3457213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mr. Peacock, Museumsdirektor",
-          "Helmut Ahner"
-        ],
-        [
-          "Alpha",
-          "Achim Schülke"
-        ],
-        [
-          "Beth",
-          "Katja Brügger"
-        ],
-        [
-          "Ernie",
-          "Wolfgang Hartmann"
-        ],
-        [
-          "Dog",
-          "Niko Minninger"
-        ],
-        [
-          "Ceewee",
-          "Michael Quiatkowski"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mr. Peacock, Museumsdirektor",
+          "sprecher" : "Helmut Ahner"
+        },
+        {
+          "rolle" : "Alpha",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Beth",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Ernie",
+          "sprecher" : "Wolfgang Hartmann"
+        },
+        {
+          "rolle" : "Dog",
+          "sprecher" : "Niko Minninger"
+        },
+        {
+          "rolle" : "Ceewee",
+          "sprecher" : "Michael Quiatkowsky"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/086/metadata.json",
@@ -9587,59 +9661,59 @@
           "end" : 3294627
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Harding, Polizeipsychologin",
-          "Katrin Wasow"
-        ],
-        [
-          "Mr. Ambler, Assistent",
-          "Rainer Schmitt"
-        ],
-        [
-          "Rodder, das Wolfsgesicht",
-          "Andreas Martens"
-        ],
-        [
-          "Mr. Laurent, Ladenbesitzer",
-          "Lutz Lukasz"
-        ],
-        [
-          "Mr. Stepelton, Ladenbesitzer",
-          "Harald Pages"
-        ],
-        [
-          "Ray, Praktikant",
-          "Marcel Rinkenauer"
-        ],
-        [
-          "Sandy, Verkäuferin",
-          "Kathi Robens"
-        ],
-        [
-          "Kundin",
-          "Cornelia Meinhardt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Harding, Polizeipsychologin",
+          "sprecher" : "Katrin Wasow"
+        },
+        {
+          "rolle" : "Mr. Ambler, Assistent",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Rodder, das Wolfsgesicht",
+          "sprecher" : "Andreas Martens"
+        },
+        {
+          "rolle" : "Mr. Laurent, Ladenbesitzer",
+          "sprecher" : "Lutz Lukasz"
+        },
+        {
+          "rolle" : "Mr. Stepelton, Ladenbesitzer",
+          "sprecher" : "Harald Pages"
+        },
+        {
+          "rolle" : "Ray, Praktikant",
+          "sprecher" : "Marcel Rinkenauer"
+        },
+        {
+          "rolle" : "Sandy, Verkäuferin",
+          "sprecher" : "Cornelia Meinhardt"
+        },
+        {
+          "rolle" : "Kundin",
+          "sprecher" : "Kathi Robens"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/087/metadata.json",
@@ -9689,79 +9763,79 @@
           "end" : 4496507
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Doe Dungeon, Programmierer",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Lili Buschfort",
-          "Christina Holsten"
-        ],
-        [
-          "Tom Beker",
-          "Wolfgang Hartmann"
-        ],
-        [
-          "Märchenerzähler",
-          "Hans Paetsch"
-        ],
-        [
-          "Königin Trulie",
-          "Hanna Reisch"
-        ],
-        [
-          "Vinton",
-          "Nils Noller"
-        ],
-        [
-          "Amme",
-          "Katharina Brauren"
-        ],
-        [
-          "Medusa",
-          "Marianne Kehlau"
-        ],
-        [
-          "Oinki Hinki",
-          "Niko Minninger"
-        ],
-        [
-          "Vampir-Frau",
-          "Julia von Spieß"
-        ],
-        [
-          "Hexe",
-          "Micaela Kreißler"
-        ],
-        [
-          "Oma",
-          "Beate Hasenau"
-        ],
-        [
-          "Wache",
-          "Michael Quiatkowsky"
-        ],
-        [
-          "Computerstimme",
-          "Sascha Gutzeit"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Doe Dungeon, Programmierer",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Lili Buschfort",
+          "sprecher" : "Christina Holsten"
+        },
+        {
+          "rolle" : "Tom Beker",
+          "sprecher" : "Wolfgang Hartmann"
+        },
+        {
+          "rolle" : "Märchenerzähler",
+          "sprecher" : "Hans Paetsch"
+        },
+        {
+          "rolle" : "Königin Trulie",
+          "sprecher" : "Hanna Reisch"
+        },
+        {
+          "rolle" : "Vinton",
+          "sprecher" : "Nils Noller"
+        },
+        {
+          "rolle" : "Amme",
+          "sprecher" : "Katharina Brauren"
+        },
+        {
+          "rolle" : "Medusa",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Oinki Hinki",
+          "sprecher" : "Niko Minninger"
+        },
+        {
+          "rolle" : "Vampir-Frau",
+          "sprecher" : "Julia von Spieß"
+        },
+        {
+          "rolle" : "Hexe",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Oma",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Wache",
+          "sprecher" : "Michael Quiatkowsky"
+        },
+        {
+          "rolle" : "Computerstimme",
+          "sprecher" : "Sascha Gutzeit"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/088/metadata.json",
@@ -9811,51 +9885,51 @@
           "end" : 3586347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Gilbert",
-          "Manfred Reddemann"
-        ],
-        [
-          "Mrs. Grayson",
-          "Beate Hasenau"
-        ],
-        [
-          "Mr. Perkins",
-          "Marco Kröger"
-        ],
-        [
-          "Mac Dunno",
-          "Gerhard Marcel"
-        ],
-        [
-          "Wachmann",
-          "Ulli Plessmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Gilbert",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Mrs. Grayson",
+          "sprecher" : "Beate Hasenau"
+        },
+        {
+          "rolle" : "Mr. Perkins",
+          "sprecher" : "Marco Kröger"
+        },
+        {
+          "rolle" : "Mac Dunno",
+          "sprecher" : "Gerhard Marcel"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Uli Pleßmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/089/metadata.json",
@@ -9905,35 +9979,35 @@
           "end" : 3532947
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Aaron Moore",
-          "Reent Reins"
-        ],
-        [
-          "Roxanne",
-          "Regine Lamster"
-        ],
-        [
-          "Bruce Black",
-          "Til Demtröder"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Aaron Moore",
+          "sprecher" : "Reent Reins"
+        },
+        {
+          "rolle" : "Roxanne",
+          "sprecher" : "Regine Lamster"
+        },
+        {
+          "rolle" : "Bruce Black",
+          "sprecher" : "Till Demtrøder"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/090/metadata.json",
@@ -9983,39 +10057,39 @@
           "end" : 3597147
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Stanley Truman",
-          "Horst Stark"
-        ],
-        [
-          "Mr. Shaw",
-          "Eberhard Haar"
-        ],
-        [
-          "Mrs. Jones",
-          "Gisela Trowe"
-        ],
-        [
-          "Mrs. Shoemaker",
-          "Barbara Schnipper"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Stanley Truman",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Mrs. Jones",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Mrs. Shoemaker",
+          "sprecher" : "Barbara Schipper"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/091/metadata.json",
@@ -10065,39 +10139,39 @@
           "end" : 3569347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Gregstone",
-          "Wolf Rathjen"
-        ],
-        [
-          "Butch",
-          "Frank Felicetti"
-        ],
-        [
-          "Ramirez",
-          "Tobias Schmidt"
-        ],
-        [
-          "Radiosprecher",
-          "Hubertus Borck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Gregstone",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Butch",
+          "sprecher" : "Frank Felicetti"
+        },
+        {
+          "rolle" : "Ramirez",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Radiosprecher",
+          "sprecher" : "Hubertus Borck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/092/metadata.json",
@@ -10147,43 +10221,44 @@
           "end" : 3592133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Quin",
-          "Rasmus Borowski"
-        ],
-        [
-          "Mr. Conrad Farnham",
-          "Lothar Grützner"
-        ],
-        [
-          "Mrs. Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Deborah Snell",
-          "Anja Topf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Quin",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Mr. Conrad Farnham",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Deborah Snell",
+          "sprecher" : "Anja Topf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/093/metadata.json",
@@ -10233,59 +10308,60 @@
           "end" : 3262720
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Alois Copper",
-          "Werner Cartano"
-        ],
-        [
-          "Mr. Carter",
-          "Marius Berthold"
-        ],
-        [
-          "Miss Lilly",
-          "Jocelyn Boisseaux-Endemann"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Frau des Bürgermeisters",
-          "Wanda Osten"
-        ],
-        [
-          "Reporter",
-          "Jacky Nonnon"
-        ],
-        [
-          "Stewart",
-          "Till Madaus"
-        ],
-        [
-          "Pico, Clown",
-          "Hubertus Borck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Alois Copper",
+          "sprecher" : "Werner Cartano"
+        },
+        {
+          "rolle" : "Mr. Carter",
+          "sprecher" : "Marius Berthold"
+        },
+        {
+          "rolle" : "Miss Lilly",
+          "sprecher" : "Jocelyne Boisseau"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Frau des Bürgermeisters",
+          "sprecher" : "Hella von der Osten-Sacken",
+          "pseudonym" : "Wanda Osten"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Jacky Nonnon"
+        },
+        {
+          "rolle" : "Stewart",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Pico, Clown",
+          "sprecher" : "Hubertus Borck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/094/metadata.json",
@@ -10335,47 +10411,47 @@
           "end" : 3603800
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jelena Charkov",
-          "Alexandra Doerk"
-        ],
-        [
-          "Mr. Charkov",
-          "Klaus Dittmann"
-        ],
-        [
-          "Dr. Arroway",
-          "Sona Cervena"
-        ],
-        [
-          "Janet, ihre Assistentin",
-          "Ute Rohrbeck"
-        ],
-        [
-          "Tom Gordon",
-          "Philip Hoier"
-        ],
-        [
-          "Dixon",
-          "Utz Richter"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Mr. Charkov",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Dr. Arroway",
+          "sprecher" : "Soňa Červená"
+        },
+        {
+          "rolle" : "Janet, ihre Assistentin",
+          "sprecher" : "Ute Rohrbeck"
+        },
+        {
+          "rolle" : "Tom Gordon",
+          "sprecher" : "Philip Hoier"
+        },
+        {
+          "rolle" : "Dixon",
+          "sprecher" : "Utz Richter"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/095/metadata.json",
@@ -10435,55 +10511,55 @@
           "end" : 3191000
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Detective Frank",
-          "Wolf Frass"
-        ],
-        [
-          "Dave Rawling",
-          "Helmut Gentsch"
-        ],
-        [
-          "Praktikantin Lesley",
-          "Ann Montenbruck"
-        ],
-        [
-          "Mrs. Shaw",
-          "Heikedine Körting"
-        ],
-        [
-          "Mr. Smith",
-          "Douglas Welbat"
-        ],
-        [
-          "Sheppard",
-          "Marius Kreissler"
-        ],
-        [
-          "Feuerwehrmann",
-          "Wolfgang Kaven"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Detective Frank",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Dave Rawling",
+          "sprecher" : "Helmut Gentsch"
+        },
+        {
+          "rolle" : "Praktikantin Lesley",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Mr. Smith",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Sheppard",
+          "sprecher" : "Marius Kreissler"
+        },
+        {
+          "rolle" : "Feuerwehrmann",
+          "sprecher" : "Wolfgang Kaven"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/096/metadata.json",
@@ -10543,43 +10619,44 @@
           "end" : 4066453
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Janet Hazelwood",
-          "Marianne Kehlau"
-        ],
-        [
-          "Laura Stryker",
-          "Regina Lemnitz"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Mrs. White",
-          "Brigitte Böttrich"
-        ],
-        [
-          "Mr. Collins",
-          "Daniel Eggers"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Janet Hazelwood",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Laura Stryker",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Mrs. White",
+          "sprecher" : "Brigitte Böttrich"
+        },
+        {
+          "rolle" : "Mr. Collins",
+          "sprecher" : "Daniel Eggers"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/097/metadata.json",
@@ -10639,63 +10716,64 @@
           "end" : 3772307
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ann Sullivan",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Mr. Martin",
-          "Christian Mey"
-        ],
-        [
-          "Mr. Caddy",
-          "Helmut Gentsch"
-        ],
-        [
-          "Kellnerin",
-          "Anna Carlsson"
-        ],
-        [
-          "Lady Day",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Henry",
-          "Wilhelm Wieben"
-        ],
-        [
-          "Mann aus der Wüste",
-          "Wilhelm Hornbostel"
-        ],
-        [
-          "Miller",
-          "Lutz Mackensy"
-        ],
-        [
-          "Debby",
-          "Roswitha Benda"
-        ],
-        [
-          "Joe",
-          "Jakob Lichtblau [Eberhard Haar]"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ann Sullivan",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Mr. Martin",
+          "sprecher" : "Christian Mey"
+        },
+        {
+          "rolle" : "Mr. Caddy",
+          "sprecher" : "Helmut Gentsch"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Lady Day",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Henry",
+          "sprecher" : "Wilhelm Wieben"
+        },
+        {
+          "rolle" : "Mann aus der Wüste",
+          "sprecher" : "Wilhelm Hornbostel"
+        },
+        {
+          "rolle" : "Miller",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Debby",
+          "sprecher" : "Roswitha Benda"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Fabian Harloff",
+          "pseudonym" : "Jakob Lichtblau"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/098/metadata.json",
@@ -10755,67 +10833,67 @@
           "end" : 4573053
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Kevin Anderson",
-          "Thomas Bug"
-        ],
-        [
-          "Clarissa Franklin",
-          "Judy Winter"
-        ],
-        [
-          "Dr. Freeman",
-          "Jürgen Thormann"
-        ],
-        [
-          "Mrs. Brighton",
-          "Monika Werner"
-        ],
-        [
-          "Mrs. Wheel",
-          "Ines Sawatzki"
-        ],
-        [
-          "Schwester Whitney",
-          "Andrea Lange"
-        ],
-        [
-          "Besucher",
-          "Eckart Dux"
-        ],
-        [
-          "Bote",
-          "Stefan Rütter"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kevin Anderson",
+          "sprecher" : "Thomas Bug"
+        },
+        {
+          "rolle" : "Clarissa Franklin",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Dr. Freeman",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Mrs. Brighton",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Mrs. Wheel",
+          "sprecher" : "Ines Sawatzki"
+        },
+        {
+          "rolle" : "Schwester Whitney",
+          "sprecher" : "Andrea Lange"
+        },
+        {
+          "rolle" : "Besucher",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Bote",
+          "sprecher" : "Stefan Rüter"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/099/metadata.json",
@@ -10866,47 +10944,47 @@
               "end" : 3204573
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Matthias Fuchs"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Skinny Norris",
-              "Andreas von der Meden"
-            ],
-            [
-              "Jelena",
-              "Alexandra Doerk"
-            ],
-            [
-              "Dr. Svenson",
-              "Antje Roosch"
-            ],
-            [
-              "Mr. Schwarz",
-              "Erik Schäffler"
-            ],
-            [
-              "Mr. Olin",
-              "Uli Krohm"
-            ],
-            [
-              "Juan",
-              "Oliver Böttcher"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Matthias Fuchs"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Skinny Norris",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Jelena Charkova",
+              "sprecher" : "Alexandra Doerk"
+            },
+            {
+              "rolle" : "Dr. Svenson",
+              "sprecher" : "Antje Roosch"
+            },
+            {
+              "rolle" : "Mr. Schwarz",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Mr. Olin",
+              "sprecher" : "Uli Krohm"
+            },
+            {
+              "rolle" : "Juan",
+              "sprecher" : "Oliver Böttcher"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/1/metadata.json",
@@ -10951,67 +11029,67 @@
               "end" : 3376800
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Matthias Fuchs"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Skinny Norris",
-              "Andreas von der Meden"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Jelena",
-              "Alexandra Doerk"
-            ],
-            [
-              "Professor Phoenix",
-              "Wilfried Glatzeder"
-            ],
-            [
-              "Dr. Svenson",
-              "Antje Roosch"
-            ],
-            [
-              "Mr. Schwarz",
-              "Erik Schäffler"
-            ],
-            [
-              "Mr. Olin",
-              "Uli Krohm"
-            ],
-            [
-              "Juan",
-              "Oliver Böttcher"
-            ],
-            [
-              "Rachel Hadden",
-              "Anna Carlsson"
-            ],
-            [
-              "Al",
-              "Nico König"
-            ],
-            [
-              "Anne",
-              "Corinna Wodrich"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Matthias Fuchs"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Skinny Norris",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Jelena Charkova",
+              "sprecher" : "Alexandra Doerk"
+            },
+            {
+              "rolle" : "Professor Phoenix",
+              "sprecher" : "Winfried Glatzeder"
+            },
+            {
+              "rolle" : "Dr. Svenson",
+              "sprecher" : "Antje Roosch"
+            },
+            {
+              "rolle" : "Mr. Schwarz",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Mr. Olin",
+              "sprecher" : "Uli Krohm"
+            },
+            {
+              "rolle" : "Juan",
+              "sprecher" : "Oliver Böttcher"
+            },
+            {
+              "rolle" : "Rachel Hadden",
+              "sprecher" : "Anna Carlsson"
+            },
+            {
+              "rolle" : "Al",
+              "sprecher" : "Nicolas König"
+            },
+            {
+              "rolle" : "Anne",
+              "sprecher" : "Corinna Wodrich"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/2/metadata.json",
@@ -11056,55 +11134,55 @@
               "end" : 3410493
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Matthias Fuchs"
-            ],
-            [
-              "Justus Jonas, Erster Detektiv",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw, Zweiter Detektiv",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews, Recherchen und Archiv",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Jelena",
-              "Alexandra Doerk"
-            ],
-            [
-              "Professor Phoenix",
-              "Wilfried Glatzeder"
-            ],
-            [
-              "Dr. Svenson",
-              "Antje Roosch"
-            ],
-            [
-              "Mr. Schwarz",
-              "Erik Schäffler"
-            ],
-            [
-              "Mr. Olin",
-              "Uli Krohm"
-            ],
-            [
-              "Juan",
-              "Oliver Böttcher"
-            ],
-            [
-              "Al",
-              "Nico König"
-            ],
-            [
-              "Anne",
-              "Corinna Wodrich"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Matthias Fuchs"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Jelena Charkova",
+              "sprecher" : "Alexandra Doerk"
+            },
+            {
+              "rolle" : "Professor Phoenix",
+              "sprecher" : "Winfried Glatzeder"
+            },
+            {
+              "rolle" : "Dr. Svenson",
+              "sprecher" : "Antje Roosch"
+            },
+            {
+              "rolle" : "Mr. Schwarz",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Mr. Olin",
+              "sprecher" : "Uli Krohm"
+            },
+            {
+              "rolle" : "Juan",
+              "sprecher" : "Oliver Böttcher"
+            },
+            {
+              "rolle" : "Al",
+              "sprecher" : "Nicolas König"
+            },
+            {
+              "rolle" : "Anne",
+              "sprecher" : "Corinna Wodrich"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/3/metadata.json",
@@ -11118,67 +11196,67 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Die drei ??? übernehmen ihren 100sten Fall Fall! In drei spannenden Folgen sind sie dem Geheimnis der Toteninsel auf der Spur.\nEine große Herausforderung für die Detektive. Weswegen sie gut beraten sind, die Hilfe alter Wegbegleiter anzunehmen, um Das Rätsel der Sphinx (Teil 1) zu lösen. Doch plötzlich ist Peter verschwunden und auch Das vergessene Volk (Teil 2) kann Justus und Bob bei ihrer Suche nicht weiterhelfen. Erst Der Fluch der Gräber (Teil 3) führt die drei ??? auf eine heiße Spur.",
       "veröffentlichungsdatum" : "2001-10-15",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Jelena",
-          "Alexandra Doerk"
-        ],
-        [
-          "Dr. Svenson",
-          "Antje Roosch"
-        ],
-        [
-          "Mr. Schwarz",
-          "Erik Schäffler"
-        ],
-        [
-          "Mr. Olin",
-          "Uli Krohm"
-        ],
-        [
-          "Juan",
-          "Oliver Böttcher"
-        ],
-        [
-          "Professor Phoenix",
-          "Wilfried Glatzeder"
-        ],
-        [
-          "Rachel Hadden",
-          "Anna Carlsson"
-        ],
-        [
-          "Al",
-          "Nico König"
-        ],
-        [
-          "Anne",
-          "Corinna Wodrich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Dr. Svenson",
+          "sprecher" : "Antje Roosch"
+        },
+        {
+          "rolle" : "Mr. Schwarz",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Mr. Olin",
+          "sprecher" : "Uli Krohm"
+        },
+        {
+          "rolle" : "Juan",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Professor Phoenix",
+          "sprecher" : "Winfried Glatzeder"
+        },
+        {
+          "rolle" : "Rachel Hadden",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Al",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Anne",
+          "sprecher" : "Corinna Wodrich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/100/metadata.json",
@@ -11236,55 +11314,55 @@
           "end" : 4313453
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Giorgio Cade",
-          "Bastian Pastewka"
-        ],
-        [
-          "Monique Carrera",
-          "Amanda Lear"
-        ],
-        [
-          "Mrs. Jones",
-          "Marianne Kehlau"
-        ],
-        [
-          "Jenny Collins",
-          "Anja Topf"
-        ],
-        [
-          "Jeremy Scott",
-          "Woody Mues"
-        ],
-        [
-          "Mrs. Scott",
-          "Hansi Jochmann"
-        ],
-        [
-          "Oma Scott",
-          "Apollonia Minniger"
-        ],
-        [
-          "Acer",
-          "Thomas Schüler"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Giorgio Cade",
+          "sprecher" : "Bastian Pastewka"
+        },
+        {
+          "rolle" : "Monique Carrera",
+          "sprecher" : "Amanda Lear"
+        },
+        {
+          "rolle" : "Mrs. Jones",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Jenny Collins",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Jeremy Scott",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Mrs. Scott",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Oma Scott",
+          "sprecher" : "Apollonia Jepsen"
+        },
+        {
+          "rolle" : "Acer",
+          "sprecher" : "Thomas Schüler"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/101/metadata.json",
@@ -11344,43 +11422,43 @@
           "end" : 3560680
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "King",
-          "Wolfgang Condrus"
-        ],
-        [
-          "Jenny Collins",
-          "Anja Topf"
-        ],
-        [
-          "Tricia Wilson",
-          "Ursula Vogel"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "King",
+          "sprecher" : "Wolfgang Condrus"
+        },
+        {
+          "rolle" : "Jenny Collins",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Tricia Wilson",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/102/metadata.json",
@@ -11440,51 +11518,52 @@
           "end" : 3810187
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brittany",
-          "Dorette Hugo"
-        ],
-        [
-          "Victor Hugenay",
-          "Albert Giro [Wolfgang Kubach]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Wilbur Graham",
-          "Thomas Bammer"
-        ],
-        [
-          "Bruder Raphael",
-          "Siegfried Kernen"
-        ],
-        [
-          "Inspektor Berger",
-          "Jan Buchwald"
-        ],
-        [
-          "Baldwin",
-          "Gerhart Hinze"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brittany",
+          "sprecher" : "Dorette Hugo"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Wilbur Graham",
+          "sprecher" : "Thomas Bammer"
+        },
+        {
+          "rolle" : "Bruder Raphael",
+          "sprecher" : "Siegfried W. Kernen"
+        },
+        {
+          "rolle" : "Inspektor Berger",
+          "sprecher" : "Jan Buchwald"
+        },
+        {
+          "rolle" : "Baldwin",
+          "sprecher" : "Gerhart Hinze"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/103/metadata.json",
@@ -11544,51 +11623,51 @@
           "end" : 4138120
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dick Perry",
-          "Ernst Hilbich"
-        ],
-        [
-          "Mrs. Meg Baker",
-          "Lotti Krekel"
-        ],
-        [
-          "Mrs. Wood",
-          "Elga Schütz"
-        ],
-        [
-          "Jack Sharky",
-          "Stefan Babic"
-        ],
-        [
-          "Betty Shutton",
-          "Regina Pressler"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dick Perry",
+          "sprecher" : "Ernst H. Hilbich"
+        },
+        {
+          "rolle" : "Mrs. Meg Baker",
+          "sprecher" : "Lotti Krekel"
+        },
+        {
+          "rolle" : "Mrs. Wood",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "Jack Sharky",
+          "sprecher" : "Stefan Babic"
+        },
+        {
+          "rolle" : "Betty Shutton",
+          "sprecher" : "Regina Pressler"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/104/metadata.json",
@@ -11648,47 +11727,47 @@
           "end" : 4545293
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Joanna Masterson",
-          "Barbara Marcks"
-        ],
-        [
-          "Jack Masterson",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Sarah Masterson",
-          "Nadja Reichardt"
-        ],
-        [
-          "Mr Harry Falkner",
-          "Wolfgang Hartmann"
-        ],
-        [
-          "Harvey Ashford",
-          "Rolf E. Schenker"
-        ],
-        [
-          "Marc",
-          "Hartmut Kollakowski"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Joanna Masterson",
+          "sprecher" : "Barbara Marcks"
+        },
+        {
+          "rolle" : "Jack Masterson",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Sarah Masterson",
+          "sprecher" : "Nadja Reichardt"
+        },
+        {
+          "rolle" : "Mr. Harry Falkner",
+          "sprecher" : "Wolfgang Hartmann"
+        },
+        {
+          "rolle" : "Harvey Ashford",
+          "sprecher" : "Rolf E. Schenker"
+        },
+        {
+          "rolle" : "Marc",
+          "sprecher" : "Hartmut Kollakowsky"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/105/metadata.json",
@@ -11748,75 +11827,77 @@
           "end" : 4255213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Amy Scream",
-          "Marianne Kehlau"
-        ],
-        [
-          "Monique Carrera",
-          "Amanda Lear"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Ellen",
-          "Celine Fontanges"
-        ],
-        [
-          "Pam",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Jim Cowley",
-          "Cäsar"
-        ],
-        [
-          "Jeffrey",
-          "Kim Alexander Frank"
-        ],
-        [
-          "Mandy Robin",
-          "Manuela Dahm"
-        ],
-        [
-          "1. Sanitäter",
-          "Robert Missler"
-        ],
-        [
-          "2. Sanitäter",
-          "Hartmut Kollakowsky"
-        ],
-        [
-          "Bardame",
-          "Monique Carrera [Amanda Lear]"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Diskothekenbesucher",
-          "Echt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Amy Scream",
+          "sprecher" : "Marianne Kehlau"
+        },
+        {
+          "rolle" : "Monique Carrera",
+          "sprecher" : "Amanda Lear"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Ellen",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Pam",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Jim Cowley",
+          "sprecher" : "Marcus Kaiser",
+          "pseudonym" : "Cäsar"
+        },
+        {
+          "rolle" : "Jeffrey",
+          "sprecher" : "Kim Frank"
+        },
+        {
+          "rolle" : "Mandy Robin",
+          "sprecher" : "Manuela Dahm"
+        },
+        {
+          "rolle" : "Sanitäter 1",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Sanitäter 2",
+          "sprecher" : "Hartmut Kollakowsky"
+        },
+        {
+          "rolle" : "Bardame",
+          "sprecher" : "Amanda Lear",
+          "pseudonym" : "Monique Carrera"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Diskothekenbesucher",
+          "sprecher" : "Echt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/106/metadata.json",
@@ -11876,55 +11957,55 @@
           "end" : 3850840
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Lama Geshe",
-          "Rolf Nagel"
-        ],
-        [
-          "Tai Sutsi",
-          "Dr. Boo Young-Shin"
-        ],
-        [
-          "Chuck",
-          "Yan Kimsang"
-        ],
-        [
-          "Vinaya",
-          "Prof. Dr. Zhu"
-        ],
-        [
-          "Mr Zhang",
-          "Ingo Feder"
-        ],
-        [
-          "Lesley Dimple",
-          "Maja Stehli [Ingeborg Kantstein ?]"
-        ],
-        [
-          "Mrs. Wilbur",
-          "Ingeburg Kanstein"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Lama Geshe",
+          "sprecher" : "Rolf Nagel"
+        },
+        {
+          "rolle" : "Tai Sutsi",
+          "sprecher" : "Dr. Boo Young-Shin"
+        },
+        {
+          "rolle" : "Chuck",
+          "sprecher" : "Yan Kimsang"
+        },
+        {
+          "rolle" : "Vinaya",
+          "sprecher" : "Prof. Dr. Zhu"
+        },
+        {
+          "rolle" : "Mr. Zhang",
+          "sprecher" : "Ingo Feder"
+        },
+        {
+          "rolle" : "Lesley Dimple",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Mrs. Wilbur",
+          "sprecher" : "Ingeburg Kanstein"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/107/metadata.json",
@@ -11989,39 +12070,39 @@
           "end" : 4004480
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Caspar Carter",
-          "Claus Wilcke"
-        ],
-        [
-          "Enid",
-          "Janina Richter"
-        ],
-        [
-          "Albert",
-          "Wolf Rathjen"
-        ],
-        [
-          "Montgomery",
-          "Hans Sievers"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Caspar Carter",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Enid",
+          "sprecher" : "Janina Richter"
+        },
+        {
+          "rolle" : "Albert",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Montgomery",
+          "sprecher" : "Hans Sievers"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/108/metadata.json",
@@ -12081,59 +12162,59 @@
           "end" : 4027533
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Nick Nobel",
-          "Ilja Richter"
-        ],
-        [
-          "Sandy",
-          "Micaela Kreissler"
-        ],
-        [
-          "Bill",
-          "Achim Schülke"
-        ],
-        [
-          "Mike Pherson",
-          "Wolf-Dietrich Berg"
-        ],
-        [
-          "Assistent",
-          "Martin Meyer"
-        ],
-        [
-          "Clarissa",
-          "Theresa Underberg"
-        ],
-        [
-          "Veronica",
-          "Saskia Weckler"
-        ],
-        [
-          "Joe",
-          "Jan-David Rönfeldt"
-        ],
-        [
-          "Sekretärin",
-          "Traudel Sperber"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Nick Nobel",
+          "sprecher" : "Ilja Richter"
+        },
+        {
+          "rolle" : "Sandy",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Bill",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Mike Pherson",
+          "sprecher" : "Wolf-Dietrich Berg"
+        },
+        {
+          "rolle" : "Assistent",
+          "sprecher" : "Martin Meyer"
+        },
+        {
+          "rolle" : "Clarissa",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Veronica",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Jan-David Rönfeldt"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Traudel Sperber"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/109/metadata.json",
@@ -12193,63 +12274,63 @@
           "end" : 3310573
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Pablo",
-          "Kai Hendrik Möller"
-        ],
-        [
-          "Dr. Brolin",
-          "Karl-Friedrich Gerster"
-        ],
-        [
-          "Jenkins",
-          "Gustav-Adolph Artz"
-        ],
-        [
-          "Professor Clark",
-          "Thor W. Müller"
-        ],
-        [
-          "Bürgermeister Hoover",
-          "Michael Griem"
-        ],
-        [
-          "Margie",
-          "Susanne Leu"
-        ],
-        [
-          "Mike",
-          "Achim Schülke"
-        ],
-        [
-          "Clark",
-          "Wolf Rathjen"
-        ],
-        [
-          "Wachmann",
-          "Kristian Kretschmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Pablo",
+          "sprecher" : "Kai Henrik Möller"
+        },
+        {
+          "rolle" : "Dr. Brolin",
+          "sprecher" : "Karl-Friedrich Gerster"
+        },
+        {
+          "rolle" : "Jenkins",
+          "sprecher" : "Gustav-Adolph Artz"
+        },
+        {
+          "rolle" : "Professor Clark",
+          "sprecher" : "Thor W. Müller"
+        },
+        {
+          "rolle" : "Bürgermeister Hoover",
+          "sprecher" : "Michael Griem"
+        },
+        {
+          "rolle" : "Margie",
+          "sprecher" : "Susanna Leu"
+        },
+        {
+          "rolle" : "Mike",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Clark",
+          "sprecher" : "Wolf Rahtjen"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Kristian Kretschmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/110/metadata.json",
@@ -12339,71 +12420,71 @@
           "end" : 3906600
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Maggie Jones",
-          "Ulrike Johannson"
-        ],
-        [
-          "Lythia Waterstone",
-          "Barbara Focke"
-        ],
-        [
-          "Elisabeth Waterstone",
-          "Linde Fulde"
-        ],
-        [
-          "John Stanley",
-          "Kai Böger"
-        ],
-        [
-          "Jack Donelly",
-          "Andreas Mattau"
-        ],
-        [
-          "Althena",
-          "Michaela Boland"
-        ],
-        [
-          "Corona",
-          "Stefanie Kirchberger"
-        ],
-        [
-          "Fahrer Ken",
-          "Wolf Frass"
-        ],
-        [
-          "John Fairbanks",
-          "Christian Rudolf"
-        ],
-        [
-          "Hal Fairbanks",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Walt",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Blackeye",
-          "Georg Marquard"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Maggie Jones",
+          "sprecher" : "Ulrike Johannson"
+        },
+        {
+          "rolle" : "Lythia Waterstone",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Elisabeth Waterstone",
+          "sprecher" : "Linde Fulda"
+        },
+        {
+          "rolle" : "John Stanley",
+          "sprecher" : "Kai Böger"
+        },
+        {
+          "rolle" : "Jack Donelly",
+          "sprecher" : "Andreas Mattau"
+        },
+        {
+          "rolle" : "Althena",
+          "sprecher" : "Michaela Boland"
+        },
+        {
+          "rolle" : "Corona",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Fahrer Ken",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "John Fairbanks",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Hal Fairbanks",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Walt",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Blackeye",
+          "sprecher" : "Georg Marquard"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/111/metadata.json",
@@ -12488,47 +12569,47 @@
           "end" : 3529667
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Donovan",
-          "Joachim Richert"
-        ],
-        [
-          "Pit",
-          "Wolfgang Wagner"
-        ],
-        [
-          "Max",
-          "Johannes Rothenstein"
-        ],
-        [
-          "Cowboy",
-          "Christian Niehues"
-        ],
-        [
-          "Creeklong",
-          "Nobi Schatka"
-        ],
-        [
-          "Brad Fleming",
-          "Dennis Jensen"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Donovan",
+          "sprecher" : "Joachim Richert"
+        },
+        {
+          "rolle" : "Pit",
+          "sprecher" : "Wolfgang Wagner"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Johannes Rothenstein"
+        },
+        {
+          "rolle" : "Cowboy",
+          "sprecher" : "Christian Niehues"
+        },
+        {
+          "rolle" : "Creeklong",
+          "sprecher" : "Nobi Schatka"
+        },
+        {
+          "rolle" : "Brad Fleming",
+          "sprecher" : "Dennis Jensen"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/112/metadata.json",
@@ -12618,47 +12699,47 @@
           "end" : 3607400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Emily",
-          "Madeleine Weingart"
-        ],
-        [
-          "Mrs Silverstone",
-          "Katrin Wasow"
-        ],
-        [
-          "Dr. Wakefield",
-          "Hans Daniel"
-        ],
-        [
-          "Alruna",
-          "Gisela Trowe"
-        ],
-        [
-          "Marcus Lake",
-          "Thomas Karallus"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Emily",
+          "sprecher" : "Madeleine Weingart"
+        },
+        {
+          "rolle" : "Mrs. Silverstone",
+          "sprecher" : "Katrin Wasow"
+        },
+        {
+          "rolle" : "Dr. Wakefield",
+          "sprecher" : "Hans Daniel"
+        },
+        {
+          "rolle" : "Alruna",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Marcus Lake",
+          "sprecher" : "Thomas Karallus"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/113/metadata.json",
@@ -12738,51 +12819,51 @@
           "end" : 4150480
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Bernadette O'Donnell",
-          "Eva Maria Bauer"
-        ],
-        [
-          "Cecilia Jones",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Elouise Adams",
-          "Hannelore Wüst"
-        ],
-        [
-          "Mrs Willow",
-          "Elga Schütz"
-        ],
-        [
-          "Möbelpacker",
-          "Christian Niehues"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Bernadette O'Donnell",
+          "sprecher" : "Eva Maria Bauer"
+        },
+        {
+          "rolle" : "Cecilia Jones",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Elouise Adams",
+          "sprecher" : "Hannelore Wüst"
+        },
+        {
+          "rolle" : "Mrs. Willow",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "Möbelpacker",
+          "sprecher" : "Christian Niehues"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/114/metadata.json",
@@ -12877,63 +12958,64 @@
           "end" : 4200627
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Escovedo",
-          "Ignacio Descalzo"
-        ],
-        [
-          "Anita Caballero",
-          "Isabell Navarro"
-        ],
-        [
-          "Lesley Dimple",
-          "Rica Blunck"
-        ],
-        [
-          "Regina Pearson",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Mr Horowitz",
-          "Rolf Jülich"
-        ],
-        [
-          "Mr Rothman",
-          "Peter Weis"
-        ],
-        [
-          "Mrs O'Rien",
-          "Victoria von Trautmannsdorff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Escovedo",
+          "sprecher" : "Ignacio Descalzo"
+        },
+        {
+          "rolle" : "Anita Caballero",
+          "sprecher" : "Isabel Navarro"
+        },
+        {
+          "rolle" : "Lesley Dimple",
+          "sprecher" : "Rica Blunck"
+        },
+        {
+          "rolle" : "Regina Pearson",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Mr. Horowitz",
+          "sprecher" : "Rolf Jülich"
+        },
+        {
+          "rolle" : "Mr. Rothman",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Mrs. O'Rien",
+          "sprecher" : "Victoria Trauttmansdorff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/115/metadata.json",
@@ -12998,51 +13080,51 @@
           "end" : 3724893
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Applegate",
-          "Stephan Benson"
-        ],
-        [
-          "Julia Applegate",
-          "Sophie Lechtenbrink"
-        ],
-        [
-          "Teddy Applegate",
-          "Jona Mues"
-        ],
-        [
-          "Rafter",
-          "Volker Bogdan"
-        ],
-        [
-          "Archie",
-          "Bertram Hiese"
-        ],
-        [
-          "Jenny Collins",
-          "Anja Topf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Applegate",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Julia Applegate",
+          "sprecher" : "Sophie Lechtenbrink"
+        },
+        {
+          "rolle" : "Teddy Applegate",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Rafter",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Archie",
+          "sprecher" : "Bertram Hiese"
+        },
+        {
+          "rolle" : "Jenny Collins",
+          "sprecher" : "Anja Topf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/116/metadata.json",
@@ -13117,59 +13199,60 @@
           "end" : 3640027
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Godwin",
-          "André Minninger"
-        ],
-        [
-          "Wagner",
-          "Jürgen Thormann"
-        ],
-        [
-          "Beaumont",
-          "Douglas Welbat"
-        ],
-        [
-          "Calhoon",
-          "Bernd Stephan"
-        ],
-        [
-          "Mike",
-          "Arndt Schmöle"
-        ],
-        [
-          "Zia",
-          "Brigitte Böttrich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Wagner",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Beaumont",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Calhoon",
+          "sprecher" : "Bernd Stephan"
+        },
+        {
+          "rolle" : "Mike",
+          "sprecher" : "Arndt Schmöle"
+        },
+        {
+          "rolle" : "Zia",
+          "sprecher" : "Brigitte Böttrich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/117/metadata.json",
@@ -13254,67 +13337,67 @@
           "end" : 3996413
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Ralph",
-          "Jan-David Rönnfeldt"
-        ],
-        [
-          "Robbie",
-          "Manfred Reddemann"
-        ],
-        [
-          "Jack",
-          "Daniel Brühl"
-        ],
-        [
-          "Dennis",
-          "Stefan Brönneke"
-        ],
-        [
-          "Gina",
-          "Chiara Ferraú"
-        ],
-        [
-          "Charly",
-          "Aaron Lee Ullmer"
-        ],
-        [
-          "Sheriff",
-          "Harry Rowohlt"
-        ],
-        [
-          "Turnbull",
-          "Detlef Bierstedt"
-        ],
-        [
-          "Jenny Collins",
-          "Anja Topf"
-        ],
-        [
-          "Dizzy",
-          "Marion Klaus"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Ralph",
+          "sprecher" : "Jan-David Rönfeldt"
+        },
+        {
+          "rolle" : "Robbie",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Daniel Brühl"
+        },
+        {
+          "rolle" : "Dennis",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Gina",
+          "sprecher" : "Chiara Ferraú"
+        },
+        {
+          "rolle" : "Charly",
+          "sprecher" : "Aaron Lee Ullmer"
+        },
+        {
+          "rolle" : "Sheriff",
+          "sprecher" : "Harry Rowohlt"
+        },
+        {
+          "rolle" : "Turnbull",
+          "sprecher" : "Detlef Bierstedt"
+        },
+        {
+          "rolle" : "Jenny Collins",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Dizzy",
+          "sprecher" : "Marion Klaus"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/118/metadata.json",
@@ -13404,59 +13487,60 @@
           "end" : 4063440
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Caitlin Kopperschmidt",
-          "Marion Martienzen"
-        ],
-        [
-          "Jeremy Kopperschmidt",
-          "Lutz Herkenrath"
-        ],
-        [
-          "Graig Kopperschmidt",
-          "Mario Grete"
-        ],
-        [
-          "George",
-          "Hendrik König"
-        ],
-        [
-          "Anthony Quinn",
-          "Franz-Joseph Steffens"
-        ],
-        [
-          "Martha",
-          "Sabine Falkenberg"
-        ],
-        [
-          "Felix Kopperschmidt",
-          "Herrmann Otto"
-        ],
-        [
-          "Mann",
-          "Frank Felicetti"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Caitlin Kopperschmidt",
+          "sprecher" : "Marion Martienzen"
+        },
+        {
+          "rolle" : "Jeremy Kopperschmidt",
+          "sprecher" : "Lutz Herkenrath"
+        },
+        {
+          "rolle" : "Graig Kopperschmidt",
+          "sprecher" : "Mario Grete"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Anthony Quinn",
+          "sprecher" : "Franz-Josef Steffens"
+        },
+        {
+          "rolle" : "Martha",
+          "sprecher" : "Sabine Falkenberg"
+        },
+        {
+          "rolle" : "Felix Kopperschmidt",
+          "sprecher" : "Hermann Otto"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Frank Felicetti"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/119/metadata.json",
@@ -13531,43 +13615,43 @@
           "end" : 3528253
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ken Parker, Beachball-Spieler",
-          "Jürgen Holdorf"
-        ],
-        [
-          "Dr. Robinson",
-          "Heinz Lieven"
-        ],
-        [
-          "Mickey McQuire",
-          "Marco Sand"
-        ],
-        [
-          "Mrs Bancroft",
-          "Ilka Kirsch"
-        ],
-        [
-          "Zuschauer",
-          "Alexander Mülle"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ken Parker, Beachball-Spieler",
+          "sprecher" : "Jürgen Holdorf"
+        },
+        {
+          "rolle" : "Dr. Robinson",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Mickey McQuire",
+          "sprecher" : "Marco Sand"
+        },
+        {
+          "rolle" : "Mrs. Bancroft",
+          "sprecher" : "Ilka Kirsch"
+        },
+        {
+          "rolle" : "Zuschauer",
+          "sprecher" : "Alexander Müller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/120/metadata.json",
@@ -13652,55 +13736,55 @@
           "end" : 3762347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Shawn",
-          "Robin Brosch"
-        ],
-        [
-          "Jolene",
-          "Marion Elskis"
-        ],
-        [
-          "Leah",
-          "Susanne Sternberg"
-        ],
-        [
-          "Jelena",
-          "Alexandra Doerk"
-        ],
-        [
-          "Sue",
-          "Kerstin Hilbig"
-        ],
-        [
-          "Kimberly Lloyd",
-          "Ingeborg Christiansen"
-        ],
-        [
-          "William Boyd",
-          "Olaf Kreuzenbeck"
-        ],
-        [
-          "Thorndike",
-          "Michael Lott"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Shawn",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Jolene",
+          "sprecher" : "Marion Elskis"
+        },
+        {
+          "rolle" : "Leah",
+          "sprecher" : "Susanne Sternberg"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Sue",
+          "sprecher" : "Kerstin Hilbig"
+        },
+        {
+          "rolle" : "Kimberly Lloyd",
+          "sprecher" : "Ingeborg Christiansen"
+        },
+        {
+          "rolle" : "William Boyd",
+          "sprecher" : "Olaf Kreutzenbeck"
+        },
+        {
+          "rolle" : "Thorndike",
+          "sprecher" : "Michael Lott"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/121/metadata.json",
@@ -13765,59 +13849,59 @@
           "end" : 3494760
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Fred Jenkins",
-          "Nick Seidensticker"
-        ],
-        [
-          "Mr Campbell",
-          "Gerhart Hinze"
-        ],
-        [
-          "Sam Reilly",
-          "Jürgen Strube"
-        ],
-        [
-          "Carl Sheehan",
-          "Michael Weckler"
-        ],
-        [
-          "Collins",
-          "Thorsten Weber"
-        ],
-        [
-          "Mr Kingsley",
-          "Herbert Tennigkeit"
-        ],
-        [
-          "Mrs Kingsley",
-          "Tina Rehfeld-Wildmann"
-        ],
-        [
-          "Devlin Reno",
-          "Jörg Pleva"
-        ],
-        [
-          "Dr. Long",
-          "Lou Wong"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Fred Jenkins",
+          "sprecher" : "Nick Seidensticker"
+        },
+        {
+          "rolle" : "Mr. Campbell",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Sam Reilly",
+          "sprecher" : "Jürgen Strube"
+        },
+        {
+          "rolle" : "Carl Sheehan",
+          "sprecher" : "Michael Weckler"
+        },
+        {
+          "rolle" : "Collins",
+          "sprecher" : "Thorsten Weber"
+        },
+        {
+          "rolle" : "Mr. Kingsley",
+          "sprecher" : "Herbert Tennigkeit"
+        },
+        {
+          "rolle" : "Mrs. Kingsley",
+          "sprecher" : "Tina Rehfeld-Wildmann"
+        },
+        {
+          "rolle" : "Devlin Reno",
+          "sprecher" : "Jörg Pleva"
+        },
+        {
+          "rolle" : "Dr. Long",
+          "sprecher" : "Lou Wong"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/122/metadata.json",
@@ -13892,43 +13976,43 @@
           "end" : 3677213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Emiliano",
-          "Tobias Schmidt"
-        ],
-        [
-          "Pancho",
-          "Ben Hecker"
-        ],
-        [
-          "Esperanza",
-          "Ingeborg Christiansen"
-        ],
-        [
-          "Pedro",
-          "Anton Sprick"
-        ],
-        [
-          "Abelardo",
-          "Peter Brix"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Emiliano",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Pancho",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Esperanza",
+          "sprecher" : "Ingeborg Christiansen"
+        },
+        {
+          "rolle" : "Pedro",
+          "sprecher" : "Anton Sprick"
+        },
+        {
+          "rolle" : "Abelardo",
+          "sprecher" : "Peter Heinrich Brix"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/123/metadata.json",
@@ -14023,43 +14107,43 @@
           "end" : 3990920
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. O'Sullivan",
-          "Eckard Dux"
-        ],
-        [
-          "Butler Paul",
-          "Volker Bogdan"
-        ],
-        [
-          "Dick Perry",
-          "Ernst Hilbich"
-        ],
-        [
-          "Polizist",
-          "Frank Thannhäuser"
-        ],
-        [
-          "Aufsicht",
-          "Patrick Bach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. O'Sullivan",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Butler Paul",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Dick Perry",
+          "sprecher" : "Ernst H. Hilbich"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Frank Thannhäuser"
+        },
+        {
+          "rolle" : "Aufsicht",
+          "sprecher" : "Patrick Bach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/124/metadata.json",
@@ -14140,55 +14224,56 @@
               "end" : 4488347
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Brittany",
-              "Dorette Hugo"
-            ],
-            [
-              "Hugenay",
-              "Albert Giro"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Jaccard (Off-Stimme)",
-              "Douglas Welbat"
-            ],
-            [
-              "Andy Miller",
-              "Jannik Endemann"
-            ],
-            [
-              "Sharon Lockwood",
-              "Nova Meierhenrich"
-            ],
-            [
-              "Moderator",
-              "Holger Wemhoff"
-            ],
-            [
-              "Rubbish George",
-              "Utz Richter"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Brittany",
+              "sprecher" : "Dorette Hugo"
+            },
+            {
+              "rolle" : "Hugenay",
+              "sprecher" : "Wolfgang Kubach",
+              "pseudonym" : "Albert Giro"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Jaccard (Off-Stimme)",
+              "sprecher" : "Douglas Welbat"
+            },
+            {
+              "rolle" : "Andy Miller",
+              "sprecher" : "Jannik Endemann"
+            },
+            {
+              "rolle" : "Sharon Lockwood",
+              "sprecher" : "Nova Meierhenrich"
+            },
+            {
+              "rolle" : "Moderator",
+              "sprecher" : "Holger Wemhoff"
+            },
+            {
+              "rolle" : "Rubbish George",
+              "sprecher" : "Utz Richter"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/1/metadata.json",
@@ -14273,75 +14358,77 @@
               "end" : 4166213
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Brittany",
-              "Dorette Hugo"
-            ],
-            [
-              "Hugenay",
-              "Albert Giro"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Graham, Reporter",
-              "Thomas Bammer"
-            ],
-            [
-              "Julianne Wallace",
-              "Marlen Diekhoff"
-            ],
-            [
-              "Sharon Lockwood",
-              "Nova Meierhenrich"
-            ],
-            [
-              "Moderator",
-              "Holger Wemhoff"
-            ],
-            [
-              "Polizist 1",
-              "Fabian Harloff"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Mrs. Albright",
-              "Lotti Krekel"
-            ],
-            [
-              "Mr. Myers",
-              "Eberhard Haar"
-            ],
-            [
-              "LKW-Fahrer",
-              "Nick Heidfeld"
-            ],
-            [
-              "Onkel Titus Jonas",
-              "Hans Meinhardt"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Brittany",
+              "sprecher" : "Dorette Hugo"
+            },
+            {
+              "rolle" : "Hugenay",
+              "sprecher" : "Wolfgang Kubach",
+              "pseudonym" : "Albert Giro"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Graham, Reporter",
+              "sprecher" : "Thomas Bammer"
+            },
+            {
+              "rolle" : "Julianne Wallace",
+              "sprecher" : "Marlen Diekhoff"
+            },
+            {
+              "rolle" : "Sharon Lockwood",
+              "sprecher" : "Nova Meierhenrich"
+            },
+            {
+              "rolle" : "Moderator",
+              "sprecher" : "Holger Wemhoff"
+            },
+            {
+              "rolle" : "Polizist 1",
+              "sprecher" : "Fabian Harloff"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Mrs. Albright",
+              "sprecher" : "Lotti Krekel"
+            },
+            {
+              "rolle" : "Mr. Myers",
+              "sprecher" : "Eberhard Haar"
+            },
+            {
+              "rolle" : "LKW-Fahrer",
+              "sprecher" : "Nick Heidfeld"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/2/metadata.json",
@@ -14436,75 +14523,77 @@
               "end" : 4464547
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Brittany",
-              "Dorette Hugo"
-            ],
-            [
-              "Hugenay",
-              "Albert Giro"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Julianne Wallace",
-              "Marlen Diekhoff"
-            ],
-            [
-              "Charles Knox",
-              "Dirk Bach"
-            ],
-            [
-              "Moderator",
-              "Holger Wemhoff"
-            ],
-            [
-              "Polizist 2",
-              "Erik Schäffler"
-            ],
-            [
-              "Ansager",
-              "Bertram Hiese"
-            ],
-            [
-              "Mr. Myers",
-              "Eberhard Haar"
-            ],
-            [
-              "Nachtschatten",
-              "Frank Tannhäuser"
-            ],
-            [
-              "Onkel Titus Jonas",
-              "Hans Meinhardt"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Mr. Baker",
-              "Wolf Pahls"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Brittany",
+              "sprecher" : "Dorette Hugo"
+            },
+            {
+              "rolle" : "Hugenay",
+              "sprecher" : "Wolfgang Kubach",
+              "pseudonym" : "Albert Giro"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Julianne Wallace",
+              "sprecher" : "Marlen Diekhoff"
+            },
+            {
+              "rolle" : "Charles Knox",
+              "sprecher" : "Dirk Bach"
+            },
+            {
+              "rolle" : "Moderator",
+              "sprecher" : "Holger Wemhoff"
+            },
+            {
+              "rolle" : "Polizist 2",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Ansager",
+              "sprecher" : "Bertram Hiese"
+            },
+            {
+              "rolle" : "Mr. Myers",
+              "sprecher" : "Eberhard Haar"
+            },
+            {
+              "rolle" : "Nachtschatten",
+              "sprecher" : "Frank Thannhäuser"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Mr. Baker",
+              "sprecher" : "Wolf Pahlke"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/3/metadata.json",
@@ -14518,111 +14607,113 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Rätselhafte Briefe eines verstorbenen Malers bringen die drei ??? auf die Spur eines verschollenes Gemäldes … Und der Gegenspieler der Detektive aus Rocky Beach ist kein Geringerer als der französische Meisterdieb Victor Hugenay! Wem wird es gelingen, Feuermond zu finden und das in dem Gemälde verborgene große Geheimnis zu lüften?",
       "veröffentlichungsdatum" : "2008-10-10",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Andy Miller",
-          "Jannik Endemann"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Ansager",
-          "Bertram Hiese"
-        ],
-        [
-          "Graham, Reporter",
-          "Thomas Bammer"
-        ],
-        [
-          "Julianne Wallace",
-          "Marlen Diekhoff"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro"
-        ],
-        [
-          "Moderator",
-          "Holger Wemhoff"
-        ],
-        [
-          "Charles Knox",
-          "Dirk Bach"
-        ],
-        [
-          "Mr. Myers",
-          "Eberhard Haar"
-        ],
-        [
-          "Nachtschatten",
-          "Frank Tannhäuser"
-        ],
-        [
-          "Brittany",
-          "Dorette Hugo"
-        ],
-        [
-          "Sharon Lockwood",
-          "Nova Meierhenrich"
-        ],
-        [
-          "Mrs. Albright",
-          "Lotti Krekel"
-        ],
-        [
-          "Jaccard (Off-Stimme)",
-          "Douglas Welbat"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Polizist 1",
-          "Fabian Harloff"
-        ],
-        [
-          "Polizist 2",
-          "Erik Schäffler"
-        ],
-        [
-          "LKW-Fahrer",
-          "Nick Heidfeld"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Rubbish George",
-          "Utz Richter"
-        ],
-        [
-          "Mr. Baker",
-          "Wolf Pahls"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Andy Miller",
+          "sprecher" : "Jannik Endemann"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Ansager",
+          "sprecher" : "Bertram Hiese"
+        },
+        {
+          "rolle" : "Graham, Reporter",
+          "sprecher" : "Thomas Bammer"
+        },
+        {
+          "rolle" : "Julianne Wallace",
+          "sprecher" : "Marlen Diekhoff"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Moderator",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Charles Knox",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "Mr. Myers",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Nachtschatten",
+          "sprecher" : "Frank Thannhäuser"
+        },
+        {
+          "rolle" : "Brittany",
+          "sprecher" : "Dorette Hugo"
+        },
+        {
+          "rolle" : "Sharon Lockwood",
+          "sprecher" : "Nova Meierhenrich"
+        },
+        {
+          "rolle" : "Mrs. Albright",
+          "sprecher" : "Lotti Krekel"
+        },
+        {
+          "rolle" : "Jaccard (Off-Stimme)",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "LKW-Fahrer",
+          "sprecher" : "Nick Heidfeld"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Mr. Baker",
+          "sprecher" : "Wolf Pahlke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/125/metadata.json",
@@ -14695,51 +14786,51 @@
           "end" : 3992933
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dr. Chandler",
-          "Wolf Pahlke"
-        ],
-        [
-          "Max",
-          "Sven Dahlem"
-        ],
-        [
-          "Austin",
-          "Patrick Bach"
-        ],
-        [
-          "Dwain",
-          "Tim Knauer"
-        ],
-        [
-          "Mr. Monroe",
-          "Jochen Regelin"
-        ],
-        [
-          "Professor Rosenberg",
-          "Lothar Grützner"
-        ],
-        [
-          "Papagei",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dr. Chandler",
+          "sprecher" : "Wolf Pahlke"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Austin",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Dwain",
+          "sprecher" : "Tim Knauer"
+        },
+        {
+          "rolle" : "Mr. Monroe",
+          "sprecher" : "Joachim Regelien"
+        },
+        {
+          "rolle" : "Professor Rosenberg",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/126/metadata.json",
@@ -14819,63 +14910,63 @@
           "end" : 4390653
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "José",
-          "Patrick Bach"
-        ],
-        [
-          "Steve Bright",
-          "Marek Erhardt"
-        ],
-        [
-          "Brian Smith",
-          "Christian Rode"
-        ],
-        [
-          "Martin",
-          "Jesse Grimm"
-        ],
-        [
-          "Wächter",
-          "Sven Dahlem"
-        ],
-        [
-          "Mrs. Osborne",
-          "Anja Nejarri"
-        ],
-        [
-          "Mr. Pentecost",
-          "Wolf Frass"
-        ],
-        [
-          "Senora Gonzalez",
-          "Susanne von Loessl"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "José",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Steve Bright",
+          "sprecher" : "Marek Erhardt"
+        },
+        {
+          "rolle" : "Brian Smith",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Martin",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Wächter",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Mrs. Osborne",
+          "sprecher" : "Anja Nejarri"
+        },
+        {
+          "rolle" : "Mr. Pentecost",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Senora Gonzalez",
+          "sprecher" : "Susanne von Loessl"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/127/metadata.json",
@@ -14955,51 +15046,51 @@
           "end" : 4412907
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs Bennett",
-          "Renate Pichler"
-        ],
-        [
-          "Wächter",
-          "Marek Erhardt"
-        ],
-        [
-          "Crowle",
-          "Christian Rudolf"
-        ],
-        [
-          "Casey Wye",
-          "Gisela Trowe"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Oliver Taper",
-          "Gosta Liptow"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Bennett",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Wächter",
+          "sprecher" : "Marek Erhardt"
+        },
+        {
+          "rolle" : "Crowle",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Casey Wye",
+          "sprecher" : "Gisela Trowe"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Oliver Taper",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/128/metadata.json",
@@ -15104,79 +15195,79 @@
           "end" : 4734387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Layla",
-          "Saskia Weckler"
-        ],
-        [
-          "Alaa Edine",
-          "Robert Missler"
-        ],
-        [
-          "Abazza",
-          "Abdul Kader-Diab"
-        ],
-        [
-          "Kamelhändler",
-          "Wolf Frass"
-        ],
-        [
-          "Kamelführer",
-          "Fathi Farnazmatis"
-        ],
-        [
-          "Wärter",
-          "Gosta Liptow"
-        ],
-        [
-          "Ägypter",
-          "Lothar Grützner"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Rubbish George",
-          "Utz Richter"
-        ],
-        [
-          "Kommissar",
-          "Klaus Dittmann"
-        ],
-        [
-          "Aisha",
-          "Susanne von Loessl"
-        ],
-        [
-          "Verkäufer",
-          "Farhat Al Yhi"
-        ],
-        [
-          "Dick Vincent",
-          "Holger Löwenberg"
-        ],
-        [
-          "Taxifahrer",
-          "Wolf Pahlke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Layla",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Alaa Edine",
+          "sprecher" : "Abdul Kader-Diab"
+        },
+        {
+          "rolle" : "Abazza",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Kamelhändler",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Kamelführer",
+          "sprecher" : "Fathi Farnazmatis"
+        },
+        {
+          "rolle" : "Wärter",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Ägypter",
+          "sprecher" : "Lothar Grützner"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Kommissar",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Aisha",
+          "sprecher" : "Susanne von Loessl"
+        },
+        {
+          "rolle" : "Verkäufer",
+          "sprecher" : "Farhat Al Yhi"
+        },
+        {
+          "rolle" : "Dick Vincent",
+          "sprecher" : "Holger Löwenberg"
+        },
+        {
+          "rolle" : "Taxifahrer",
+          "sprecher" : "Wolf Pahlke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/129/metadata.json",
@@ -15276,63 +15367,64 @@
           "end" : 4112560
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Beverly Leung",
-          "Susanne Stangl"
-        ],
-        [
-          "Thomas Johnson",
-          "Lutz Herkenrath"
-        ],
-        [
-          "1. Polizist",
-          "Robert Missler"
-        ],
-        [
-          "2. Polizist",
-          "Edgar Hoppe"
-        ],
-        [
-          "James",
-          "Sönke Städtler"
-        ],
-        [
-          "Daniel Baker",
-          "Sascha Rotermund"
-        ],
-        [
-          "Mr. Grogan",
-          "Günter Flesch"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Beverly Leung",
+          "sprecher" : "Susanne Stangl"
+        },
+        {
+          "rolle" : "Thomas Johnson",
+          "sprecher" : "Lutz Herkenrath"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Edgar Hoppe"
+        },
+        {
+          "rolle" : "James",
+          "sprecher" : "Sönke Städtler"
+        },
+        {
+          "rolle" : "Daniel Baker",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Mr. Grogan",
+          "sprecher" : "Günther Flesch"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/130/metadata.json",
@@ -15397,59 +15489,59 @@
           "end" : 4242960
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Lloyd Scavenger",
-          "Stefan Benson"
-        ],
-        [
-          "Jack Lowell",
-          "Siegfried Kernen"
-        ],
-        [
-          "Alexander Nolan",
-          "Wilfried Hochholdinger"
-        ],
-        [
-          "Jaqueline Williams",
-          "Henrike Fehrs"
-        ],
-        [
-          "Ian Parsley",
-          "Jörg Gillner"
-        ],
-        [
-          "Mary Parsley",
-          "Karin Abicht"
-        ],
-        [
-          "Jasper Kittle",
-          "Peter Weis"
-        ],
-        [
-          "Shawne Davison",
-          "Susanne Lothar"
-        ],
-        [
-          "Officer Wood",
-          "Roman Kretschmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Lloyd Scavenger",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Jack Lowell",
+          "sprecher" : "Siegfried W. Kernen"
+        },
+        {
+          "rolle" : "Alexander Nolan",
+          "sprecher" : "Wilfried Hochholdinger"
+        },
+        {
+          "rolle" : "Jaqueline Williams",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Ian Parsley",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Mary Parsley",
+          "sprecher" : "Carin Abicht"
+        },
+        {
+          "rolle" : "Jasper Kittle",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Shawne Davison",
+          "sprecher" : "Susanne Lothar"
+        },
+        {
+          "rolle" : "Officer Wood",
+          "sprecher" : "Roman Kretschmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/131/metadata.json",
@@ -15514,71 +15606,71 @@
           "end" : 3799387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Miss Bennett",
-          "Renate Pichler"
-        ],
-        [
-          "Karen",
-          "Celine Fontange"
-        ],
-        [
-          "Becky",
-          "Katharina v. Keller"
-        ],
-        [
-          "Felicia Sparing",
-          "Rhea Harder"
-        ],
-        [
-          "Mrs. Amelia Sparing",
-          "Karin Buchholz"
-        ],
-        [
-          "Mr. Sparing",
-          "Sky du Mont"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Professor Alkurah",
-          "Ben Hecker"
-        ],
-        [
-          "Eroll",
-          "Bertram Hiese"
-        ],
-        [
-          "Mrs. Featherstone",
-          "Sabine Hahn"
-        ],
-        [
-          "Wärter",
-          "Jürgen Holdorf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Miss Bennett",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Karen",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Becky",
+          "sprecher" : "Katharina von Keller"
+        },
+        {
+          "rolle" : "Felicia Sparing",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Mrs. Amelia Sparing",
+          "sprecher" : "Karin Buchholz"
+        },
+        {
+          "rolle" : "Mr. Sparing",
+          "sprecher" : "Sky du Mont"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Professor Alkurah",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Eroll",
+          "sprecher" : "Bertram Hiese"
+        },
+        {
+          "rolle" : "Mrs. Featherstone",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Wärter",
+          "sprecher" : "Jürgen Holdorf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/132/metadata.json",
@@ -15643,59 +15735,59 @@
           "end" : 3473893
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sergeant Ludlow",
-          "Dietmar Mues"
-        ],
-        [
-          "Banden-Chef",
-          "Eberhard Haar"
-        ],
-        [
-          "Eddy Reardon",
-          "Lukas Sperber"
-        ],
-        [
-          "Spanier",
-          "Erik Schäffler"
-        ],
-        [
-          "Jack",
-          "Fabian Harloff"
-        ],
-        [
-          "Italiener",
-          "Lutz Harder"
-        ],
-        [
-          "Gauner",
-          "Sven Dahlem"
-        ],
-        [
-          "Gehilfe",
-          "Gerhart Hinze"
-        ],
-        [
-          "Polizist",
-          "Bertram Hiese"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sergeant Ludlow",
+          "sprecher" : "Dietmar Mues"
+        },
+        {
+          "rolle" : "Banden-Chef",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Eddy Reardon",
+          "sprecher" : "Lukas T. Sperber"
+        },
+        {
+          "rolle" : "Spanier",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Italiener",
+          "sprecher" : "Lutz Harder"
+        },
+        {
+          "rolle" : "Gauner",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Gehilfe",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Bertram Hiese"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/133/metadata.json",
@@ -15780,51 +15872,51 @@
           "end" : 4029587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Christine",
-          "Inken Sommer"
-        ],
-        [
-          "Mr. Bambridge",
-          "Gustav-Adolph Artz"
-        ],
-        [
-          "Lo Wang",
-          "Dae Joon Yoo"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Anthony Hearst",
-          "Wolfgang Pampel"
-        ],
-        [
-          "Truck-Fahrer",
-          "Konstantin Graudus"
-        ],
-        [
-          "Avercromby",
-          "Nicolas König"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Christine",
+          "sprecher" : "Inken Sommer"
+        },
+        {
+          "rolle" : "Mr. Bambridge",
+          "sprecher" : "Gustav-Adolph Artz"
+        },
+        {
+          "rolle" : "Lo Wang",
+          "sprecher" : "Dae Joon Yoo"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Anthony Hearst",
+          "sprecher" : "Wolfgang Pampel"
+        },
+        {
+          "rolle" : "Truck-Fahrer",
+          "sprecher" : "Konstantin Graudus"
+        },
+        {
+          "rolle" : "Avercromby",
+          "sprecher" : "Nicolas König"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/134/metadata.json",
@@ -15929,47 +16021,47 @@
           "end" : 4271013
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Pilot",
-          "Gerhart Hinze"
-        ],
-        [
-          "Max",
-          "Traudel Sperber"
-        ],
-        [
-          "Liolotta",
-          "Peter Striebeck"
-        ],
-        [
-          "Althena",
-          "Steffi Kirchberger"
-        ],
-        [
-          "Sarah Livingston",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Elvira Zuckerman",
-          "Konstanze Ullmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Pilot",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Liolotta",
+          "sprecher" : "Peter Striebeck"
+        },
+        {
+          "rolle" : "Althena",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Sarah Livingston",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Elvira Zuckerman",
+          "sprecher" : "Konstanze Ullmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/135/metadata.json",
@@ -16054,63 +16146,63 @@
           "end" : 4117027
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Darren Duff",
-          "Jesse Grimm"
-        ],
-        [
-          "Taucher Carl",
-          "Oliver Böttcher"
-        ],
-        [
-          "Taucherin Joan",
-          "Christine Pappert"
-        ],
-        [
-          "Paul Brooks",
-          "Heinz Lieven"
-        ],
-        [
-          "Joe Wilcox",
-          "Rolf Becker"
-        ],
-        [
-          "Cassandra Wilcox",
-          "Elke Reissert"
-        ],
-        [
-          "Daniel",
-          "Jochen Baumert"
-        ],
-        [
-          "Henry",
-          "Frank Felicetti"
-        ],
-        [
-          "Doktor Holloway",
-          "Barbara Focke"
-        ],
-        [
-          "Cedric Duff",
-          "Rolf E. Schenker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Darren Duff",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Taucher Carl",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Taucherin Joan",
+          "sprecher" : "Christine Pappert"
+        },
+        {
+          "rolle" : "Paul Brooks",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Joe Wilcox",
+          "sprecher" : "Rolf Becker"
+        },
+        {
+          "rolle" : "Cassandra Wilcox",
+          "sprecher" : "Elke Reissert"
+        },
+        {
+          "rolle" : "Daniel",
+          "sprecher" : "Jochen Baumert"
+        },
+        {
+          "rolle" : "Henry",
+          "sprecher" : "Frank Felicetti"
+        },
+        {
+          "rolle" : "Doktor Holloway",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Cedric Duff",
+          "sprecher" : "Rolf E. Schenker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/136/metadata.json",
@@ -16195,47 +16287,47 @@
           "end" : 4653507
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Winston Granville",
-          "Christian Rode"
-        ],
-        [
-          "Matthew Granville",
-          "Uwe Friedrichsen"
-        ],
-        [
-          "Smithy",
-          "Konstantin Graudus"
-        ],
-        [
-          "Mr. Jackmore",
-          "Michael Brennicke"
-        ],
-        [
-          "Professor Frazier",
-          "Wilhelm Wieben"
-        ],
-        [
-          "Polizist",
-          "Tetje Mierendorf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Winston Granville",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Matthew Granville",
+          "sprecher" : "Uwe Friedrichsen"
+        },
+        {
+          "rolle" : "Smithy",
+          "sprecher" : "Konstantin Graudus"
+        },
+        {
+          "rolle" : "Mr. Jackmore",
+          "sprecher" : "Michael Brennicke"
+        },
+        {
+          "rolle" : "Professor Frazier",
+          "sprecher" : "Wilhelm Wieben"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Tetje Mierendorf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/137/metadata.json",
@@ -16320,39 +16412,39 @@
           "end" : 3987133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Davy Swann",
-          "Thorsten Sense"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Craig Holden",
-          "Gerhard Olschewski"
-        ],
-        [
-          "Löwenritter",
-          "Burghart Klaußner"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Davy Swann",
+          "sprecher" : "Torsten Sense"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Craig Holden",
+          "sprecher" : "Gerhard Olschewski"
+        },
+        {
+          "rolle" : "Löwenritter",
+          "sprecher" : "Burghart Klaußner"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/138/metadata.json",
@@ -16432,79 +16524,80 @@
           "end" : 3860747
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Helena Darraz",
-          "Ingrid Andree"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Pritchard",
-          "Sascha Rotermund"
-        ],
-        [
-          "Sid",
-          "Tilman Madaus"
-        ],
-        [
-          "Caroline",
-          "Celine Fontanges"
-        ],
-        [
-          "Sandy",
-          "Simona Pahl"
-        ],
-        [
-          "Steven",
-          "René Dawn-Claude"
-        ],
-        [
-          "Ernest",
-          "Tim Kreuer"
-        ],
-        [
-          "Radioansagerin",
-          "Susanne Wulkow"
-        ],
-        [
-          "Harvey Griscom",
-          "Christian Rudolf"
-        ],
-        [
-          "John Dellcourt",
-          "Gustav Adolph Artz"
-        ],
-        [
-          "Miss Darraz",
-          "Sabine Hahn"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Helena Darraz",
+          "sprecher" : "Ingrid Andree"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Pritchard",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Sid",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Caroline",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Sandy",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Steven",
+          "sprecher" : "René Dawn-Claude"
+        },
+        {
+          "rolle" : "Ernest",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Radioansagerin",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Harvey Griscom",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "John Dellcourt",
+          "sprecher" : "Gustav Adolph Artz"
+        },
+        {
+          "rolle" : "Miss Darraz",
+          "sprecher" : "Sabine Hahn"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/139/metadata.json",
@@ -16579,59 +16672,59 @@
           "end" : 4658533
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Josy McDonaghough",
-          "Lili Draeger"
-        ],
-        [
-          "Homer Diesel",
-          "Christian Senger"
-        ],
-        [
-          "Mary Stamper",
-          "Annabelle Krieg"
-        ],
-        [
-          "Otis Stamper",
-          "Klaus Dittman"
-        ],
-        [
-          "Jonathan Black",
-          "Eckart Dux"
-        ],
-        [
-          "Miles Black",
-          "Sascha Rotermund"
-        ],
-        [
-          "Klara Kowalski",
-          "Steffi Kirchberger"
-        ],
-        [
-          "Silvester Proud",
-          "Gustav A. Artz"
-        ],
-        [
-          "Pfarrer Clark",
-          "Gerd Baltus"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Josy McDonaghough",
+          "sprecher" : "Lili Draeger"
+        },
+        {
+          "rolle" : "Homer Diesel",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Mary Stamper",
+          "sprecher" : "Annabelle Krieg"
+        },
+        {
+          "rolle" : "Otis Stamper",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Jonathan Black",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Miles Black",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Klara Kowalski",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Silvester Proud",
+          "sprecher" : "Gustav Adolph Artz"
+        },
+        {
+          "rolle" : "Pfarrer Clark",
+          "sprecher" : "Gerd Baltus"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/140/metadata.json",
@@ -16716,71 +16809,72 @@
           "end" : 3562347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Jeffrey Seaman",
-          "Daniel Welbat"
-        ],
-        [
-          "Steven",
-          "Oliver Böttcher"
-        ],
-        [
-          "Eric",
-          "Patrick Bach"
-        ],
-        [
-          "Mr. Settler",
-          "Christian Senger"
-        ],
-        [
-          "Auktionator",
-          "Achim Schülke"
-        ],
-        [
-          "Frau",
-          "Hilla Fitzen"
-        ],
-        [
-          "Patrick O'Brian",
-          "Wolfgang Riehm"
-        ],
-        [
-          "William de Haas",
-          "Jörg Gillner"
-        ],
-        [
-          "Theodor Brewster",
-          "Tobias Meister"
-        ],
-        [
-          "Butler",
-          "Olaf Kreuzenbeck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Jeffrey Seaman",
+          "sprecher" : "Daniel Welbat"
+        },
+        {
+          "rolle" : "Steven",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Eric",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Mr. Settler",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Auktionator",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Hilla Fitzen"
+        },
+        {
+          "rolle" : "Patrick O'Brian",
+          "sprecher" : "Wolfgang Riehm"
+        },
+        {
+          "rolle" : "William de Haas",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Theodor Brewster",
+          "sprecher" : "Tobias Meister"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Olaf Kreutzenbeck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/141/metadata.json",
@@ -16865,79 +16959,79 @@
           "end" : 3437227
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Carol Ford",
-          "Claudia Schermutzki"
-        ],
-        [
-          "Francis Studstill",
-          "Elena Wilms"
-        ],
-        [
-          "Baxter Norsworthy",
-          "Udo Schenk"
-        ],
-        [
-          "Gordon Hoke",
-          "Holger Löwenberg"
-        ],
-        [
-          "Jared Fox",
-          "Meik Spallek"
-        ],
-        [
-          "Candace Duskin",
-          "Andrea Linau"
-        ],
-        [
-          "George Bennet",
-          "Urs Affolter"
-        ],
-        [
-          "Greg Harper",
-          "Robert Missler"
-        ],
-        [
-          "Woodland",
-          "Jürgen Thormann"
-        ],
-        [
-          "Reporterin",
-          "Jamie Leaves"
-        ],
-        [
-          "Reporter",
-          "Glenn Goltz"
-        ],
-        [
-          "Wellford",
-          "Oliver Geilhardt"
-        ],
-        [
-          "Pilot",
-          "Achim Schülke"
-        ],
-        [
-          "Lautsprecherstimme",
-          "Sascha Draeger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Carol Ford",
+          "sprecher" : "Claudia Schermutzki"
+        },
+        {
+          "rolle" : "Francis Studstill",
+          "sprecher" : "Elena Wilms"
+        },
+        {
+          "rolle" : "Baxter Norsworthy",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Gordon Hoke",
+          "sprecher" : "Holger Löwenberg"
+        },
+        {
+          "rolle" : "Jared Fox",
+          "sprecher" : "Meik Spallek"
+        },
+        {
+          "rolle" : "Candace Duskin",
+          "sprecher" : "Andrea Lienau"
+        },
+        {
+          "rolle" : "George Bennet",
+          "sprecher" : "Urs Affolter"
+        },
+        {
+          "rolle" : "Greg Harper",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Woodland",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Reporterin",
+          "sprecher" : "Jamie Leaves"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Glenn Goltz"
+        },
+        {
+          "rolle" : "Wellford",
+          "sprecher" : "Oliver Geilhardt"
+        },
+        {
+          "rolle" : "Pilot",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Lautsprecherstimme",
+          "sprecher" : "Sascha Draeger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/142/metadata.json",
@@ -17012,55 +17106,55 @@
           "end" : 3621920
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Richie Hanson",
-          "Dennis Schmidt-Foß"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Benni",
-          "Ivo Möller"
-        ],
-        [
-          "Jacki Jin",
-          "Robert Missler"
-        ],
-        [
-          "Kellnerin",
-          "Corinna Wodrich"
-        ],
-        [
-          "Croupier",
-          "Dirk Bach"
-        ],
-        [
-          "Mann",
-          "Arndt Schmöle"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Richie Hanson",
+          "sprecher" : "Dennis Schmidt-Foß"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Benni",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Jacki Jin",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Croupier",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Arndt Schmöle"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/143/metadata.json",
@@ -17145,55 +17239,56 @@
           "end" : 4256000
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Arthur Sinclair",
-          "Joachim Pukaß"
-        ],
-        [
-          "Mr. Peastone",
-          "Eberhard Haar"
-        ],
-        [
-          "Jeremy Witherspoon",
-          "Martin Semmelrogge"
-        ],
-        [
-          "Barnaby Witherspoon",
-          "Achim Schülke"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Godwin",
-          "André Minninger"
-        ],
-        [
-          "Mann",
-          "Holger Löwenberg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Arthur Sinclair",
+          "sprecher" : "Joachim Pukaß"
+        },
+        {
+          "rolle" : "Mr. Peastone",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Jeremy Witherspoon",
+          "sprecher" : "Martin Semmelrogge"
+        },
+        {
+          "rolle" : "Barnaby Witherspoon",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Holger Löwenberg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/144/metadata.json",
@@ -17273,55 +17368,55 @@
           "end" : 3722547
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Takasi Yukawa",
-          "Wilfried Diallaz"
-        ],
-        [
-          "Frank Hektor",
-          "Michael Lott"
-        ],
-        [
-          "Sean Doherty",
-          "Leonhard Mahlich"
-        ],
-        [
-          "Mandy",
-          "Jasmin Wagner"
-        ],
-        [
-          "Zeno Daniels",
-          "Philipp Baltus"
-        ],
-        [
-          "Percy",
-          "Jesse Grimm"
-        ],
-        [
-          "Keko",
-          "Jens Wendland"
-        ],
-        [
-          "Anthony Fender",
-          "Peter Buchholz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Takasi Yukawa",
+          "sprecher" : "Wilfried Dziallas"
+        },
+        {
+          "rolle" : "Frank Hektor",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Sean Doherty",
+          "sprecher" : "Leonhard Mahlich"
+        },
+        {
+          "rolle" : "Mandy",
+          "sprecher" : "Jasmin Wagner"
+        },
+        {
+          "rolle" : "Zeno Daniels",
+          "sprecher" : "Philipp Baltus"
+        },
+        {
+          "rolle" : "Percy",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Keko",
+          "sprecher" : "Jens Wendland"
+        },
+        {
+          "rolle" : "Anthony Fender",
+          "sprecher" : "Peter Buchholz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/145/metadata.json",
@@ -17421,79 +17516,80 @@
           "end" : 3430360
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Quentin Wadleigh",
-          "Christian Rudolf"
-        ],
-        [
-          "Dr. Winston Wadleigh",
-          "Mathias Münster"
-        ],
-        [
-          "Dr. John Frears",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Jamie",
-          "Philipp Draeger"
-        ],
-        [
-          "Sammy",
-          "Jacob Mayerhoff"
-        ],
-        [
-          "Mrs. Pitkätossu",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Jackall Madson",
-          "Ingo Nommsen"
-        ],
-        [
-          "Tiger Madson",
-          "Dieter Dücker"
-        ],
-        [
-          "Vivian",
-          "Saskia Mayerhoff"
-        ],
-        [
-          "Fitzwilliam Waterfield",
-          "Wolfgang Völz"
-        ],
-        [
-          "Sanitäter",
-          "Robin Brosch"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Quentin Wadleigh",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Dr. Winston Wadleigh",
+          "sprecher" : "Mathias Münster"
+        },
+        {
+          "rolle" : "Dr. John Frears",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Jamie",
+          "sprecher" : "Philipp Draeger"
+        },
+        {
+          "rolle" : "Sammy",
+          "sprecher" : "Jacob Mayerhoff"
+        },
+        {
+          "rolle" : "Mrs. Pitkätossu",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Jackall Madson",
+          "sprecher" : "Ingo Nommsen"
+        },
+        {
+          "rolle" : "Tiger Madson",
+          "sprecher" : "Dieter Dücker"
+        },
+        {
+          "rolle" : "Vivian",
+          "sprecher" : "Saskia Mayerhoff"
+        },
+        {
+          "rolle" : "Fitzwilliam Waterfield",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Robin Brosch"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/146/metadata.json",
@@ -17558,71 +17654,71 @@
           "end" : 3770533
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Adam Campbell",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Henry Campbell",
-          "Christian Rudolf"
-        ],
-        [
-          "John Taylor",
-          "Holger Umbreit"
-        ],
-        [
-          "Edward Crockett",
-          "Ben Hecker"
-        ],
-        [
-          "Mrs. Harkort",
-          "Katja Brügger"
-        ],
-        [
-          "Mr. Prescott",
-          "Stefan Kaminski"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Jack Leech",
-          "Volker Bogdan"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Einbrecher",
-          "Patrick Bach"
-        ],
-        [
-          "Max",
-          "Tommaso Cacciapuoti"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Adam Campbell",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Henry Campbell",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "John Taylor",
+          "sprecher" : "Holger Umbreit"
+        },
+        {
+          "rolle" : "Edward Crockett",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Mrs. Harkort",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Mr. Prescott",
+          "sprecher" : "Stefan Kaminski"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Jack Leech",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Einbrecher",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Tommaso Cacciapuoti"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/147/metadata.json",
@@ -17687,55 +17783,55 @@
           "end" : 4011933
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Allie Jamison",
-          "Katrin Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Ursula Burns",
-          "Birke Bruck"
-        ],
-        [
-          "Emerald Pendragon",
-          "Monty Arnold"
-        ],
-        [
-          "Carl Parsley",
-          "Peter Weis"
-        ],
-        [
-          "Sunshine",
-          "Dagmar Dreke"
-        ],
-        [
-          "1. Mann",
-          "Tetje Mierendorf"
-        ],
-        [
-          "2. Mann",
-          "Gosta Liptow"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Allie Jamison",
+          "sprecher" : "Katrin Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Ursula Burns",
+          "sprecher" : "Birke Bruck"
+        },
+        {
+          "rolle" : "Emerald Pendragon",
+          "sprecher" : "Monty Arnold"
+        },
+        {
+          "rolle" : "Carl Parsley",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Sunshine",
+          "sprecher" : "Dagmar Dreke"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Tetje Mierendorf"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Gosta Liptow"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/148/metadata.json",
@@ -17825,71 +17921,71 @@
           "end" : 3717773
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Cynthia McGowan",
-          "Luise Lunow"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Mrs. Andrews",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mina Parker",
-          "Annabelle Krieg"
-        ],
-        [
-          "Brandon Fraser",
-          "Tim Grobe"
-        ],
-        [
-          "Beatrix Fraser",
-          "Sophie Lechtenbrink"
-        ],
-        [
-          "Roxy",
-          "Julia Fölster"
-        ],
-        [
-          "Josh",
-          "Volker Hanisch"
-        ],
-        [
-          "Paul",
-          "Tim Kreuer"
-        ],
-        [
-          "Davis",
-          "Frank Meyer-Brockmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Cynthia McGowan",
+          "sprecher" : "Luise Lunow"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mina Parker",
+          "sprecher" : "Annabelle Krieg"
+        },
+        {
+          "rolle" : "Brandon Fraser",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Beatrix Fraser",
+          "sprecher" : "Sophie Lechtenbrink"
+        },
+        {
+          "rolle" : "Roxy",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Josh",
+          "sprecher" : "Volker Hanisch"
+        },
+        {
+          "rolle" : "Paul",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Davis",
+          "sprecher" : "Frank Meyer-Brockmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/149/metadata.json",
@@ -17980,79 +18076,79 @@
               "end" : 4055093
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Frank Mason",
-              "Wolfgang Condrus"
-            ],
-            [
-              "Miles Dempster",
-              "Stephan Benson"
-            ],
-            [
-              "Mr. Sapchevsky",
-              "Andreas Schmidt-Schaller"
-            ],
-            [
-              "Gerry",
-              "Kostja Ullmann"
-            ],
-            [
-              "Ismael",
-              "Stephan Schad"
-            ],
-            [
-              "Carla Fenton",
-              "Natalie O'Hara"
-            ],
-            [
-              "Mrs. Maruthers",
-              "Ulrike Johannson"
-            ],
-            [
-              "Inspektor Havilland",
-              "Oliver Kalkofe"
-            ],
-            [
-              "Taylor",
-              "Bernhard Hoecker"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Angelica",
-              "Anna Thalbach"
-            ],
-            [
-              "Schwester 1",
-              "Manuela Becker"
-            ],
-            [
-              "Schwester 2",
-              "Traudel Sperber"
-            ],
-            [
-              "Pfleger",
-              "Sven Dahlem"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Frank Mason",
+              "sprecher" : "Wolfgang Condrus"
+            },
+            {
+              "rolle" : "Miles Dempster",
+              "sprecher" : "Stephan Benson"
+            },
+            {
+              "rolle" : "Mr. Sapchevsky",
+              "sprecher" : "Andreas Schmidt-Schaller"
+            },
+            {
+              "rolle" : "Gerry",
+              "sprecher" : "Kostja Ullmann"
+            },
+            {
+              "rolle" : "Ismael",
+              "sprecher" : "Stephan Schad"
+            },
+            {
+              "rolle" : "Carla Fenton",
+              "sprecher" : "Natalie O'Hara"
+            },
+            {
+              "rolle" : "Mrs. Maruthers",
+              "sprecher" : "Ulrike Johannson"
+            },
+            {
+              "rolle" : "Inspektor Havilland",
+              "sprecher" : "Oliver Kalkofe"
+            },
+            {
+              "rolle" : "Taylor",
+              "sprecher" : "Bernhard Hoëcker"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Angelica",
+              "sprecher" : "Anna Thalbach"
+            },
+            {
+              "rolle" : "Schwester 1",
+              "sprecher" : "Manuela Becker"
+            },
+            {
+              "rolle" : "Schwester 2",
+              "sprecher" : "Traudel Sperber"
+            },
+            {
+              "rolle" : "Pfleger",
+              "sprecher" : "Sven Dahlem"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/1/metadata.json",
@@ -18147,83 +18243,83 @@
               "end" : 4100240
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Taylor",
-              "Bernhard Hoecker"
-            ],
-            [
-              "Mr. Smith",
-              "Tim Grobe"
-            ],
-            [
-              "Curtis Fisher",
-              "Tobias Schmidt"
-            ],
-            [
-              "Amrita Chakyar",
-              "Angela Stresemann"
-            ],
-            [
-              "Inspektor Havilland",
-              "Oliver Kalkofe"
-            ],
-            [
-              "Ismael",
-              "Stephan Schad"
-            ],
-            [
-              "Angelica",
-              "Anna Thalbach"
-            ],
-            [
-              "Sergeant Madhu",
-              "Olli Dittrich"
-            ],
-            [
-              "Mr. Andrews",
-              "Henry König"
-            ],
-            [
-              "Mrs. Andrews",
-              "Konstanze Ullmer"
-            ],
-            [
-              "Frank Mason",
-              "Wolfgang Condrus"
-            ],
-            [
-              "Mr. Raffer",
-              "Harald Dietl"
-            ],
-            [
-              "Feuerwehrmann",
-              "Kai-Hendrik Möller"
-            ],
-            [
-              "Kapitän",
-              "Sky du Mont"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Taylor",
+              "sprecher" : "Bernhard Hoëcker"
+            },
+            {
+              "rolle" : "Mr. Smith",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Curtis Fisher",
+              "sprecher" : "Tobias Schmidt"
+            },
+            {
+              "rolle" : "Amrita Chakyar",
+              "sprecher" : "Angela Stresemann"
+            },
+            {
+              "rolle" : "Inspektor Havilland",
+              "sprecher" : "Oliver Kalkofe"
+            },
+            {
+              "rolle" : "Ismael",
+              "sprecher" : "Stephan Schad"
+            },
+            {
+              "rolle" : "Angelica",
+              "sprecher" : "Anna Thalbach"
+            },
+            {
+              "rolle" : "Sergeant Madhu",
+              "sprecher" : "Olli Dittrich"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Mrs. Andrews",
+              "sprecher" : "Konstanze Ullmer"
+            },
+            {
+              "rolle" : "Frank Mason",
+              "sprecher" : "Wolfgang Condrus"
+            },
+            {
+              "rolle" : "Mr. Raffer",
+              "sprecher" : "Harald Dietl"
+            },
+            {
+              "rolle" : "Feuerwehrmann",
+              "sprecher" : "Kai Henrik Möller"
+            },
+            {
+              "rolle" : "Kapitän",
+              "sprecher" : "Sky du Mont"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/2/metadata.json",
@@ -18293,83 +18389,83 @@
               "end" : 3763400
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Frank Mason",
-              "Wolfgang Condrus"
-            ],
-            [
-              "Taylor",
-              "Bernhard Hoecker"
-            ],
-            [
-              "Curtis Fisher",
-              "Tobias Schmidt"
-            ],
-            [
-              "John Fisher",
-              "Dirk Bach"
-            ],
-            [
-              "Gerry",
-              "Kostja Ullmann"
-            ],
-            [
-              "Ismael",
-              "Stephan Schad"
-            ],
-            [
-              "Mr. Smith",
-              "Tim Grobe"
-            ],
-            [
-              "Mrs. Maruthers",
-              "Ulrike Johannson"
-            ],
-            [
-              "Angelica",
-              "Anna Thalbach"
-            ],
-            [
-              "Sergeant Madhu",
-              "Olli Dittrich"
-            ],
-            [
-              "Mr. Castro",
-              "Jörg Gillner"
-            ],
-            [
-              "Sanitäter",
-              "Robert Kottula"
-            ],
-            [
-              "Anudhara",
-              "Rosakutty Hemsing"
-            ],
-            [
-              "Ruth",
-              "Gabriele Libbach"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Frank Mason",
+              "sprecher" : "Wolfgang Condrus"
+            },
+            {
+              "rolle" : "Taylor",
+              "sprecher" : "Bernhard Hoëcker"
+            },
+            {
+              "rolle" : "Curtis Fisher",
+              "sprecher" : "Tobias Schmidt"
+            },
+            {
+              "rolle" : "John Fisher",
+              "sprecher" : "Dirk Bach"
+            },
+            {
+              "rolle" : "Gerry",
+              "sprecher" : "Kostja Ullmann"
+            },
+            {
+              "rolle" : "Ismael",
+              "sprecher" : "Stephan Schad"
+            },
+            {
+              "rolle" : "Mr. Smith",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Mrs. Maruthers",
+              "sprecher" : "Ulrike Johannson"
+            },
+            {
+              "rolle" : "Angelica",
+              "sprecher" : "Anna Thalbach"
+            },
+            {
+              "rolle" : "Sergeant Madhu",
+              "sprecher" : "Olli Dittrich"
+            },
+            {
+              "rolle" : "Mr. Castro",
+              "sprecher" : "Jörg Gillner"
+            },
+            {
+              "rolle" : "Sanitäter",
+              "sprecher" : "Robert Kotulla"
+            },
+            {
+              "rolle" : "Anudhara",
+              "sprecher" : "Rosakutty Hemsing"
+            },
+            {
+              "rolle" : "Ruth",
+              "sprecher" : "Gabriele Libbach"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/3/metadata.json",
@@ -18383,139 +18479,139 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Die drei ??? übernehmen und lösen (hoffentlich!) ihren 150sten Fall! In drei atemberaubenden Folgen sind sie dem Rätsel der Geisterbucht auf der Spur! Welches Geheimnis verbirgt sich hinter dem Testament, dass der exzentrische Harry Shreber kurz vor seinem Tod verfasst hat? Führen die verschlüsselten Verse tatsächlich zu Rashuras Schatz? (Teil A) Den drei Detektiven wird nichts anderes übrig bleiben: Sie müssen in Flammendes Wasser (Teil B) hinab tauchen, denn nur in der Tiefe des Meeres kann geklärt werden, warum Der brennende Kristall (Teil C) so viel Unglück über eine große Anzahl Menschen bringen konnte …",
       "veröffentlichungsdatum" : "2011-11-11",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Frank Mason",
-          "Wolfgang Condrus"
-        ],
-        [
-          "Miles Dempster",
-          "Stephan Benson"
-        ],
-        [
-          "Mr. Sapchevsky",
-          "Andreas Schmidt-Schaller"
-        ],
-        [
-          "Gerry",
-          "Kostja Ullmann"
-        ],
-        [
-          "Ismael",
-          "Stephan Schad"
-        ],
-        [
-          "Carla Fenton",
-          "Natalie O'Hara"
-        ],
-        [
-          "Mrs. Maruthers",
-          "Ulrike Johannson"
-        ],
-        [
-          "Inspektor Havilland",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Taylor",
-          "Bernhard Hoecker"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Angelica",
-          "Anna Thalbach"
-        ],
-        [
-          "Schwester 1",
-          "Manuela Becker"
-        ],
-        [
-          "Schwester 2",
-          "Traudel Sperber"
-        ],
-        [
-          "Pfleger",
-          "Sven Dahlem"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mr. Smith",
-          "Tim Grobe"
-        ],
-        [
-          "Curtis Fisher",
-          "Tobias Schmidt"
-        ],
-        [
-          "Amrita Chakyar",
-          "Angela Stresemann"
-        ],
-        [
-          "Sergeant Madhu",
-          "Olli Dittrich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Mrs. Andrews",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Mr. Raffer",
-          "Harald Dietl"
-        ],
-        [
-          "Feuerwehrmann",
-          "Kai-Hendrik Möller"
-        ],
-        [
-          "Kapitän",
-          "Sky du Mont"
-        ],
-        [
-          "John Fisher",
-          "Dirk Bach"
-        ],
-        [
-          "Mr. Castro",
-          "Jörg Gillner"
-        ],
-        [
-          "Sanitäter",
-          "Robert Kottula"
-        ],
-        [
-          "Anudhara",
-          "Rosakutty Hemsing"
-        ],
-        [
-          "Ruth",
-          "Gabriele Libbach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Frank Mason",
+          "sprecher" : "Wolfgang Condrus"
+        },
+        {
+          "rolle" : "Miles Dempster",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Mr. Sapchevsky",
+          "sprecher" : "Andreas Schmidt-Schaller"
+        },
+        {
+          "rolle" : "Gerry",
+          "sprecher" : "Kostja Ullmann"
+        },
+        {
+          "rolle" : "Ismael",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Carla Fenton",
+          "sprecher" : "Natalie O'Hara"
+        },
+        {
+          "rolle" : "Mrs. Maruthers",
+          "sprecher" : "Ulrike Johannson"
+        },
+        {
+          "rolle" : "Inspektor Havilland",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Taylor",
+          "sprecher" : "Bernhard Hoëcker"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Angelica",
+          "sprecher" : "Anna Thalbach"
+        },
+        {
+          "rolle" : "Schwester 1",
+          "sprecher" : "Manuela Becker"
+        },
+        {
+          "rolle" : "Schwester 2",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Pfleger",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mr. Smith",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Curtis Fisher",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Amrita Chakyar",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Sergeant Madhu",
+          "sprecher" : "Olli Dittrich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Mr. Raffer",
+          "sprecher" : "Harald Dietl"
+        },
+        {
+          "rolle" : "Feuerwehrmann",
+          "sprecher" : "Kai Henrik Möller"
+        },
+        {
+          "rolle" : "Kapitän",
+          "sprecher" : "Sky du Mont"
+        },
+        {
+          "rolle" : "John Fisher",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "Mr. Castro",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Robert Kotulla"
+        },
+        {
+          "rolle" : "Anudhara",
+          "sprecher" : "Rosakutty Hemsing"
+        },
+        {
+          "rolle" : "Ruth",
+          "sprecher" : "Gabriele Libbach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/150/metadata.json",
@@ -18613,87 +18709,87 @@
           "end" : 3943307
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Laurence Seinfeld",
-          "Wolf Frass"
-        ],
-        [
-          "Denzel Hopkins",
-          "Tilo Schmitz"
-        ],
-        [
-          "Goldie Hopkins",
-          "Madeleine Weingarten"
-        ],
-        [
-          "Neil Rockwell",
-          "Wanja Mues"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Summer Hopkins",
-          "Regina Lemnitz"
-        ],
-        [
-          "Brooks, Galerist",
-          "Martin May"
-        ],
-        [
-          "Mr. Elroy Follister",
-          "Stephan Schwartz"
-        ],
-        [
-          "Martha",
-          "Hanna Reisch"
-        ],
-        [
-          "Dillon",
-          "Gregor Reisch"
-        ],
-        [
-          "Wayne",
-          "Woody Mues"
-        ],
-        [
-          "Gefängniswärter",
-          "Gosta Liptow"
-        ],
-        [
-          "Wirt",
-          "Klaus Dittmann"
-        ],
-        [
-          "Greis",
-          "Jürgen Thormann"
-        ],
-        [
-          "Beamter",
-          "Monty Arnold"
-        ],
-        [
-          "Taxifahrer",
-          "Harald Dietl"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Laurence Seinfeld",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Denzel Hopkins",
+          "sprecher" : "Tilo Schmitz"
+        },
+        {
+          "rolle" : "Goldie Hopkins",
+          "sprecher" : "Madeleine Weingart"
+        },
+        {
+          "rolle" : "Neil Rockwell",
+          "sprecher" : "Wanja Mues"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Summer Hopkins",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Brooks, Galerist",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Mr. Elroy Follister",
+          "sprecher" : "Stephan Schwartz"
+        },
+        {
+          "rolle" : "Martha",
+          "sprecher" : "Hanna Reisch"
+        },
+        {
+          "rolle" : "Dillon",
+          "sprecher" : "Gregor Reisch"
+        },
+        {
+          "rolle" : "Wayne",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Gefängniswärter",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Wirt",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Greis",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Beamter",
+          "sprecher" : "Monty Arnold"
+        },
+        {
+          "rolle" : "Taxifahrer",
+          "sprecher" : "Harald Dietl"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/151/metadata.json",
@@ -18773,83 +18869,83 @@
           "end" : 3374867
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Bert Young",
-          "Horst Stark"
-        ],
-        [
-          "Mrs. Johnson",
-          "Gabriele Libbach"
-        ],
-        [
-          "Chapman",
-          "Sascha Rotermund"
-        ],
-        [
-          "Tony",
-          "Reent Reins"
-        ],
-        [
-          "Blake",
-          "Wolfgang Rositzka"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Rubbish George",
-          "Utz Richter"
-        ],
-        [
-          "1. Mann",
-          "Rasmus Borowski"
-        ],
-        [
-          "2. Mann",
-          "Jo Kappl"
-        ],
-        [
-          "Verkäufer",
-          "Marcus Schönhoff"
-        ],
-        [
-          "Sunny",
-          "Rainer Schmitt"
-        ],
-        [
-          "Fernsehr-Sprecher",
-          "Jannik Schümann"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ],
-        [
-          "Francesco",
-          "Anton Sprick"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Bert Young",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Mrs. Johnson",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Chapman",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Reent Reins"
+        },
+        {
+          "rolle" : "Blake",
+          "sprecher" : "Wolfgang Rositzka"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Utz Richter"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Joachim Kappl"
+        },
+        {
+          "rolle" : "Verkäufer",
+          "sprecher" : "Marcus Schönhoff"
+        },
+        {
+          "rolle" : "Sunny",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Fernsehe-Sprecher",
+          "sprecher" : "Jannik Schümann"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Francesco",
+          "sprecher" : "Anton Sprick"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/152/metadata.json",
@@ -18924,79 +19020,79 @@
           "end" : 3243960
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sean O'Donnell",
-          "Till Demtrøder"
-        ],
-        [
-          "Alexander Chilton",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Mann im Stadion",
-          "Eric Förster"
-        ],
-        [
-          "Ordner",
-          "Matthias Treder"
-        ],
-        [
-          "Frau im Police Department",
-          "Corinna Wodrich"
-        ],
-        [
-          "Mrs. Gardiner",
-          "Elisa Linnemann"
-        ],
-        [
-          "Sekretärin",
-          "Susan Jarling"
-        ],
-        [
-          "Inspektor Craig",
-          "Gustav-Adolph Artz"
-        ],
-        [
-          "Tom Chilton",
-          "Christopher Arndt"
-        ],
-        [
-          "Junger Mann auf der Pier",
-          "Christian Senger"
-        ],
-        [
-          "Junge im Stadion",
-          "Johann Gutjahr"
-        ],
-        [
-          "Live-Kommentator",
-          "Ulli Potofski"
-        ],
-        [
-          "Ansager",
-          "Frank Wintjen"
-        ],
-        [
-          "Frau auf dem Pier",
-          "Katinka Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sean O'Donnell",
+          "sprecher" : "Till Demtrøder"
+        },
+        {
+          "rolle" : "Alexander Chilton",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Mann im Stadion",
+          "sprecher" : "Eric Förster"
+        },
+        {
+          "rolle" : "Ordner",
+          "sprecher" : "Matthias Treder"
+        },
+        {
+          "rolle" : "Frau im Police Department",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Mrs. Gardiner",
+          "sprecher" : "Elisa Linnemann"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Inspektor Craig",
+          "sprecher" : "Gustav-Adolph Artz"
+        },
+        {
+          "rolle" : "Tom Chilton",
+          "sprecher" : "Christopher Arndt"
+        },
+        {
+          "rolle" : "Junger Mann auf der Pier",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Junge im Stadion",
+          "sprecher" : "Johann Gutjahr"
+        },
+        {
+          "rolle" : "Live-Kommentator",
+          "sprecher" : "Ulrich Potofski"
+        },
+        {
+          "rolle" : "Ansager",
+          "sprecher" : "Frank Wintjen"
+        },
+        {
+          "rolle" : "Frau auf dem Pier",
+          "sprecher" : "Katinka Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/153/metadata.json",
@@ -19081,95 +19177,96 @@
           "end" : 4238587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Titus Jonas",
-          "Hans Meinhard"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Prof. Jane Heathcliff",
-          "Victoria von Trauttmansdorff"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mr. Grey",
-          "Urs Affolter"
-        ],
-        [
-          "Lester Price",
-          "Fabian Harloff"
-        ],
-        [
-          "Cinelly",
-          "Bernd Stephan"
-        ],
-        [
-          "Mr. Monroe",
-          "Achim Schülke"
-        ],
-        [
-          "Miss Deborah Cassidy",
-          "Barbara Focke"
-        ],
-        [
-          "Mr. Burke",
-          "Kai-Hendrik Möller"
-        ],
-        [
-          "Miss Trimble",
-          "Christine Pappert"
-        ],
-        [
-          "Mr. Weston",
-          "Joachim Lautenbach"
-        ],
-        [
-          "Nachbarin",
-          "Doris Maria Kaiser"
-        ],
-        [
-          "Butler",
-          "Erik Schäffler"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Michael Kowalski",
-          "Tobias Schmidt"
-        ],
-        [
-          "Jack",
-          "Leonhard Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Prof. Jane Heathcliff",
+          "sprecher" : "Victoria Trauttmansdorff"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mr. Grey",
+          "sprecher" : "Urs Affolter"
+        },
+        {
+          "rolle" : "Lester Price",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Cinelly",
+          "sprecher" : "Bernd Stephan"
+        },
+        {
+          "rolle" : "Mr. Monroe",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Miss Deborah Cassidy",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Mr. Burke",
+          "sprecher" : "Kai Henrik Möller"
+        },
+        {
+          "rolle" : "Miss Trimble",
+          "sprecher" : "Christine Pappert"
+        },
+        {
+          "rolle" : "Mr. Weston",
+          "sprecher" : "Joachim Lautenbach"
+        },
+        {
+          "rolle" : "Nachbarin",
+          "sprecher" : "Doris Maria Kaiser"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Michael Kowalski",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Leonhard Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/154/metadata.json",
@@ -19269,63 +19366,63 @@
           "end" : 4055280
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Zack Martin",
-          "Christian Stark"
-        ],
-        [
-          "Mary-Ann Leigh",
-          "Manuela Bäcker"
-        ],
-        [
-          "Latona Johnson",
-          "Julia Hummer"
-        ],
-        [
-          "Frank Norman",
-          "Till Huster"
-        ],
-        [
-          "Mrs. Robinson",
-          "Heidi Berndt"
-        ],
-        [
-          "Angela Sciutto",
-          "Gisela Fritsch"
-        ],
-        [
-          "Federico Sciutto",
-          "Rainer Fritzsche"
-        ],
-        [
-          "Mr. Torrance",
-          "Ingo Feder"
-        ],
-        [
-          "Frau",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Kind",
-          "Undine Ullmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Zack Martin",
+          "sprecher" : "Christian Stark"
+        },
+        {
+          "rolle" : "Mary-Ann Leigh",
+          "sprecher" : "Manuela Eifrig"
+        },
+        {
+          "rolle" : "Latona Johnson",
+          "sprecher" : "Julia Hummer"
+        },
+        {
+          "rolle" : "Frank Norman",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Mrs. Robinson",
+          "sprecher" : "Heidi Berndt"
+        },
+        {
+          "rolle" : "Angela Sciutto",
+          "sprecher" : "Gisela Fritsch"
+        },
+        {
+          "rolle" : "Federico Sciutto",
+          "sprecher" : "Rainer Fritzsche"
+        },
+        {
+          "rolle" : "Mr. Torrance",
+          "sprecher" : "Ingo Feder"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Kind",
+          "sprecher" : "Undine Ullmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/155/metadata.json",
@@ -19420,63 +19517,63 @@
           "end" : 4331240
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ryan Holbrooke",
-          "Manfred Reddemann"
-        ],
-        [
-          "Sheriff Pickett",
-          "Gerhart Hinze"
-        ],
-        [
-          "Stephen Baron",
-          "Patrick Elias"
-        ],
-        [
-          "Zyklon",
-          "Wolfgang Berger"
-        ],
-        [
-          "Al Dahab",
-          "Neil Malik"
-        ],
-        [
-          "Frau",
-          "Regine Lamster"
-        ],
-        [
-          "Matthew",
-          "Mike Olsowski"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Zabriski",
-          "Volker Bogdan"
-        ],
-        [
-          "Fred",
-          "Oliver Mink"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ryan Holbrooke",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Sheriff Pickett",
+          "sprecher" : "Gerhart Hinze"
+        },
+        {
+          "rolle" : "Stephen Baron",
+          "sprecher" : "Patrick Elias"
+        },
+        {
+          "rolle" : "Zyklon",
+          "sprecher" : "Wolfgang Berger"
+        },
+        {
+          "rolle" : "Al Dahab",
+          "sprecher" : "Neil Malik Abdullah"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Regine Lamster"
+        },
+        {
+          "rolle" : "Matthew",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Zabriski",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Fred",
+          "sprecher" : "Oliver Mink"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/156/metadata.json",
@@ -19556,63 +19653,64 @@
           "end" : 4461093
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Riese",
-          "Tilo Schmitz"
-        ],
-        [
-          "Hunnicutt",
-          "Heinz Lieven"
-        ],
-        [
-          "Sheila",
-          "Melanie Pukaß"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Felicity",
-          "Kari Erlhoff"
-        ],
-        [
-          "Chester",
-          "Mike Olsowski"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Gizmo",
-          "Michael von Rospatt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Riese",
+          "sprecher" : "Tilo Schmitz"
+        },
+        {
+          "rolle" : "Hunnicutt",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Sheila",
+          "sprecher" : "Melanie Pukaß"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Felicity",
+          "sprecher" : "Kari Erlhoff"
+        },
+        {
+          "rolle" : "Chester",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Gizmo",
+          "sprecher" : "Michael von Rospatt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/157/metadata.json",
@@ -19697,75 +19795,75 @@
           "end" : 3396520
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Michelle",
-          "Ulrike Stürzbecher"
-        ],
-        [
-          "Ronald Pounder",
-          "Jürgen Kluckert"
-        ],
-        [
-          "Maurice Blight",
-          "Oliver Böttcher"
-        ],
-        [
-          "Betsy",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Isabella",
-          "Isabel Navarro"
-        ],
-        [
-          "Vladas Abakulow",
-          "Eric Schäffler"
-        ],
-        [
-          "Moody Firthway",
-          "Peter Striebeck"
-        ],
-        [
-          "Polizist",
-          "Mike Olsowski"
-        ],
-        [
-          "Jenna",
-          "Konstanze Ullmer"
-        ],
-        [
-          "1. Mann",
-          "Olaf Kreutzenbeck"
-        ],
-        [
-          "2. Mann",
-          "Rainer Fritzsche"
-        ],
-        [
-          "3. Mann",
-          "Claus Fuchs"
-        ],
-        [
-          "4. Mann",
-          "Jannik Endemann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Michelle",
+          "sprecher" : "Ulrike Stürzbecher"
+        },
+        {
+          "rolle" : "Ronald Pounder",
+          "sprecher" : "Jürgen Kluckert"
+        },
+        {
+          "rolle" : "Maurice Blight",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Betsy",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Isabella",
+          "sprecher" : "Isabel Navarro"
+        },
+        {
+          "rolle" : "Vladas Abakulow",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Moody Firthway",
+          "sprecher" : "Peter Striebeck"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Jenna",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Olaf Kreutzenbeck"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Rainer Fritzsche"
+        },
+        {
+          "rolle" : "Mann 3",
+          "sprecher" : "Claus Fuchs"
+        },
+        {
+          "rolle" : "Mann 4",
+          "sprecher" : "Jannik Endemann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/158/metadata.json",
@@ -19840,55 +19938,56 @@
           "end" : 3931427
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Caroline Cotta",
-          "Michaela Mahlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Sergeant Donatelli",
-          "Peter Weis"
-        ],
-        [
-          "1. Mann",
-          "Robin Brosch"
-        ],
-        [
-          "2. Mann",
-          "Gerhart Hinze"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Caroline Cotta",
+          "sprecher" : "Micaëla Kreißler"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Sergeant Donatelli",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Gerhart Hinze"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/159/metadata.json",
@@ -19953,67 +20052,67 @@
           "end" : 3820387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Barbara",
-          "Tanja Geke"
-        ],
-        [
-          "Professor Mathewson",
-          "Stephan Schwartz"
-        ],
-        [
-          "Arthur",
-          "Stephan Benson"
-        ],
-        [
-          "Alan Jones",
-          "Wolfgang Pampel"
-        ],
-        [
-          "Shu Liin",
-          "Monika Freisfeld-Pampel"
-        ],
-        [
-          "Kellner",
-          "Sven Dahlem"
-        ],
-        [
-          "Frank",
-          "Simon Jäger"
-        ],
-        [
-          "Stadtverwalter",
-          "Achim Schülke"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Feuerschlucker",
-          "Bertram Hiese"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Barbara",
+          "sprecher" : "Tanja Geke"
+        },
+        {
+          "rolle" : "Professor Mathewson",
+          "sprecher" : "Stephan Schwartz"
+        },
+        {
+          "rolle" : "Arthur",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Alan Jones",
+          "sprecher" : "Wolfgang Pampel"
+        },
+        {
+          "rolle" : "Shu Liin",
+          "sprecher" : "Monika Freisfeld-Pampel"
+        },
+        {
+          "rolle" : "Kellner",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Frank",
+          "sprecher" : "Simon Jäger"
+        },
+        {
+          "rolle" : "Stadtverwalter",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Feuerschlucker",
+          "sprecher" : "Bertram Hiese"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/160/metadata.json",
@@ -20103,63 +20202,63 @@
           "end" : 4238493
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Greenwalt",
-          "Harald Dietl"
-        ],
-        [
-          "Brock",
-          "Guido A. Schick"
-        ],
-        [
-          "Deforge",
-          "Bruno F. Apitz"
-        ],
-        [
-          "Mrs. Kretchmer",
-          "Monika Werner"
-        ],
-        [
-          "Mrs. Espenson",
-          "Karin Eckhold"
-        ],
-        [
-          "Mrs. Wondratschek",
-          "Ela Nitzsche"
-        ],
-        [
-          "Mrs. Field",
-          "Celine Fontanges"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Harris",
-          "Lutz Harder"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Greenwalt",
+          "sprecher" : "Harald Dietl"
+        },
+        {
+          "rolle" : "Brock",
+          "sprecher" : "Guido A. Schick"
+        },
+        {
+          "rolle" : "Deforge",
+          "sprecher" : "Bruno F. Apitz"
+        },
+        {
+          "rolle" : "Mrs. Kretchmer",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Mrs. Espenson",
+          "sprecher" : "Karin Eckhold"
+        },
+        {
+          "rolle" : "Mrs. Wondratschek",
+          "sprecher" : "Ela Nitzsche"
+        },
+        {
+          "rolle" : "Mrs. Field",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Harris",
+          "sprecher" : "Lutz Harder"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/161/metadata.json",
@@ -20234,59 +20333,59 @@
           "end" : 4365707
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Prof. Arnold Brewster",
-          "Horst Naumann"
-        ],
-        [
-          "Miss Daggett",
-          "Ingeborg Christiansen"
-        ],
-        [
-          "Hold",
-          "Christian Rode"
-        ],
-        [
-          "Hank Tornby",
-          "Edgar Hoppe"
-        ],
-        [
-          "Mike Cobble",
-          "Gordon Piedesack"
-        ],
-        [
-          "Martin Ishniak",
-          "Erkki Hopf"
-        ],
-        [
-          "Samuel Cobble",
-          "Eckart Dux"
-        ],
-        [
-          "William Prescott",
-          "Eberhard Haar"
-        ],
-        [
-          "Jim Sesto",
-          "Gustav-Adolph Artz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Prof. Arnold Brewster",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Miss Daggett",
+          "sprecher" : "Ingeborg Christiansen"
+        },
+        {
+          "rolle" : "Hold",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Hank Tornby",
+          "sprecher" : "Edgar Hoppe"
+        },
+        {
+          "rolle" : "Mike Cobble",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Martin Ishniak",
+          "sprecher" : "Erkki Hopf"
+        },
+        {
+          "rolle" : "Samuel Cobble",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "William Prescott",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Jim Sesto",
+          "sprecher" : "Gustav-Adolph Artz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/162/metadata.json",
@@ -20361,31 +20460,31 @@
           "end" : 4468413
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Fynch",
-          "Stefan Benson"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Fynch",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/163/metadata.json",
@@ -20455,63 +20554,65 @@
           "end" : 4125760
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Lenni",
-          "Tim Kreuer"
-        ],
-        [
-          "John Greyfox",
-          "Douglas Welbat"
-        ],
-        [
-          "Clay Carson",
-          "Krystian Martinek"
-        ],
-        [
-          "Walter",
-          "Achim Schülke"
-        ],
-        [
-          "Freddy Hays",
-          "Woody Mues"
-        ],
-        [
-          "Trainer",
-          "Bruno F. Apitz"
-        ],
-        [
-          "Mann",
-          "Wolfram Winfried"
-        ],
-        [
-          "Junge",
-          "Francesco Nieheim"
-        ],
-        [
-          "Spieler",
-          "Carsten Kausse"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Lenni",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "John Greyfox",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Clay Carson",
+          "sprecher" : "Krystian Martinek"
+        },
+        {
+          "rolle" : "Walter",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Freddy Hays",
+          "sprecher" : "Bruno F. Apitz"
+        },
+        {
+          "rolle" : "Trainer",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Wolfram Damerius",
+          "pseudonym" : "Wolfram Winfried"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Frank Boldewin",
+          "pseudonym" : "Francesco Nieheim"
+        },
+        {
+          "rolle" : "Spieler",
+          "sprecher" : "Carsten Kausse"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/164/metadata.json",
@@ -20586,67 +20687,67 @@
           "end" : 4217360
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Randy",
-          "Marek Harloff"
-        ],
-        [
-          "Jeanne",
-          "Katja Brügger"
-        ],
-        [
-          "Ginette",
-          "Birte Kretschmer"
-        ],
-        [
-          "Tara",
-          "Angela Roy"
-        ],
-        [
-          "Steven",
-          "Robert Steudtner"
-        ],
-        [
-          "Ranger Thornton",
-          "Detlef Bierstedt"
-        ],
-        [
-          "Mr. Louis",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Busfahrer",
-          "Volker Bogdan"
-        ],
-        [
-          "Lindsey",
-          "Susan Jarling"
-        ],
-        [
-          "Reporter",
-          "Daniel Welbat"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Randy",
+          "sprecher" : "Marek Harloff"
+        },
+        {
+          "rolle" : "Jeanne",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Ginette",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Tara",
+          "sprecher" : "Angela Roy"
+        },
+        {
+          "rolle" : "Steven",
+          "sprecher" : "Robert Steudtner"
+        },
+        {
+          "rolle" : "Ranger Thornton",
+          "sprecher" : "Detlef Bierstedt"
+        },
+        {
+          "rolle" : "Mr. Louis",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Busfahrer",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Lindsey",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Daniel Welbat"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/165/metadata.json",
@@ -20711,43 +20812,43 @@
           "end" : 4063013
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mr. Bennet",
-          "Sven Dahlem"
-        ],
-        [
-          "Mrs. Dearing",
-          "Saskia Weckler"
-        ],
-        [
-          "Conrad Nash",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Frau",
-          "Elga Schütz"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mr. Bennet",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Mrs. Dearing",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Conrad Nash",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Elga Schütz"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/166/metadata.json",
@@ -20842,79 +20943,84 @@
           "end" : 4324213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Andy Carson",
-          "Stefan Schwade"
-        ],
-        [
-          "Mrs. Hampton",
-          "Celine Fontanges"
-        ],
-        [
-          "Nicky DeLores",
-          "Morgens von Gadow"
-        ],
-        [
-          "Miss Woodrow",
-          "Karin Abicht"
-        ],
-        [
-          "Judy Nigel",
-          "Angela Stresemann"
-        ],
-        [
-          "Direktor Grayston",
-          "Jörg Gillner"
-        ],
-        [
-          "Gregory Katic",
-          "Oliver Böttcher"
-        ],
-        [
-          "Mr. Clark",
-          "Stefan Brentle"
-        ],
-        [
-          "Tarzan",
-          "Sascha Draeger"
-        ],
-        [
-          "Mädchen",
-          "Nicola Melissian"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Callister",
-          "Ingo Feder"
-        ],
-        [
-          "Lionel Pengrim",
-          "Robert Missler"
-        ],
-        [
-          "Ned",
-          "Bruno Ploeger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Andy Carson",
+          "sprecher" : "Stefan Schwade"
+        },
+        {
+          "rolle" : "Mrs. Hampton",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Nicky DeLores",
+          "sprecher" : "Mogens von Gadow"
+        },
+        {
+          "rolle" : "Mrs. Woodrow",
+          "sprecher" : "Carin Abicht"
+        },
+        {
+          "rolle" : "Judy Nigel",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Direktor Grayston",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Gregory Katic",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Mr. Clark",
+          "sprecher" : "Stefan Brentle"
+        },
+        {
+          "rolle" : "Tarzan",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Mädchen 1",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Mädchen 2",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Callister",
+          "sprecher" : "Ingo Feder"
+        },
+        {
+          "rolle" : "Lionel Pengrim",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Ned",
+          "sprecher" : "Charles Rettinghaus",
+          "pseudonym" : "Bruno Ploeger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/167/metadata.json",
@@ -20984,83 +21090,83 @@
           "end" : 4675973
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Deborah",
-          "Gabi Libbach"
-        ],
-        [
-          "Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Samuel Rodman",
-          "Christian Concillio"
-        ],
-        [
-          "Benjamin Rodman",
-          "Henning Karge"
-        ],
-        [
-          "Vallery Flockheart",
-          "Caroline Kiesewetter"
-        ],
-        [
-          "Nigel Tillerman",
-          "Lutz Mackensy"
-        ],
-        [
-          "Josh Reilly",
-          "Nicholas Müller"
-        ],
-        [
-          "Lexington",
-          "Sascha Eigner"
-        ],
-        [
-          "Reporter",
-          "Rasmus Borowski"
-        ],
-        [
-          "Journalistin",
-          "Nicola Melissian"
-        ],
-        [
-          "Prescott",
-          "Rolf Becker"
-        ],
-        [
-          "Sergeant Morales",
-          "Peter Weis"
-        ],
-        [
-          "Mr. Arvidson",
-          "Gosta Liptow"
-        ],
-        [
-          "Mrs. Arvidson",
-          "Hedy Haase"
-        ],
-        [
-          "Mann",
-          "Andreas Becker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Deborah",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Samuel Rodman",
+          "sprecher" : "Christian Concilio"
+        },
+        {
+          "rolle" : "Benjamin Rodman",
+          "sprecher" : "Henning Karge"
+        },
+        {
+          "rolle" : "Vallery Flockheart",
+          "sprecher" : "Caroline Kiesewetter"
+        },
+        {
+          "rolle" : "Nigel Tillerman",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Josh Reilly",
+          "sprecher" : "Nicholas Müller"
+        },
+        {
+          "rolle" : "Lexington",
+          "sprecher" : "Sascha Eigner"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Journalistin",
+          "sprecher" : "Nicolá Melissian"
+        },
+        {
+          "rolle" : "Prescott",
+          "sprecher" : "Rolf Becker"
+        },
+        {
+          "rolle" : "Sergeant Morales",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Mr. Arvidson",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Mrs. Arvidson",
+          "sprecher" : "Hedy Haase"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Andreas Becker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/168/metadata.json",
@@ -21130,71 +21236,72 @@
           "end" : 4910587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Bradley",
-          "Nico König"
-        ],
-        [
-          "Bishop Blake",
-          "Wolf Frass"
-        ],
-        [
-          "Junge Frau",
-          "Heikedine Körting"
-        ],
-        [
-          "Derek",
-          "Tim Helssen"
-        ],
-        [
-          "Mrs. Kretschmer",
-          "Monika Werner"
-        ],
-        [
-          "Chastity",
-          "Undine Ullmer"
-        ],
-        [
-          "Charity",
-          "Kassandra Ullmer"
-        ],
-        [
-          "Sam Chiccarelli",
-          "Astrid Kollex"
-        ],
-        [
-          "Griffin Silverman",
-          "Stephan Schad"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Bradley",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Bishop Blake",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Junge Frau",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Derek",
+          "sprecher" : "Tim Helssen"
+        },
+        {
+          "rolle" : "Mrs. Kretschmer",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Chastity",
+          "sprecher" : "Undine Ullmer"
+        },
+        {
+          "rolle" : "Charity",
+          "sprecher" : "Kassandra Ullmer"
+        },
+        {
+          "rolle" : "Sam Chiccarelli",
+          "sprecher" : "Astrid Kollex"
+        },
+        {
+          "rolle" : "Griffin Silverman",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/169/metadata.json",
@@ -21269,87 +21376,87 @@
           "end" : 4816533
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mitch Palmer",
-          "Michael Lott"
-        ],
-        [
-          "Dimitri",
-          "Manou Lubowski"
-        ],
-        [
-          "Roy",
-          "Gosta Liptow"
-        ],
-        [
-          "Boss",
-          "Henry König"
-        ],
-        [
-          "Cindy",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Mike",
-          "Oliver Böttcher"
-        ],
-        [
-          "Wirt",
-          "Peter Lakenmacher"
-        ],
-        [
-          "Rockford",
-          "Christian Senger"
-        ],
-        [
-          "Casino-Besucher",
-          "Robin Bosch"
-        ],
-        [
-          "Casino-Besucherin",
-          "Brigitte Böttrich"
-        ],
-        [
-          "Rezeption 1",
-          "Dorothea Lott"
-        ],
-        [
-          "Rezeption 2",
-          "Marco Spina"
-        ],
-        [
-          "Fernfahrer",
-          "Tilman Madaus"
-        ],
-        [
-          "Putzfrau",
-          "Maria Baptista"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mitch Palmer",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Dimitri",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Roy",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Boss",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Cindy",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Mike",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Wirt",
+          "sprecher" : "Peter Lakenmacher"
+        },
+        {
+          "rolle" : "Rockford",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Casino-Besucher",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Casino-Besucherin",
+          "sprecher" : "Brigitte Böttrich"
+        },
+        {
+          "rolle" : "Rezeption 1",
+          "sprecher" : "Dorothea Lott"
+        },
+        {
+          "rolle" : "Rezeption 2",
+          "sprecher" : "Marco Spina"
+        },
+        {
+          "rolle" : "Fernfahrer",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Putzfrau",
+          "sprecher" : "Maria Baptista"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/170/metadata.json",
@@ -21419,91 +21526,91 @@
           "end" : 4040853
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Harry Salas",
-          "Pat Murphy"
-        ],
-        [
-          "Vanessa Goodstein",
-          "Simone Ritscher"
-        ],
-        [
-          "Eliah Cristobal",
-          "Stephan Schwartz"
-        ],
-        [
-          "Albert Goodstein",
-          "Manfred Reddemann"
-        ],
-        [
-          "Ben Kramer",
-          "Jan-Christof Kick"
-        ],
-        [
-          "Fiona Kramer",
-          "Lilian Körting"
-        ],
-        [
-          "Wirt",
-          "Harald Halgardt"
-        ],
-        [
-          "Jimmy Blue Eye",
-          "Ulli Potofski"
-        ],
-        [
-          "1. Mann",
-          "Achim Schülke"
-        ],
-        [
-          "2. Mann",
-          "Fabian Harloff"
-        ],
-        [
-          "Frau",
-          "Saskia Weckler"
-        ],
-        [
-          "Rosaria",
-          "Gela del Este"
-        ],
-        [
-          "Silvie",
-          "Katharina von Keller"
-        ],
-        [
-          "Jessy",
-          "Manuela Bäcker"
-        ],
-        [
-          "Sergeant",
-          "Alexander Stamm"
-        ],
-        [
-          "Polizist",
-          "Gordon Piedesack"
-        ],
-        [
-          "Rikuo Yamamoto",
-          "Toru Takahashi"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Harry Salas",
+          "sprecher" : "Pat Murphy"
+        },
+        {
+          "rolle" : "Vanessa Goodstein",
+          "sprecher" : "Simone Ritscher"
+        },
+        {
+          "rolle" : "Eliah Cristobal",
+          "sprecher" : "Stephan Schwartz"
+        },
+        {
+          "rolle" : "Albert Goodstein",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Ben Kramer",
+          "sprecher" : "Jan-Christof Kick"
+        },
+        {
+          "rolle" : "Fiona Kramer",
+          "sprecher" : "Lilian Körting"
+        },
+        {
+          "rolle" : "Wirt",
+          "sprecher" : "Harald Halgardt"
+        },
+        {
+          "rolle" : "Jimmy Blue Eye",
+          "sprecher" : "Ulrich Potofski"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Rosaria",
+          "sprecher" : "Gela del Este"
+        },
+        {
+          "rolle" : "Silvie",
+          "sprecher" : "Katharina von Keller"
+        },
+        {
+          "rolle" : "Jessy",
+          "sprecher" : "Manuela Eifrig"
+        },
+        {
+          "rolle" : "Sergeant",
+          "sprecher" : "Alexander Stamm"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Rikuo Yamamoto",
+          "sprecher" : "Toru Takahashi"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/171/metadata.json",
@@ -21578,63 +21685,63 @@
           "end" : 4375213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Drago Martinez",
-          "Konstantin Graudus"
-        ],
-        [
-          "Fred Osborne",
-          "Erik Schäffler"
-        ],
-        [
-          "Cecile Jezero",
-          "Sandra Quadflieg"
-        ],
-        [
-          "Deborah",
-          "Kornelia Lüdorff"
-        ],
-        [
-          "Short",
-          "Manfred Liptow"
-        ],
-        [
-          "Anthony",
-          "Lutz Harder"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Heavy Metal",
-          "Iris Rufner"
-        ],
-        [
-          "Arthur Pepper",
-          "Frank Thannhäuser"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Drago Martinez",
+          "sprecher" : "Konstantin Graudus"
+        },
+        {
+          "rolle" : "Fred Osborne",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Cecile Jezero",
+          "sprecher" : "Sandra Quadflieg"
+        },
+        {
+          "rolle" : "Deborah",
+          "sprecher" : "Kornelia Lüdorff"
+        },
+        {
+          "rolle" : "Short",
+          "sprecher" : "Manfred Liptow"
+        },
+        {
+          "rolle" : "Anthony",
+          "sprecher" : "Lutz Harder"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Heavy Metal",
+          "sprecher" : "Iris Rufner"
+        },
+        {
+          "rolle" : "Arthur Pepper",
+          "sprecher" : "Frank Thannhäuser"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/172/metadata.json",
@@ -21704,59 +21811,59 @@
           "end" : 4225213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Rupert",
-          "Udo Schenk"
-        ],
-        [
-          "Luke",
-          "Daniel Kirchberger"
-        ],
-        [
-          "Gwendolyn Pembroke",
-          "Aranka Mamero"
-        ],
-        [
-          "Lance Vaughn",
-          "Rainer Schmitt"
-        ],
-        [
-          "'The Destroyer'",
-          "Stephan Schad"
-        ],
-        [
-          "Darby Farnham",
-          "Christine Jensen"
-        ],
-        [
-          "Earl Forrester",
-          "Tobias Schmidt"
-        ],
-        [
-          "Alvin Cray",
-          "Michael Bideller"
-        ],
-        [
-          "Mr. Lloyd",
-          "Lutz Mackensy"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Rupert",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Luke",
+          "sprecher" : "Daniel Kirchberger"
+        },
+        {
+          "rolle" : "Gwendolyn Pembroke",
+          "sprecher" : "Aranka Jaenke-Mamero"
+        },
+        {
+          "rolle" : "Lance Vaughn",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "'The Destroyer'",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Darby Farnham",
+          "sprecher" : "Christine Jensen"
+        },
+        {
+          "rolle" : "Earl Forrester",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Alvin Cray",
+          "sprecher" : "Michael Bideller"
+        },
+        {
+          "rolle" : "Mr. Lloyd",
+          "sprecher" : "Lutz Mackensy"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/173/metadata.json",
@@ -21821,55 +21928,55 @@
           "end" : 3800827
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Guillermo",
-          "Mario Ramos"
-        ],
-        [
-          "Stanley Morgan",
-          "Romanus Fuhrmann"
-        ],
-        [
-          "Grace Powell",
-          "Luise Lunow"
-        ],
-        [
-          "Angus",
-          "Till Demtrøder"
-        ],
-        [
-          "Inspektor Cottahol",
-          "Holger Mahlich"
-        ],
-        [
-          "Baxter",
-          "Hans Kahlert"
-        ],
-        [
-          "Kranführer",
-          "Klaus Dittmann"
-        ],
-        [
-          "Steve",
-          "Martin Brücker"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Guillermo",
+          "sprecher" : "Mario Ramos"
+        },
+        {
+          "rolle" : "Stanley Morgan",
+          "sprecher" : "Romanus Fuhrmann"
+        },
+        {
+          "rolle" : "Grace Powell",
+          "sprecher" : "Luise Lunow"
+        },
+        {
+          "rolle" : "Angus",
+          "sprecher" : "Till Demtrøder"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Baxter",
+          "sprecher" : "Hans Kahlert"
+        },
+        {
+          "rolle" : "Kranführer",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Steve",
+          "sprecher" : "Martin Brücker"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/174/metadata.json",
@@ -21951,99 +22058,99 @@
               "end" : 3648933
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Mr. Andrews",
-              "Henry König"
-            ],
-            [
-              "Jeremy Bright",
-              "Stephan Schad"
-            ],
-            [
-              "Taylor-Jackson",
-              "Jona Mues"
-            ],
-            [
-              "Francine Breckenridge",
-              "Elga Schütz"
-            ],
-            [
-              "A.C. Berany",
-              "Hanni Vanhaiden"
-            ],
-            [
-              "Samantha",
-              "Henrike Fehrs"
-            ],
-            [
-              "Corvy",
-              "Karen Suender"
-            ],
-            [
-              "Lemuel Garvine",
-              "Tim Grobe"
-            ],
-            [
-              "Prof. Roalstad",
-              "Jürgen Thormann"
-            ],
-            [
-              "Chris",
-              "Soi Anifantis"
-            ],
-            [
-              "Gamma",
-              "Wolfram Grandezka"
-            ],
-            [
-              "Barfrau",
-              "Rhesi Underberg"
-            ],
-            [
-              "John",
-              "Stephan Benson"
-            ],
-            [
-              "Walker",
-              "Rüdiger Schulzki"
-            ],
-            [
-              "Lederhose",
-              "Klaus Krückemeyer"
-            ],
-            [
-              "1. Polizist",
-              "Tim Kreuer"
-            ],
-            [
-              "2. Polizist",
-              "Jesse Grimm"
-            ],
-            [
-              "Telefonstimme",
-              "Wolfgang Völz"
-            ],
-            [
-              "Menge",
-              "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Jeremy Bright",
+              "sprecher" : "Stephan Schad"
+            },
+            {
+              "rolle" : "Taylor-Jackson",
+              "sprecher" : "Jona Mues"
+            },
+            {
+              "rolle" : "Francine Breckenridge",
+              "sprecher" : "Elga Schütz"
+            },
+            {
+              "rolle" : "A.C. Berany",
+              "sprecher" : "Hanni Vanhaiden"
+            },
+            {
+              "rolle" : "Samantha",
+              "sprecher" : "Henrike Fehrs"
+            },
+            {
+              "rolle" : "Corvy",
+              "sprecher" : "Karen Suender"
+            },
+            {
+              "rolle" : "Lemuel Garvine",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Prof. Roalstad",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Chris",
+              "sprecher" : "Soi Anifantis"
+            },
+            {
+              "rolle" : "Gamma",
+              "sprecher" : "Wolfram Grandezka"
+            },
+            {
+              "rolle" : "Barfrau",
+              "sprecher" : "Theresa Underberg"
+            },
+            {
+              "rolle" : "John",
+              "sprecher" : "Stephan Benson"
+            },
+            {
+              "rolle" : "Walker",
+              "sprecher" : "Rüdiger Schulzki"
+            },
+            {
+              "rolle" : "Lederhose",
+              "sprecher" : "Klaus Krückemeyer"
+            },
+            {
+              "rolle" : "Polizist 1",
+              "sprecher" : "Tim Kreuer"
+            },
+            {
+              "rolle" : "Polizist 2",
+              "sprecher" : "Jesse Grimm"
+            },
+            {
+              "rolle" : "Telefonstimme",
+              "sprecher" : "Wolfgang Völz"
+            },
+            {
+              "rolle" : "Menge",
+              "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/1/metadata.json",
@@ -22104,75 +22211,75 @@
               "end" : 3434200
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Taylor-Jackson",
-              "Jona Mues"
-            ],
-            [
-              "Samantha",
-              "Henrike Fehrs"
-            ],
-            [
-              "Jason",
-              "Woody Mues"
-            ],
-            [
-              "Mrs. Roalstad",
-              "Beate Rysopp"
-            ],
-            [
-              "Prof. Roalstad",
-              "Jürgen Thormann"
-            ],
-            [
-              "Corvy",
-              "Karen Suender"
-            ],
-            [
-              "Mrs. Fernandez",
-              "Anja Topf"
-            ],
-            [
-              "Lemuel Garvine",
-              "Tim Grobe"
-            ],
-            [
-              "Emery",
-              "Peter Weis"
-            ],
-            [
-              "Ginger",
-              "Heidi Schaffrath"
-            ],
-            [
-              "Sanitäter",
-              "Franzisko Löwe"
-            ],
-            [
-              "Schwester",
-              "Maike Nagel"
-            ],
-            [
-              "Menge",
-              "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Taylor-Jackson",
+              "sprecher" : "Jona Mues"
+            },
+            {
+              "rolle" : "Samantha",
+              "sprecher" : "Henrike Fehrs"
+            },
+            {
+              "rolle" : "Jason",
+              "sprecher" : "Woody Mues"
+            },
+            {
+              "rolle" : "Mrs. Roalstad",
+              "sprecher" : "Beate Rysopp"
+            },
+            {
+              "rolle" : "Prof. Roalstad",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Corvy",
+              "sprecher" : "Karen Suender"
+            },
+            {
+              "rolle" : "Mrs. Fernandez",
+              "sprecher" : "Anja Topf"
+            },
+            {
+              "rolle" : "Lemuel Garvine",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Emery",
+              "sprecher" : "Peter Weis"
+            },
+            {
+              "rolle" : "Ginger",
+              "sprecher" : "Heidi Schaffrath"
+            },
+            {
+              "rolle" : "Sanitäter",
+              "sprecher" : "Franzisko Löwe"
+            },
+            {
+              "rolle" : "Schwester",
+              "sprecher" : "Maike Nagel"
+            },
+            {
+              "rolle" : "Menge",
+              "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/2/metadata.json",
@@ -22228,67 +22335,67 @@
               "end" : 4166493
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Taylor-Jackson",
-              "Jona Mues"
-            ],
-            [
-              "Jason",
-              "Woody Mues"
-            ],
-            [
-              "Ivy",
-              "Leonie Lander"
-            ],
-            [
-              "Prof. Haynthorb",
-              "Wolfgang Draeger"
-            ],
-            [
-              "Mrs. Fernandez",
-              "Anja Topf"
-            ],
-            [
-              "Samantha",
-              "Henrike Fehrs"
-            ],
-            [
-              "Francine Breckenridge",
-              "Elga Schütz"
-            ],
-            [
-              "Dr. Wilcomb",
-              "Heinz Lieven"
-            ],
-            [
-              "3. Polizist",
-              "Wolfgang Kaven"
-            ],
-            [
-              "Mr. Andrews",
-              "Henry König"
-            ],
-            [
-              "Menge",
-              "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Taylor-Jackson",
+              "sprecher" : "Jona Mues"
+            },
+            {
+              "rolle" : "Jason",
+              "sprecher" : "Woody Mues"
+            },
+            {
+              "rolle" : "Ivy",
+              "sprecher" : "Leonie Landa"
+            },
+            {
+              "rolle" : "Prof. Haynthorb",
+              "sprecher" : "Wolfgang Draeger"
+            },
+            {
+              "rolle" : "Mrs. Fernandez",
+              "sprecher" : "Anja Topf"
+            },
+            {
+              "rolle" : "Samantha",
+              "sprecher" : "Henrike Fehrs"
+            },
+            {
+              "rolle" : "Francine Breckenridge",
+              "sprecher" : "Elga Schütz"
+            },
+            {
+              "rolle" : "Dr. Wilcomb",
+              "sprecher" : "Heinz Lieven"
+            },
+            {
+              "rolle" : "Polizist 3",
+              "sprecher" : "Wolfgang Kaven"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Menge",
+              "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/3/metadata.json",
@@ -22301,143 +22408,143 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Die drei Detektive bekommen eine einmalige Chance: Sie dürfen an der Universität Ruxton für ein paar Wochen das Studentenleben testen! Doch schnell wird klar, dass hier nicht nur Vorlesungen, Partys und Wohnheimzoff auf sie warten, sondern ein neuer Fall!",
       "veröffentlichungsdatum" : "2015-05-15",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Jeremy Bright",
-          "Stephan Schad"
-        ],
-        [
-          "Taylor-Jackson",
-          "Jona Mues"
-        ],
-        [
-          "Francine Breckenridge",
-          "Elga Schütz"
-        ],
-        [
-          "A.C. Berany",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Samantha",
-          "Henrike Fehrs"
-        ],
-        [
-          "Corvy",
-          "Karen Suender"
-        ],
-        [
-          "Lemuel Garvine",
-          "Tim Grobe"
-        ],
-        [
-          "Prof. Roalstad",
-          "Jürgen Thormann"
-        ],
-        [
-          "Chris",
-          "Soi Anifantis"
-        ],
-        [
-          "Gamma",
-          "Wolfram Grandezka"
-        ],
-        [
-          "Barfrau",
-          "Rhesi Underberg"
-        ],
-        [
-          "John",
-          "Stephan Benson"
-        ],
-        [
-          "Walker",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Lederhose",
-          "Klaus Krückemeyer"
-        ],
-        [
-          "1. Polizist",
-          "Tim Kreuer"
-        ],
-        [
-          "2. Polizist",
-          "Jesse Grimm"
-        ],
-        [
-          "Telefonstimme",
-          "Wolfgang Völz"
-        ],
-        [
-          "Jason",
-          "Woody Mues"
-        ],
-        [
-          "Mrs. Roalstad",
-          "Beate Rysopp"
-        ],
-        [
-          "Mrs. Fernandez",
-          "Anja Topf"
-        ],
-        [
-          "Emery",
-          "Peter Weis"
-        ],
-        [
-          "Ginger",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Sanitäter",
-          "Franzisko Löwe"
-        ],
-        [
-          "Schwester",
-          "Maike Nagel"
-        ],
-        [
-          "Ivy",
-          "Leonie Lander"
-        ],
-        [
-          "Prof. Haynthorb",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Dr. Wilcomb",
-          "Heinz Lieven"
-        ],
-        [
-          "3. Polizist",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Menge",
-          "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Jeremy Bright",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Taylor-Jackson",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Francine Breckenridge",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "A.C. Berany",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Samantha",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Corvy",
+          "sprecher" : "Karen Suender"
+        },
+        {
+          "rolle" : "Lemuel Garvine",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Prof. Roalstad",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Chris",
+          "sprecher" : "Soi Anifantis"
+        },
+        {
+          "rolle" : "Gamma",
+          "sprecher" : "Wolfram Grandezka"
+        },
+        {
+          "rolle" : "Barfrau",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "John",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Walker",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Lederhose",
+          "sprecher" : "Klaus Krückemeyer"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Telefonstimme",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Jason",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Mrs. Roalstad",
+          "sprecher" : "Beate Rysopp"
+        },
+        {
+          "rolle" : "Mrs. Fernandez",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Emery",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Ginger",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Franzisko Löwe"
+        },
+        {
+          "rolle" : "Schwester",
+          "sprecher" : "Maike Nagel"
+        },
+        {
+          "rolle" : "Ivy",
+          "sprecher" : "Leonie Landa"
+        },
+        {
+          "rolle" : "Prof. Haynthorb",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Dr. Wilcomb",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Polizist 3",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Menge",
+          "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/175/metadata.json",
@@ -22514,59 +22621,59 @@
           "end" : 4064107
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Sidney",
-          "Dorothee Sturz"
-        ],
-        [
-          "Tiffany",
-          "Maureen Havlena"
-        ],
-        [
-          "Salma Hutchinson",
-          "Tina Eschmann"
-        ],
-        [
-          "Trevor Pomery",
-          "Ben Hecker"
-        ],
-        [
-          "Beatrice",
-          "Ursula Sieg"
-        ],
-        [
-          "Claire",
-          "Karin Eckhold"
-        ],
-        [
-          "Pflegerin",
-          "Susanne Wulkow"
-        ],
-        [
-          "Roger Wolf",
-          "Stephan Schad"
-        ],
-        [
-          "Menge Fußballstadion",
-          "Die Gäste der Record-Release-Party am 22.02.2015 in Dortmund. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Sidney",
+          "sprecher" : "Dorothee Sturz"
+        },
+        {
+          "rolle" : "Tiffany",
+          "sprecher" : "Maureen Havlena"
+        },
+        {
+          "rolle" : "Salma Hutchinson",
+          "sprecher" : "Tina Eschmann"
+        },
+        {
+          "rolle" : "Trevor Pomery",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Beatrice",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Claire",
+          "sprecher" : "Karin Eckhold"
+        },
+        {
+          "rolle" : "Pflegerin",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Roger Wolf",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Menge Fußballstadion",
+          "sprecher" : "Die Gäste der Record-Release-Party am 22.02.2015 in Dortmund. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/176/metadata.json",
@@ -22631,59 +22738,59 @@
           "end" : 4121080
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dusty Kirkpatrick",
-          "Hans Kahlert"
-        ],
-        [
-          "Miranda Kramer",
-          "Susanne Sternberg"
-        ],
-        [
-          "Barclay",
-          "Horst Stark"
-        ],
-        [
-          "Brian",
-          "Volker Hanisch"
-        ],
-        [
-          "Raven",
-          "Neda Rahmanian"
-        ],
-        [
-          "Dr. Hardwick",
-          "Till Huster"
-        ],
-        [
-          "Robert",
-          "Tim Kreuer"
-        ],
-        [
-          "Manolo",
-          "Wolfgang Berger"
-        ],
-        [
-          "Polizist",
-          "Kai-Hendrik Möller"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dusty Kirkpatrick",
+          "sprecher" : "Hans Kahlert"
+        },
+        {
+          "rolle" : "Miranda Kramer",
+          "sprecher" : "Susanne Sternberg"
+        },
+        {
+          "rolle" : "Barclay",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Brian",
+          "sprecher" : "Volker Hanisch"
+        },
+        {
+          "rolle" : "Raven",
+          "sprecher" : "Neda Rahmanian"
+        },
+        {
+          "rolle" : "Dr. Hardwick",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Robert",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Manolo",
+          "sprecher" : "Wolfgang Berger"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Kai Henrik Möller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/177/metadata.json",
@@ -22748,51 +22855,51 @@
           "end" : 3955933
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Barbara Mathewson",
-          "Tanja Geke"
-        ],
-        [
-          "Zacharias Faring",
-          "Olaf Reichmann"
-        ],
-        [
-          "Malone",
-          "Tilo Schmitz"
-        ],
-        [
-          "Ben Crane",
-          "Christian Rudolf"
-        ],
-        [
-          "Timothy Jackson",
-          "Nicolas König"
-        ],
-        [
-          "Reginald",
-          "Tobias Schmidt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Barbara Mathewson",
+          "sprecher" : "Tanja Geke"
+        },
+        {
+          "rolle" : "Zacharias Faring",
+          "sprecher" : "Olaf Reichmann"
+        },
+        {
+          "rolle" : "Malone",
+          "sprecher" : "Tilo Schmitz"
+        },
+        {
+          "rolle" : "Ben Crane",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Timothy Jackson",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Reginald",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/178/metadata.json",
@@ -22852,71 +22959,71 @@
           "end" : 4297960
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Evander Whiteside",
-          "Claus Wilcke"
-        ],
-        [
-          "Wendy Brown",
-          "Catrin Owerfeldt"
-        ],
-        [
-          "Christopher Barclay",
-          "Martin Paas"
-        ],
-        [
-          "Edgar Bristol",
-          "Sascha Gutzeit"
-        ],
-        [
-          "Carter Godfrey",
-          "Nicolas König"
-        ],
-        [
-          "Chuck Foster",
-          "Heiko Wohlgemuth"
-        ],
-        [
-          "Busfahrer Sam",
-          "Achim Schülke"
-        ],
-        [
-          "Officer Ossietzky",
-          "Romanus Fuhrmann"
-        ],
-        [
-          "Matt",
-          "Mike Olsowski"
-        ],
-        [
-          "Stephen",
-          "Alexander Kruuse-Mettin"
-        ],
-        [
-          "Billy",
-          "Tom Pidde"
-        ],
-        [
-          "Polizist Jerry",
-          "Stefan Weißenburger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Evander Whiteside",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Wendy Brown",
+          "sprecher" : "Catrin Owerfeldt"
+        },
+        {
+          "rolle" : "Christopher Barclay",
+          "sprecher" : "Martin Paas"
+        },
+        {
+          "rolle" : "Edgar Bristol",
+          "sprecher" : "Sascha Gutzeit"
+        },
+        {
+          "rolle" : "Carter Godfrey",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Chuck Foster",
+          "sprecher" : "Heiko Wohlgemuth"
+        },
+        {
+          "rolle" : "Busfahrer Sam",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Officer Ossietzky",
+          "sprecher" : "Romanus Fuhrmann"
+        },
+        {
+          "rolle" : "Matt",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Stephen",
+          "sprecher" : "Alexander Mettin"
+        },
+        {
+          "rolle" : "Billy",
+          "sprecher" : "Tom Pidde"
+        },
+        {
+          "rolle" : "Polizist Jerry",
+          "sprecher" : "Stefan Weißenburger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/179/metadata.json",
@@ -22976,59 +23083,59 @@
           "end" : 4667840
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Michael Rompa",
-          "Mario Ramos"
-        ],
-        [
-          "Afton",
-          "Julia Fölster"
-        ],
-        [
-          "Skinny Norris",
-          "Michael Harck"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Chef",
-          "Eric Schäffler"
-        ],
-        [
-          "Ron",
-          "Gordon Piedesack"
-        ],
-        [
-          "Ansage",
-          "Joachim Langer"
-        ],
-        [
-          "Oma",
-          "Renate Pichler"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Michael Rompa",
+          "sprecher" : "Mario Ramos"
+        },
+        {
+          "rolle" : "Afton",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Michael Harck"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Chef",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Ron",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Ansage",
+          "sprecher" : "Joachim Langer"
+        },
+        {
+          "rolle" : "Oma",
+          "sprecher" : "Renate Pichler"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/180/metadata.json",
@@ -23088,75 +23195,75 @@
           "end" : 4413560
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Quinn",
-          "Tobias Diakow"
-        ],
-        [
-          "Nightingale",
-          "Jürgen Thormann"
-        ],
-        [
-          "Pablo",
-          "Till Huster"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Thompson",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Mrs. Kato",
-          "Dorothea Hagena"
-        ],
-        [
-          "Sullivan",
-          "Jonas Hartmann"
-        ],
-        [
-          "Angelina",
-          "Norma Draeger"
-        ],
-        [
-          "Joshua",
-          "Hugo Richert"
-        ],
-        [
-          "1. Junge",
-          "Louis Körting"
-        ],
-        [
-          "2. Junge",
-          "Henrik Bichels"
-        ],
-        [
-          "Mädchen",
-          "Lilian Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Quinn",
+          "sprecher" : "Tobias Diakow"
+        },
+        {
+          "rolle" : "Nightingale",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Pablo",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Thompson",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Mrs. Kato",
+          "sprecher" : "Dorothea Hagena"
+        },
+        {
+          "rolle" : "Sullivan",
+          "sprecher" : "Jonas Hartmann"
+        },
+        {
+          "rolle" : "Angelina",
+          "sprecher" : "Norma Draeger"
+        },
+        {
+          "rolle" : "Joshua",
+          "sprecher" : "Hugo Richert"
+        },
+        {
+          "rolle" : "Junge 1",
+          "sprecher" : "Louis Körting"
+        },
+        {
+          "rolle" : "Junge 2",
+          "sprecher" : "Henrik Bichels"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Lilian Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/181/metadata.json",
@@ -23211,99 +23318,99 @@
           "end" : 4546493
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Shaw",
-          "Heikedine Körting"
-        ],
-        [
-          "Randy Carlisle",
-          "Johannes Semm"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Godween",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Polizist",
-          "Christoph Meyer"
-        ],
-        [
-          "Mia",
-          "Elea Richert"
-        ],
-        [
-          "Mrs. Crouch",
-          "Pia Werfel"
-        ],
-        [
-          "Rosemarie Wohlbauer",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Shinefield, Edna",
-          "Edna Shinefield"
-        ],
-        [
-          "George",
-          "Gordon Piedesack"
-        ],
-        [
-          "Ronny",
-          "Anton Pleva"
-        ],
-        [
-          "Loreen",
-          "Barbara Schipper"
-        ],
-        [
-          "TV-Moderatorin",
-          "Dagmar Berghoff"
-        ],
-        [
-          "Daphne",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Kiera",
-          "Isabella Grothe"
-        ],
-        [
-          "Luther Litti",
-          "Wolf Frass"
-        ],
-        [
-          "Kyle Caldwell",
-          "Joachim Kretzer"
-        ],
-        [
-          "Hay",
-          "Tobias Diakow"
-        ],
-        [
-          "Junge",
-          "Hugo Richert"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Randy Carlisle",
+          "sprecher" : "Johannes Semm"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Busfahrer",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Christoph Meyer"
+        },
+        {
+          "rolle" : "Mia",
+          "sprecher" : "Elea Richert"
+        },
+        {
+          "rolle" : "Mrs. Crouch",
+          "sprecher" : "Pia Werfel"
+        },
+        {
+          "rolle" : "Edna Shinefield",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Ronny",
+          "sprecher" : "Anton Pleva"
+        },
+        {
+          "rolle" : "Loreen",
+          "sprecher" : "Barbara Schipper"
+        },
+        {
+          "rolle" : "TV-Moderatorin",
+          "sprecher" : "Dagmar Berghoff"
+        },
+        {
+          "rolle" : "Daphne",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Kiera",
+          "sprecher" : "Isabella Grothe"
+        },
+        {
+          "rolle" : "Luther Litti",
+          "sprecher" : "Wolf Frass"
+        },
+        {
+          "rolle" : "Kyle Caldwell",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Hay",
+          "sprecher" : "Tobias Diakow"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Hugo Richert"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/182/metadata.json",
@@ -23363,83 +23470,83 @@
           "end" : 4566333
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Lenny The Rock",
-          "Peter Kirchberger"
-        ],
-        [
-          "Sue Tamara",
-          "Maria Hartmann"
-        ],
-        [
-          "Sax Sandler",
-          "Christian Concilio"
-        ],
-        [
-          "Tim Durnell",
-          "Douglas Welbat"
-        ],
-        [
-          "Ron",
-          "Gosta Liptow"
-        ],
-        [
-          "Keith",
-          "Tobias Schmidt"
-        ],
-        [
-          "Debbie Peterson",
-          "Maud Ackermann"
-        ],
-        [
-          "Frank Wheeler",
-          "Timo Wenzel"
-        ],
-        [
-          "Joe",
-          "Stefan Brönneke"
-        ],
-        [
-          "Clayton",
-          "Gordon Piedesack"
-        ],
-        [
-          "Kellnerin",
-          "Simona Pahl"
-        ],
-        [
-          "Partygäste",
-          "Die Gäste der Record-Release-Party am 8. Mai 2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Lenny The Rock",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Sue Tamara",
+          "sprecher" : "Maria Hartmann"
+        },
+        {
+          "rolle" : "Sax Sandler",
+          "sprecher" : "Christian Concilio"
+        },
+        {
+          "rolle" : "Tim Durnell",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Ron",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Keith",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Debbie Peterson",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Frank Wheeler",
+          "sprecher" : "Timo Alexander Wenzel"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Clayton",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Partygäste",
+          "sprecher" : "Die Gäste der Record-Release-Party am 08.05.2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/183/metadata.json",
@@ -23489,79 +23596,79 @@
           "end" : 4139387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jesse",
-          "Jacob Weigert"
-        ],
-        [
-          "Trainer",
-          "Till Huster"
-        ],
-        [
-          "Jaden",
-          "Flemming Draeger"
-        ],
-        [
-          "Joshua",
-          "Louis Körting"
-        ],
-        [
-          "April",
-          "Lilli Körting"
-        ],
-        [
-          "Autumn",
-          "Sabrina Heuer-Diakow"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Charles Morland",
-          "Horst Stark"
-        ],
-        [
-          "Tanika Frost",
-          "Isabella Grothe"
-        ],
-        [
-          "Savannah Frost",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Dennis Frost",
-          "Sascha Oliver Bauer"
-        ],
-        [
-          "Jane Thompson",
-          "Maud Ackermann"
-        ],
-        [
-          "Tyler",
-          "Christian Rudolf"
-        ],
-        [
-          "Gardener",
-          "Christian Concilio"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jesse",
+          "sprecher" : "Jacob Weigert"
+        },
+        {
+          "rolle" : "Trainer",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Jaden",
+          "sprecher" : "Flemming Draeger"
+        },
+        {
+          "rolle" : "Joshua",
+          "sprecher" : "Louis Körting"
+        },
+        {
+          "rolle" : "April",
+          "sprecher" : "Lilli Körting"
+        },
+        {
+          "rolle" : "Autumn",
+          "sprecher" : "Sabrina Heuer-Diakow"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Charles Morland",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Tanika Frost",
+          "sprecher" : "Isabella Grothe"
+        },
+        {
+          "rolle" : "Savannah Frost",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Dennis Frost",
+          "sprecher" : "Sascha Oliver Bauer"
+        },
+        {
+          "rolle" : "Jane Thompson",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Tyler",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Gardener",
+          "sprecher" : "Christian Concilio"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/184/metadata.json",
@@ -23626,71 +23733,71 @@
           "end" : 3685613
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Adam Quinn",
-          "Romanus Fuhrmann"
-        ],
-        [
-          "Mr. Carrington",
-          "Martin May"
-        ],
-        [
-          "Mrs. Carrington",
-          "Manuela Dahm-Mauerhofer"
-        ],
-        [
-          "Liza Hawkins",
-          "Lucia Angela Mahler"
-        ],
-        [
-          "Mr. Hawkins",
-          "Achim Schülke"
-        ],
-        [
-          "Mrs. Hawkins",
-          "Birte Kretschmer"
-        ],
-        [
-          "Leslie Logue-Smith",
-          "Uschi Hugo"
-        ],
-        [
-          "Schauspieler",
-          "Erik Schäffler"
-        ],
-        [
-          "Britney Rogers",
-          "Theresa Berlage"
-        ],
-        [
-          "Sanitäter",
-          "Oliver Böttcher"
-        ],
-        [
-          "Mr. Sisko",
-          "Daniel Welbat"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Adam Quinn",
+          "sprecher" : "Romanus Fuhrmann"
+        },
+        {
+          "rolle" : "Mr. Carrington",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Mrs. Carrington",
+          "sprecher" : "Manuela Dahm"
+        },
+        {
+          "rolle" : "Liza Hawkins",
+          "sprecher" : "Lucia-Angelina Mahler"
+        },
+        {
+          "rolle" : "Mr. Hawkins",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Mrs. Hawkins",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Leslie Logue-Smith",
+          "sprecher" : "Uschi Hugo"
+        },
+        {
+          "rolle" : "Schauspieler",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Britney Rogers",
+          "sprecher" : "Theresa Berlage"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Mr. Sisko",
+          "sprecher" : "Daniel Welbat"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/185/metadata.json",
@@ -23750,71 +23857,71 @@
           "end" : 4356747
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ben Peck",
-          "Wolfgang Völz"
-        ],
-        [
-          "Sandra",
-          "Maureen Havlena"
-        ],
-        [
-          "TV-Nachrichtensprecher",
-          "Holger Wemhoff"
-        ],
-        [
-          "Mr. Castro",
-          "Jürgen Thormann"
-        ],
-        [
-          "Doktor Burke",
-          "Hans Peter Korff"
-        ],
-        [
-          "Mrs. Penny",
-          "Herma Koehn"
-        ],
-        [
-          "Schwester Beatrice",
-          "Roswitha Völz"
-        ],
-        [
-          "Mr. Hooper",
-          "Günther Karl"
-        ],
-        [
-          "Ellyn Djawadi",
-          "Anika Pages"
-        ],
-        [
-          "Mr. Turner",
-          "Klaus Dittmann"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ben Peck",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Sandra",
+          "sprecher" : "Maureen Havlena"
+        },
+        {
+          "rolle" : "TV-Nachrichtensprecher",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Mr. Castro",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Doktor Burke",
+          "sprecher" : "Hans Peter Korff"
+        },
+        {
+          "rolle" : "Mrs. Penny",
+          "sprecher" : "Herma Koehn"
+        },
+        {
+          "rolle" : "Schwester Beatrice",
+          "sprecher" : "Roswitha Völz"
+        },
+        {
+          "rolle" : "Mr. Hooper",
+          "sprecher" : "Günther Karl"
+        },
+        {
+          "rolle" : "Ellyn Djawadi",
+          "sprecher" : "Annika Pages"
+        },
+        {
+          "rolle" : "Mr. Turner",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/186/metadata.json",
@@ -23879,75 +23986,75 @@
           "end" : 4036133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Kramer",
-          "Volker Bogdan"
-        ],
-        [
-          "Emma Bailey",
-          "Hansi Jochmann"
-        ],
-        [
-          "Hank",
-          "Ben Hecker"
-        ],
-        [
-          "Lewis Geriwell",
-          "Frank Gustavus"
-        ],
-        [
-          "Henry Appleton",
-          "Peter Heeckt"
-        ],
-        [
-          "Amber",
-          "Sarah Madeleine Tusk"
-        ],
-        [
-          "Laura",
-          "Maud Ackermann"
-        ],
-        [
-          "Gerald",
-          "Michael von Rospatt"
-        ],
-        [
-          "Nat",
-          "Tobias Schmidt"
-        ],
-        [
-          "Collins",
-          "Gosta Liptow"
-        ],
-        [
-          "Nader Rope",
-          "Michael Bideller"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kramer",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "Emma Bailey",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Hank",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Lewis Geriwell",
+          "sprecher" : "Frank Gustavus"
+        },
+        {
+          "rolle" : "Henry Appleton",
+          "sprecher" : "Peter Heeckt"
+        },
+        {
+          "rolle" : "Amber",
+          "sprecher" : "Sarah Madeleine Tusk"
+        },
+        {
+          "rolle" : "Laura",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Gerald",
+          "sprecher" : "Michael von Rospatt"
+        },
+        {
+          "rolle" : "Nat",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Collins",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Nader Rope",
+          "sprecher" : "Michael Bideller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/187/metadata.json",
@@ -24016,71 +24123,71 @@
           "end" : 4807547
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Clarissa Franklin",
-          "Judy Winter"
-        ],
-        [
-          "Laura Stryker",
-          "Regina Lemnitz"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Anruferin",
-          "Topsy Küppers"
-        ],
-        [
-          "Anrufer",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Regisseur",
-          "Nikolas Tantsoukes"
-        ],
-        [
-          "Stephen",
-          "Timo Hempel"
-        ],
-        [
-          "Redakteurin",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Sax Sandler",
-          "Christian Concilio"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Clarissa Franklin",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Laura Stryker",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Anruferin",
+          "sprecher" : "Topsy Küppers"
+        },
+        {
+          "rolle" : "Anrufer",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Regisseur",
+          "sprecher" : "Nikolas Tantsoukes"
+        },
+        {
+          "rolle" : "Stephen",
+          "sprecher" : "Timo Hempel"
+        },
+        {
+          "rolle" : "Redakteurin",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Sax Sandler",
+          "sprecher" : "Christian Concilio"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/188/metadata.json",
@@ -24139,67 +24246,67 @@
           "end" : 3917560
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Whitty",
-          "Claus Wilcke"
-        ],
-        [
-          "Hank",
-          "Robert Missler"
-        ],
-        [
-          "Cowboy Dick",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Mr. Arbuthnott",
-          "Eckart Dux"
-        ],
-        [
-          "Mrs. Lockwood",
-          "Ingeborg Kallweit"
-        ],
-        [
-          "Linda",
-          "Svenja Pages"
-        ],
-        [
-          "Roger",
-          "Christian Stark"
-        ],
-        [
-          "Mann",
-          "Gernot Endemann"
-        ],
-        [
-          "Einsatzleiter",
-          "Achim Schülke"
-        ],
-        [
-          "Polizist",
-          "Alexander Mettin"
-        ],
-        [
-          "Mechaniker",
-          "Joachim Kretzer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Whitty",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Hank",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Cowboy Dick",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Mr. Arbuthnott",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Mrs. Lockwood",
+          "sprecher" : "Ingeborg Kallweit"
+        },
+        {
+          "rolle" : "Linda",
+          "sprecher" : "Svenja Pages"
+        },
+        {
+          "rolle" : "Roger",
+          "sprecher" : "Christian Stark"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Einsatzleiter",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Alexander Mettin"
+        },
+        {
+          "rolle" : "Mechaniker",
+          "sprecher" : "Joachim Kretzer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/189/metadata.json",
@@ -24248,55 +24355,55 @@
           "end" : 3834400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Jeff Ranaldo",
-          "Till Huster"
-        ],
-        [
-          "Mr. McBrandon",
-          "Rainer Brandt"
-        ],
-        [
-          "Sandy",
-          "Anna Carlsson"
-        ],
-        [
-          "Roboter",
-          "Joachim Kretzer"
-        ],
-        [
-          "Computerstimme",
-          "Hansi Jochmann"
-        ],
-        [
-          "Bruce Torino",
-          "Michael Lott"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Jeff Ranaldo",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Mr. McBrandon",
+          "sprecher" : "Rainer Brandt"
+        },
+        {
+          "rolle" : "Sandy",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Roboter",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Computerstimme",
+          "sprecher" : "Hansi Jochmann"
+        },
+        {
+          "rolle" : "Bruce Torino",
+          "sprecher" : "Michael Lott"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/190/metadata.json",
@@ -24355,51 +24462,51 @@
           "end" : 4266120
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Priscilla Sicktree",
-          "Marianne Bernhardt"
-        ],
-        [
-          "Hank",
-          "Henry König"
-        ],
-        [
-          "Brian",
-          "Patrick Mölleken"
-        ],
-        [
-          "Ashlyn",
-          "Julia Fölster"
-        ],
-        [
-          "Rosie Wrenwick",
-          "Gerlinde Dillge"
-        ],
-        [
-          "Sheriff Stone",
-          "Horst Stark"
-        ],
-        [
-          "Hilfssheriff Jonathan",
-          "Christian Rudolf"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Priscilla Sicktree",
+          "sprecher" : "Marianne Bernhardt"
+        },
+        {
+          "rolle" : "Hank",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Brian",
+          "sprecher" : "Patrick Mölleken"
+        },
+        {
+          "rolle" : "Ashlyn",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Rosie Wrenwick",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Sheriff Stone",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Hilfssheriff Jonathan",
+          "sprecher" : "Christian Rudolf"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/191/metadata.json",
@@ -24458,63 +24565,63 @@
           "end" : 4081427
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Zuko",
-          "Kostja Ullmann"
-        ],
-        [
-          "Katara",
-          "Mitsue Kono"
-        ],
-        [
-          "Xiang Than",
-          "Horst Naumann"
-        ],
-        [
-          "Fan Quoc",
-          "Christine Wilhelmi"
-        ],
-        [
-          "Fan Yuen",
-          "Frank Gustavus"
-        ],
-        [
-          "Dealerin",
-          "Barbara Schipper"
-        ],
-        [
-          "1. Chinese",
-          "Frank Richartz"
-        ],
-        [
-          "2. Chinese",
-          "Erik Schäffler"
-        ],
-        [
-          "Fan Hao",
-          "Gerd Baltus"
-        ],
-        [
-          "Einlass",
-          "Matti Schmidt-Schaller"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Zuko",
+          "sprecher" : "Kostja Ullmann"
+        },
+        {
+          "rolle" : "Katara",
+          "sprecher" : "Mitsue Kono"
+        },
+        {
+          "rolle" : "Xiang Than",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Fan Quoc",
+          "sprecher" : "Christine Wilhelmi"
+        },
+        {
+          "rolle" : "Fan Yuen",
+          "sprecher" : "Frank Gustavus"
+        },
+        {
+          "rolle" : "Dealerin",
+          "sprecher" : "Barbara Schipper"
+        },
+        {
+          "rolle" : "Chinese 1",
+          "sprecher" : "Frank Richartz"
+        },
+        {
+          "rolle" : "Chinese 2",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Fan Hao",
+          "sprecher" : "Gerd Baltus"
+        },
+        {
+          "rolle" : "Einlass",
+          "sprecher" : "Matti Schmidt-Schaller"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/192/metadata.json",
@@ -24573,83 +24680,83 @@
           "end" : 4183227
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Angler",
-          "Stephan Chrzescinski"
-        ],
-        [
-          "Mac Anderson",
-          "Achim Buch"
-        ],
-        [
-          "Reporterin",
-          "Marion Gretchen Schmitz"
-        ],
-        [
-          "Mann",
-          "Sven Dahlem"
-        ],
-        [
-          "Grady",
-          "Werner Wilkening"
-        ],
-        [
-          "Pettengill",
-          "Peter Kirchberger"
-        ],
-        [
-          "Sheriff Rolins",
-          "Tommi Piper"
-        ],
-        [
-          "Farragut",
-          "Hanns Jörg Krumpholz"
-        ],
-        [
-          "Leah",
-          "Antje Birnbaum"
-        ],
-        [
-          "Cynthia Wetmore",
-          "Dorothea Hagena"
-        ],
-        [
-          "Hotelier",
-          "Gordon Piedesack"
-        ],
-        [
-          "Frau",
-          "Maud Ackermann"
-        ],
-        [
-          "Junge",
-          "Tim Heuer"
-        ],
-        [
-          "Daniel",
-          "Jannik Schümann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Angler",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Mac Anderson",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Reporterin",
+          "sprecher" : "Marion Gretchen Schmitz"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Sven Dahlem"
+        },
+        {
+          "rolle" : "Grady",
+          "sprecher" : "Werner Wilkening"
+        },
+        {
+          "rolle" : "Pettengill",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Sheriff Rolins",
+          "sprecher" : "Tommi Piper"
+        },
+        {
+          "rolle" : "Farragut",
+          "sprecher" : "Hanns Jörg Krumpholz"
+        },
+        {
+          "rolle" : "Leah",
+          "sprecher" : "Antje Birnbaum"
+        },
+        {
+          "rolle" : "Cynthia Wetmore",
+          "sprecher" : "Dorothea Hagena"
+        },
+        {
+          "rolle" : "Hotelier",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Frau",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Tim Heuer"
+        },
+        {
+          "rolle" : "Daniel",
+          "sprecher" : "Jannik Schümann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/193/metadata.json",
@@ -24708,79 +24815,79 @@
           "end" : 4616840
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Gladys Pixie",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Frank Firhouse",
-          "Lutz Mackensy"
-        ],
-        [
-          "Maggie Smith",
-          "Susanne Wulkow"
-        ],
-        [
-          "Aurora",
-          "Andreja Schneider"
-        ],
-        [
-          "Angela",
-          "Lucia Mahler"
-        ],
-        [
-          "Conchita Dominguez",
-          "Katja Brügger"
-        ],
-        [
-          "Reporter",
-          "Jörgpeter von Clarenau"
-        ],
-        [
-          "Putzfrau",
-          "Clarissa Börner"
-        ],
-        [
-          "Heather",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Folder",
-          "Harald Weiler"
-        ],
-        [
-          "Hopper",
-          "Achim Schülke"
-        ],
-        [
-          "Rezeptionist",
-          "Christopher Hoseit"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Gladys Pixie",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Frank Firhouse",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Maggie Smith",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Aurora",
+          "sprecher" : "Andreja Schneider"
+        },
+        {
+          "rolle" : "Angela",
+          "sprecher" : "Lucia-Angelina Mahler"
+        },
+        {
+          "rolle" : "Conchita Dominguez",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Jörgpeter Ahlers"
+        },
+        {
+          "rolle" : "Putzfrau",
+          "sprecher" : "Clarissa Börner"
+        },
+        {
+          "rolle" : "Heather",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Folder",
+          "sprecher" : "Harald Weiler"
+        },
+        {
+          "rolle" : "Hopper",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Rezeptionist",
+          "sprecher" : "Christopher Hoseit"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/194/metadata.json",
@@ -24834,55 +24941,55 @@
           "end" : 4503053
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Wally Robertson",
-          "Michael Prelle"
-        ],
-        [
-          "Charmayne Robertson",
-          "Daniela Hoffmann"
-        ],
-        [
-          "Dwaight Hayward",
-          "Gordon Piedesack"
-        ],
-        [
-          "Mrs. Flagstaff",
-          "Sabine Hahn"
-        ],
-        [
-          "Polizist",
-          "Erik Schäffler"
-        ],
-        [
-          "1. Mann",
-          "Ingo Menowski"
-        ],
-        [
-          "2. Mann",
-          "Riko Tauber"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Wally Robertson",
+          "sprecher" : "Michael Prelle"
+        },
+        {
+          "rolle" : "Charmayne Robertson",
+          "sprecher" : "Daniela Hoffmann"
+        },
+        {
+          "rolle" : "Dwaight Hayward",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Mrs. Flagstaff",
+          "sprecher" : "Sabine Hahn"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Mann 1",
+          "sprecher" : "Ingo Menowski"
+        },
+        {
+          "rolle" : "Mann 2",
+          "sprecher" : "Riko Tauber"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/195/metadata.json",
@@ -24941,59 +25048,59 @@
           "end" : 4728400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Patricia Osborne",
-          "Barbara Focke"
-        ],
-        [
-          "Osiris",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Sunshine",
-          "Dagmar Dreke"
-        ],
-        [
-          "Vandaan",
-          "Andreas Birnbaum"
-        ],
-        [
-          "Frank Corman /Mr Giggles",
-          "Lutz Mackensy"
-        ],
-        [
-          "Trixie Stiles",
-          "Anne Moll"
-        ],
-        [
-          "Bryan Bonfanti",
-          "Frank Roder"
-        ],
-        [
-          "Miller",
-          "Birte Kretschmer"
-        ],
-        [
-          "Henson",
-          "Constantin Stahlberg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Patricia Osborne",
+          "sprecher" : "Barbara Focke"
+        },
+        {
+          "rolle" : "Osiris",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Sunshine",
+          "sprecher" : "Dagmar Dreke"
+        },
+        {
+          "rolle" : "Vandaan",
+          "sprecher" : "Andreas Birnbaum"
+        },
+        {
+          "rolle" : "Frank Corman / Mr Giggles",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Trixie Stiles",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Bryan Bonfanti",
+          "sprecher" : "Frank Roder"
+        },
+        {
+          "rolle" : "Miller",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Henson",
+          "sprecher" : "Constantin Stahlberg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/196/metadata.json",
@@ -25057,83 +25164,84 @@
           "end" : 4190827
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Matthew Kooning",
-          "Tim Kreuer"
-        ],
-        [
-          "Doktor Kooning",
-          "Dietrich Adam"
-        ],
-        [
-          "Mrs. Kooning",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Finnley Stenseth",
-          "Julian Greis"
-        ],
-        [
-          "Farryn Stenseth",
-          "Clarissa Börner"
-        ],
-        [
-          "Mrs. Stenseth",
-          "Herma Koehn"
-        ],
-        [
-          "Stacey Warren",
-          "Katja Brügger"
-        ],
-        [
-          "Brandon",
-          "Stefan Exner"
-        ],
-        [
-          "Surferin",
-          "Simona Pahl"
-        ],
-        [
-          "Surfer",
-          "Tim Knauer"
-        ],
-        [
-          "Dylan",
-          "Sascha Rotermund"
-        ],
-        [
-          "Steven",
-          "Johannes Korff"
-        ],
-        [
-          "M. Keen",
-          "Detlef Tams"
-        ],
-        [
-          "George",
-          "Mars Saibert"
-        ],
-        [
-          "Mann",
-          "Gunnar Bergmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Matthew Kooning",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Doktor Kooning",
+          "sprecher" : "Dietrich Adam"
+        },
+        {
+          "rolle" : "Mrs. Kooning",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Finnley Stenseth",
+          "sprecher" : "Julian Greis"
+        },
+        {
+          "rolle" : "Farryn Stenseth",
+          "sprecher" : "Clarissa Börner"
+        },
+        {
+          "rolle" : "Mrs. Stenseth",
+          "sprecher" : "Herma Koehn"
+        },
+        {
+          "rolle" : "Stacey Warren",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Brandon",
+          "sprecher" : "Stefan Exner"
+        },
+        {
+          "rolle" : "Surferin",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Surfer",
+          "sprecher" : "Tim Knauer"
+        },
+        {
+          "rolle" : "Dylan",
+          "sprecher" : "Sascha Rotermund"
+        },
+        {
+          "rolle" : "Steven",
+          "sprecher" : "Johannes Korff"
+        },
+        {
+          "rolle" : "M. Keen",
+          "sprecher" : "Detlef Tams"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Marcel Saibert"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Peter Flechtner",
+          "pseudonym" : "Gunnar Bergmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/197/metadata.json",
@@ -25192,83 +25300,83 @@
           "end" : 4166400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Elliot Littlehorn",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Tobin Muller",
-          "Niko Minninger"
-        ],
-        [
-          "Amalia",
-          "Malin Steffen"
-        ],
-        [
-          "Zauberer Miller",
-          "Julian Horeyseck"
-        ],
-        [
-          "Kelvin Mitchell",
-          "Kai Mertens"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Leigh",
-          "Vivian Brünner"
-        ],
-        [
-          "Mutter",
-          "Tina Eschmann"
-        ],
-        [
-          "Zoey",
-          "Manuela Eifrig"
-        ],
-        [
-          "Mabel",
-          "Nicola Schäffler"
-        ],
-        [
-          "Glatzkopf",
-          "Achim Schülke"
-        ],
-        [
-          "Dustin Cooper",
-          "Claus Fuchs"
-        ],
-        [
-          "Wahrsagerin Susannah",
-          "Mia Diekow"
-        ],
-        [
-          "Dr. Benchfield",
-          "Harald Dietl"
-        ],
-        [
-          "Emily",
-          "Birte Kretschmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Elliot Littlehorn",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Tobin Muller",
+          "sprecher" : "Niko Minninger"
+        },
+        {
+          "rolle" : "Amalia",
+          "sprecher" : "Malin Steffen"
+        },
+        {
+          "rolle" : "Zauberer Miller",
+          "sprecher" : "Julian Horeyseck"
+        },
+        {
+          "rolle" : "Kelvin Mitchell",
+          "sprecher" : "Kai Mertens"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Leigh",
+          "sprecher" : "Vivian Brünner"
+        },
+        {
+          "rolle" : "Mutter",
+          "sprecher" : "Tina Eschmann"
+        },
+        {
+          "rolle" : "Zoey",
+          "sprecher" : "Manuela Eifrig"
+        },
+        {
+          "rolle" : "Mabel",
+          "sprecher" : "Nicola Schäffler"
+        },
+        {
+          "rolle" : "Glatzkopf",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Dustin Cooper",
+          "sprecher" : "Claus Fuchs"
+        },
+        {
+          "rolle" : "Wahrsagerin Susannah",
+          "sprecher" : "Mia Diekow"
+        },
+        {
+          "rolle" : "Dr. Benchfield",
+          "sprecher" : "Harald Dietl"
+        },
+        {
+          "rolle" : "Emily",
+          "sprecher" : "Birte Kretschmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/198/metadata.json",
@@ -25327,59 +25435,59 @@
           "end" : 4506587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Mr. Aaron Grover",
-          "Gernot Endemann"
-        ],
-        [
-          "Msr. Patricia Grover",
-          "Heidi Berndt"
-        ],
-        [
-          "Elodie Grover",
-          "Henrike Fehrs"
-        ],
-        [
-          "Desmond Cathpole",
-          "Martin Brücker"
-        ],
-        [
-          "Hausmeister Spencer",
-          "Werner Cartano"
-        ],
-        [
-          "Mr. Rubberwood",
-          "Udo Schenk"
-        ],
-        [
-          "Mr. Parker Mayfield",
-          "Holger Umbreit"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Mr. Aaron Grover",
+          "sprecher" : "Gernot Endemann"
+        },
+        {
+          "rolle" : "Msr. Patricia Grover",
+          "sprecher" : "Heidi Berndt"
+        },
+        {
+          "rolle" : "Elodie Grover",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Desmond Cathpole",
+          "sprecher" : "Martin Brücker"
+        },
+        {
+          "rolle" : "Hausmeister Spencer",
+          "sprecher" : "Werner Cartano"
+        },
+        {
+          "rolle" : "Mr. Rubberwood",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Mr. Parker Mayfield",
+          "sprecher" : "Holger Umbreit"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/199/metadata.json",
@@ -25684,127 +25792,127 @@
           "end" : 17712107
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Off-Sprecher",
-          "Udo Schenk"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Timothy",
-          "Peter Buchholz"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Inspector Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Goodween",
-          "André Minninger"
-        ],
-        [
-          "Rubbish George",
-          "Hans Peter Korff"
-        ],
-        [
-          "Vikram",
-          "Michael Deffert"
-        ],
-        [
-          "Bonnie Newman",
-          "Carla Becker"
-        ],
-        [
-          "Mr. August",
-          "Carlo von Tiedemann"
-        ],
-        [
-          "Gus August",
-          "Stephan Chrzescinski"
-        ],
-        [
-          "Helena",
-          "Neda Rahmanian"
-        ],
-        [
-          "Mr. Anderson",
-          "Hubertus Meyer-Burckhardt"
-        ],
-        [
-          "Gabriel White",
-          "Till Hagen"
-        ],
-        [
-          "Solomon Charles",
-          "Jürgen Thormann"
-        ],
-        [
-          "Mr. Dwiggins",
-          "Hanns Jörg Krumpholz"
-        ],
-        [
-          "Mr. Randur",
-          "Eckart Dux"
-        ],
-        [
-          "Beaver",
-          "Peter Franke"
-        ],
-        [
-          "Jariwala",
-          "Till Demtrøder"
-        ],
-        [
-          "Shakrabati",
-          "Sonny Pathak"
-        ],
-        [
-          "Shekinah",
-          "Madeleine Weingart"
-        ],
-        [
-          "Nachtwächter",
-          "Wolfgang Häntsch"
-        ],
-        [
-          "Maria",
-          "Caroline Kiesewetter"
-        ],
-        [
-          "Bruce",
-          "Michael Lott"
-        ],
-        [
-          "Polizist",
-          "Mars Saibert"
-        ],
-        [
-          "Officer",
-          "Helge Halvé"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Off-Sprecher",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Timothy",
+          "sprecher" : "Peter Buchholz"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Hans Peter Korff"
+        },
+        {
+          "rolle" : "Vikram",
+          "sprecher" : "Michael Deffert"
+        },
+        {
+          "rolle" : "Bonnie Newman",
+          "sprecher" : "Carla Becker"
+        },
+        {
+          "rolle" : "Mr. August",
+          "sprecher" : "Carlo von Tiedemann"
+        },
+        {
+          "rolle" : "Gus August",
+          "sprecher" : "Stephan Chrzescinski"
+        },
+        {
+          "rolle" : "Helena",
+          "sprecher" : "Neda Rahmanian"
+        },
+        {
+          "rolle" : "Mr. Anderson",
+          "sprecher" : "Hubertus Meyer-Burckhardt"
+        },
+        {
+          "rolle" : "Gabriel White",
+          "sprecher" : "Till Hagen"
+        },
+        {
+          "rolle" : "Solomon Charles",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Mr. Dwiggins",
+          "sprecher" : "Hanns Jörg Krumpholz"
+        },
+        {
+          "rolle" : "Mr. Randur",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Beaver",
+          "sprecher" : "Peter Franke"
+        },
+        {
+          "rolle" : "Jariwala",
+          "sprecher" : "Till Demtrøder"
+        },
+        {
+          "rolle" : "Shakrabati",
+          "sprecher" : "Sonny Pathak"
+        },
+        {
+          "rolle" : "Shekinah",
+          "sprecher" : "Madeleine Weingart"
+        },
+        {
+          "rolle" : "Nachtwächter",
+          "sprecher" : "Wolfgang Häntsch"
+        },
+        {
+          "rolle" : "Maria",
+          "sprecher" : "Caroline Kiesewetter"
+        },
+        {
+          "rolle" : "Bruce",
+          "sprecher" : "Michael Lott"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Marcel Saibert"
+        },
+        {
+          "rolle" : "Officer",
+          "sprecher" : "Helge Halvé"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/200/metadata.json",
@@ -25867,59 +25975,59 @@
           "end" : 4703027
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ben Hustler",
-          "Christian Brückner"
-        ],
-        [
-          "Loomy",
-          "Achim Schülke"
-        ],
-        [
-          "Angie",
-          "Angelika Bartsch"
-        ],
-        [
-          "Lesley",
-          "Ann Montenbruck"
-        ],
-        [
-          "Buchhändlerin",
-          "Victoria Fleer"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Andrews",
-          "Heidrun von Goessel"
-        ],
-        [
-          "Kathy",
-          "Celine Fontanges"
-        ],
-        [
-          "Harry",
-          "Woody Mues"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ben Hustler",
+          "sprecher" : "Christian Brückner"
+        },
+        {
+          "rolle" : "Loomy",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Angie",
+          "sprecher" : "Angelika Bartsch"
+        },
+        {
+          "rolle" : "Lesley",
+          "sprecher" : "Ann Montenbruck"
+        },
+        {
+          "rolle" : "Buchhändlerin",
+          "sprecher" : "Victoria Fleer"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Heidrun von Goessel"
+        },
+        {
+          "rolle" : "Kathy",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Harry",
+          "sprecher" : "Woody Mues"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/201/metadata.json",
@@ -25973,47 +26081,47 @@
           "end" : 4568253
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Laurenne Duffy",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Joe Patwin",
-          "Jürgen Uter"
-        ],
-        [
-          "Trevor Tompson",
-          "Marek Erhardt"
-        ],
-        [
-          "Bruce Osborne",
-          "Martin Paas"
-        ],
-        [
-          "Kelly",
-          "Henrike Fehrs"
-        ],
-        [
-          "Walt Duffy",
-          "Stephan Benson"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Laurenne Duffy",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Joe Patwin",
+          "sprecher" : "Jürgen Uter"
+        },
+        {
+          "rolle" : "Trevor Tompson",
+          "sprecher" : "Marek Erhardt"
+        },
+        {
+          "rolle" : "Bruce Osborne",
+          "sprecher" : "Martin Paas"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Walt Duffy",
+          "sprecher" : "Stephan Benson"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/202/metadata.json",
@@ -26072,47 +26180,47 @@
           "end" : 4610333
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jorunn",
-          "Lilith Gebauer"
-        ],
-        [
-          "Mrs. Planter",
-          "Angela Quast"
-        ],
-        [
-          "Deidre",
-          "Gabriele Libbach"
-        ],
-        [
-          "Special Agent Ross",
-          "Udo Schenk"
-        ],
-        [
-          "Special Agent Wright",
-          "Astrid Kollex"
-        ],
-        [
-          "Fischer",
-          "Peter Franke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jorunn",
+          "sprecher" : "Lilith Gebauer"
+        },
+        {
+          "rolle" : "Mrs. Planter",
+          "sprecher" : "Angela Quast"
+        },
+        {
+          "rolle" : "Deidre",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Special Agent Ross",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Special Agent Wright",
+          "sprecher" : "Astrid Kollex"
+        },
+        {
+          "rolle" : "Fischer",
+          "sprecher" : "Peter Franke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/203/metadata.json",
@@ -26161,51 +26269,51 @@
           "end" : 4144067
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mary",
-          "Marion Gretchen-Schmitz"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Potato-Fred",
-          "Peter Weis"
-        ],
-        [
-          "Mr. Pinches",
-          "Jürgen Uter"
-        ],
-        [
-          "Carter Bridou",
-          "Peter G. Dirmeier"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Marion Gretchen Schmitz"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Potato-Fred",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Mr. Pinches",
+          "sprecher" : "Jürgen Uter"
+        },
+        {
+          "rolle" : "Carter Bridou",
+          "sprecher" : "Peter G. Dirmeier"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/204/metadata.json",
@@ -26254,75 +26362,75 @@
           "end" : 4255120
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Trish",
-          "Katrin Decker"
-        ],
-        [
-          "Giovanni",
-          "Stephan Schad"
-        ],
-        [
-          "Rosaly",
-          "Gertie Honeck"
-        ],
-        [
-          "Matteo",
-          "Roman Rossa"
-        ],
-        [
-          "Caroline",
-          "Marianne Bernhardt"
-        ],
-        [
-          "Butler",
-          "Ivo Möller"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Charles Stapleton",
-          "Romanus Fuhrmann"
-        ],
-        [
-          "Direktor Greenwalt",
-          "Jürgen Uter"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Angestellter",
-          "Oliver Böttcher"
-        ],
-        [
-          "Polizist",
-          "Carlo von Tiedemann"
-        ],
-        [
-          "Papagei",
-          "Merete Brettschneider"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Trish",
+          "sprecher" : "Katrin Decker"
+        },
+        {
+          "rolle" : "Giovanni",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Rosaly",
+          "sprecher" : "Gertie Honeck"
+        },
+        {
+          "rolle" : "Matteo",
+          "sprecher" : "Roman Rossa"
+        },
+        {
+          "rolle" : "Caroline",
+          "sprecher" : "Marianne Bernhardt"
+        },
+        {
+          "rolle" : "Butler",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Charles Stapleton",
+          "sprecher" : "Romanus Fuhrmann"
+        },
+        {
+          "rolle" : "Direktor Greenwalt",
+          "sprecher" : "Jürgen Uter"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Angestellter",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Carlo von Tiedemann"
+        },
+        {
+          "rolle" : "Papagei",
+          "sprecher" : "Merete Brettschneider"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/205/metadata.json",
@@ -26371,51 +26479,51 @@
           "end" : 3762867
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Mason Huntington",
-          "Wolfgang Häntsch"
-        ],
-        [
-          "Mrs. Brankle",
-          "Mignon Remé"
-        ],
-        [
-          "Xeni",
-          "Lina Maria Millat"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Seymore-Wrightson",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Franklyn Seymore",
-          "Achim Schülke"
-        ],
-        [
-          "Liane Shore",
-          "Sadra Keck"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Mason Huntington",
+          "sprecher" : "Wolfgang Häntsch"
+        },
+        {
+          "rolle" : "Mrs. Brankle",
+          "sprecher" : "Mignon Remé"
+        },
+        {
+          "rolle" : "Xeni",
+          "sprecher" : "Lina Maria Millat"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Seymore-Wrightson",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Franklyn Seymore",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Liane Shore",
+          "sprecher" : "Sandra Keck"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/206/metadata.json",
@@ -26464,63 +26572,63 @@
           "end" : 3725680
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Minh",
-          "Jona Mues"
-        ],
-        [
-          "Luke",
-          "Alexander Merbeth"
-        ],
-        [
-          "Mark",
-          "Woody Mues"
-        ],
-        [
-          "Stéphane Mertens",
-          "Peter Kaempfe"
-        ],
-        [
-          "Kassiererin",
-          "Birte Kretschmer"
-        ],
-        [
-          "Ron Baxter",
-          "Robin Brosch"
-        ],
-        [
-          "Oma",
-          "Apollonia Jepsen"
-        ],
-        [
-          "Mrs. Willard",
-          "Daniela Ziegler"
-        ],
-        [
-          "Li",
-          "Traudel Sperber"
-        ],
-        [
-          "Tilan",
-          "Caroline Kiesewetter"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Minh",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Luke",
+          "sprecher" : "Alexander Merbeth"
+        },
+        {
+          "rolle" : "Mark",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Stéphane Mertens",
+          "sprecher" : "Peter Kaempfe"
+        },
+        {
+          "rolle" : "Kassiererin",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Ron Baxter",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Oma",
+          "sprecher" : "Apollonia Jepsen"
+        },
+        {
+          "rolle" : "Mrs. Willard",
+          "sprecher" : "Daniela Ziegler"
+        },
+        {
+          "rolle" : "Li",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Tilan",
+          "sprecher" : "Caroline Kiesewetter"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/207/metadata.json",
@@ -26569,79 +26677,79 @@
           "end" : 4250387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Bootsie Washington",
-          "Andreas Birnbaum"
-        ],
-        [
-          "Majorie Dever",
-          "Victoria Trauttmansdorff"
-        ],
-        [
-          "Schwester",
-          "Gabriele Libbach"
-        ],
-        [
-          "Leland Hanson",
-          "Matthias Keller"
-        ],
-        [
-          "Jolene",
-          "Sarah Madeleine Tusk"
-        ],
-        [
-          "Perceval",
-          "André Beyer"
-        ],
-        [
-          "Mercury",
-          "Kerstin Draeger"
-        ],
-        [
-          "Coldfield",
-          "Wolf-Dietrich Sprenger"
-        ],
-        [
-          "Urs",
-          "Hanns Jörg Krumpholz"
-        ],
-        [
-          "Nicolas",
-          "Uwe Lauschke"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Carver",
-          "Andreas Zaron"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Bootsie Washington",
+          "sprecher" : "Andreas Birnbaum"
+        },
+        {
+          "rolle" : "Majorie Dever",
+          "sprecher" : "Victoria Trauttmansdorff"
+        },
+        {
+          "rolle" : "Schwester",
+          "sprecher" : "Gabriele Libbach"
+        },
+        {
+          "rolle" : "Leland Hanson",
+          "sprecher" : "Matthias Keller"
+        },
+        {
+          "rolle" : "Jolene",
+          "sprecher" : "Sarah Madeleine Tusk"
+        },
+        {
+          "rolle" : "Perceval",
+          "sprecher" : "André Beyer"
+        },
+        {
+          "rolle" : "Mercury",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Coldfield",
+          "sprecher" : "Wolf-Dietrich Sprenger"
+        },
+        {
+          "rolle" : "Urs",
+          "sprecher" : "Hanns Jörg Krumpholz"
+        },
+        {
+          "rolle" : "Nicolas",
+          "sprecher" : "Uwe Lauschke"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Carver",
+          "sprecher" : "Andreas Zaron"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/208/metadata.json",
@@ -26695,59 +26803,59 @@
           "end" : 3596773
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Oisin Murphy",
-          "Douglas Welbat"
-        ],
-        [
-          "Lelia Murphy",
-          "Katja Brügger"
-        ],
-        [
-          "Virgil",
-          "Steffen Groth"
-        ],
-        [
-          "Wanda Waffle",
-          "Anja Topf"
-        ],
-        [
-          "Smiddie",
-          "Ivo Möller"
-        ],
-        [
-          "Clown",
-          "Andreas Birnbaum"
-        ],
-        [
-          "Zamora",
-          "Rainer Schmitt"
-        ],
-        [
-          "Easly",
-          "Paul Michaeli"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Oisin Murphy",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Lelia Murphy",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Virgil",
+          "sprecher" : "Steffen Groth"
+        },
+        {
+          "rolle" : "Wanda Waffle",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Smiddie",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Clown",
+          "sprecher" : "Andreas Birnbaum"
+        },
+        {
+          "rolle" : "Zamora",
+          "sprecher" : "Rainer Schmitt"
+        },
+        {
+          "rolle" : "Easly",
+          "sprecher" : "Paul Michaeli"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/209/metadata.json",
@@ -26796,51 +26904,51 @@
           "end" : 3627267
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Zach Cannings",
-          "Martin May"
-        ],
-        [
-          "Nicole",
-          "Saskia Weckler"
-        ],
-        [
-          "Mitarbeiter",
-          "Achim Funk"
-        ],
-        [
-          "Sara Roskin",
-          "Elke Reissert"
-        ],
-        [
-          "Caden Devlin",
-          "Werner Wilkening"
-        ],
-        [
-          "Offizier der Küstenwache (1)",
-          "Thorsten Laussch"
-        ],
-        [
-          "Offizier der Küstenwache (2)",
-          "Andreas Birnbaum"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Zach Cannings",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Nicole",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Mitarbeiter",
+          "sprecher" : "Achim Funk"
+        },
+        {
+          "rolle" : "Sara Roskin",
+          "sprecher" : "Elke Reissert"
+        },
+        {
+          "rolle" : "Caden Devlin",
+          "sprecher" : "Werner Wilkening"
+        },
+        {
+          "rolle" : "Offizier der Küstenwache 1",
+          "sprecher" : "Thorsten Laussch"
+        },
+        {
+          "rolle" : "Offizier der Küstenwache 2",
+          "sprecher" : "Andreas Birnbaum"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/210/metadata.json",
@@ -26889,59 +26997,59 @@
           "end" : 4321973
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jock",
-          "Christian Stark"
-        ],
-        [
-          "Gavin Sterling",
-          "Stephan Benson"
-        ],
-        [
-          "Judith Sterling",
-          "Hedi Kriegeskotte"
-        ],
-        [
-          "Leopold Nelson",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Marlow",
-          "Janis Zaurins"
-        ],
-        [
-          "Rick",
-          "Daniel Welbat"
-        ],
-        [
-          "Mrs. Torres",
-          "Heidi Berndt"
-        ],
-        [
-          "Dark Blue D",
-          "Ivo Möller"
-        ],
-        [
-          "Busfahrerin",
-          "Rosemarie Wohlbauer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jock",
+          "sprecher" : "Christian Stark"
+        },
+        {
+          "rolle" : "Gavin Sterling",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Judith Sterling",
+          "sprecher" : "Hedi Kriegeskotte"
+        },
+        {
+          "rolle" : "Leopold Nelson",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Marlow",
+          "sprecher" : "Janis Zaurins"
+        },
+        {
+          "rolle" : "Rick",
+          "sprecher" : "Daniel Welbat"
+        },
+        {
+          "rolle" : "Mrs. Torres",
+          "sprecher" : "Heidi Berndt"
+        },
+        {
+          "rolle" : "Dark Blue D",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Busfahrerin",
+          "sprecher" : "Rosemarie Wohlbauer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/211/metadata.json",
@@ -26995,59 +27103,59 @@
           "end" : 4395213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Larry Conklin",
-          "Helmut Zierl"
-        ],
-        [
-          "Fairfax",
-          "Wolfgang Pampel"
-        ],
-        [
-          "Zachary",
-          "Nicolas König"
-        ],
-        [
-          "Butler Francis",
-          "Bruno F. Apitz"
-        ],
-        [
-          "Mrs. Dutton",
-          "Monika Werner"
-        ],
-        [
-          "Noreen",
-          "Simona Pahl"
-        ],
-        [
-          "Mrs. Mobray",
-          "Eva Weissmann"
-        ],
-        [
-          "Polizist",
-          "Holger Wemhoff"
-        ],
-        [
-          "Miyazawa",
-          "Achim Schülke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Larry Conklin",
+          "sprecher" : "Helmut Zierl"
+        },
+        {
+          "rolle" : "Fairfax",
+          "sprecher" : "Wolfgang Pampel"
+        },
+        {
+          "rolle" : "Zachary",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Butler Francis",
+          "sprecher" : "Bruno F. Apitz"
+        },
+        {
+          "rolle" : "Mrs. Dutton",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Noreen",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Mrs. Mobray",
+          "sprecher" : "Eva Weissmann"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Miyazawa",
+          "sprecher" : "Achim Schülke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/212/metadata.json",
@@ -27101,75 +27209,75 @@
           "end" : 4378267
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Jojo",
-          "Lovis Harloff"
-        ],
-        [
-          "Mrs Carmichael",
-          "Anne Moll"
-        ],
-        [
-          "Mr Jeremiah Carmichael",
-          "Peter Bieringer"
-        ],
-        [
-          "Gravedigger",
-          "Lutz Mackensy"
-        ],
-        [
-          "Kruger",
-          "Gordon Piedesack"
-        ],
-        [
-          "Annabelle Delaney",
-          "Sabine Kaack"
-        ],
-        [
-          "Claire Delaney",
-          "Theresa Underberg"
-        ],
-        [
-          "Ace Hall",
-          "Patrick Berg"
-        ],
-        [
-          "Vince Buchanan",
-          "Joachim Kretzer"
-        ],
-        [
-          "Neal Buchanan",
-          "Marek Harloff"
-        ],
-        [
-          "Moderator",
-          "Holger Wemhoff"
-        ],
-        [
-          "Pearson",
-          "Till Huster"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Jojo",
+          "sprecher" : "Lovis Harloff"
+        },
+        {
+          "rolle" : "Mrs. Carmichael",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Mr. Jeremiah Carmichael",
+          "sprecher" : "Peter Bieringer"
+        },
+        {
+          "rolle" : "Gravedigger",
+          "sprecher" : "Lutz Mackensy"
+        },
+        {
+          "rolle" : "Kruger",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Annabelle Delaney",
+          "sprecher" : "Sabine Kaack"
+        },
+        {
+          "rolle" : "Claire Delaney",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Ace Hall",
+          "sprecher" : "Patrick Berg"
+        },
+        {
+          "rolle" : "Vince Buchanan",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Neal Buchanan",
+          "sprecher" : "Marek Harloff"
+        },
+        {
+          "rolle" : "Moderator",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Pearson",
+          "sprecher" : "Till Huster"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/213/metadata.json",
@@ -27218,67 +27326,67 @@
           "end" : 3938600
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Kommissarin Lisa Merryweather",
-          "Caroline Peters"
-        ],
-        [
-          "Elena Fleckenstein",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Roderick Sanders",
-          "Albrecht Ganskopf"
-        ],
-        [
-          "Fahrerin",
-          "Elga Schütz"
-        ],
-        [
-          "Rubbish George",
-          "Hans Peter Korff"
-        ],
-        [
-          "Officer Brown",
-          "André Beyer"
-        ],
-        [
-          "Bote",
-          "Achim Schülke"
-        ],
-        [
-          "Polizist",
-          "Alexander Mettin"
-        ],
-        [
-          "Angestellte im Altenheim",
-          "Barbara Schipper"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Kommissarin Lisa Merryweather",
+          "sprecher" : "Caroline Peters"
+        },
+        {
+          "rolle" : "Elena Fleckenstein",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Roderick Sanders",
+          "sprecher" : "Albrecht Ganskopf"
+        },
+        {
+          "rolle" : "Fahrerin",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Hans Peter Korff"
+        },
+        {
+          "rolle" : "Officer Brown",
+          "sprecher" : "André Beyer"
+        },
+        {
+          "rolle" : "Bote",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Alexander Mettin"
+        },
+        {
+          "rolle" : "Angestellte im Altenheim",
+          "sprecher" : "Barbara Schipper"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/214/metadata.json",
@@ -27337,63 +27445,63 @@
           "end" : 3954893
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Arnold Grasso",
-          "Patrick Berg"
-        ],
-        [
-          "Amalia",
-          "Verena Frost"
-        ],
-        [
-          "Sarah",
-          "Jana Schmidt"
-        ],
-        [
-          "Eric",
-          "Rasmus Borowski"
-        ],
-        [
-          "Nicolas",
-          "Lukas T. Sperber"
-        ],
-        [
-          "Dennis",
-          "Detlef Tams"
-        ],
-        [
-          "Dale Congden",
-          "Peter Kaempfe"
-        ],
-        [
-          "Professor Hogan",
-          "Hannes Hellmann"
-        ],
-        [
-          "Officer",
-          "Torsten Münchow"
-        ],
-        [
-          "Ansage",
-          "Anne Moll"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Arnold Grasso",
+          "sprecher" : "Patrick Berg"
+        },
+        {
+          "rolle" : "Amalia",
+          "sprecher" : "Verena Frost"
+        },
+        {
+          "rolle" : "Sarah",
+          "sprecher" : "Jana Catharina Schmidt"
+        },
+        {
+          "rolle" : "Eric",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "Nicolas",
+          "sprecher" : "Lukas T. Sperber"
+        },
+        {
+          "rolle" : "Dennis",
+          "sprecher" : "Detlef Tams"
+        },
+        {
+          "rolle" : "Dale Congden",
+          "sprecher" : "Peter Kaempfe"
+        },
+        {
+          "rolle" : "Professor Hogan",
+          "sprecher" : "Hannes Hellmann"
+        },
+        {
+          "rolle" : "Officer",
+          "sprecher" : "Torsten Münchow"
+        },
+        {
+          "rolle" : "Ansage",
+          "sprecher" : "Anne Moll"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/215/metadata.json",
@@ -27457,55 +27565,55 @@
           "end" : 3884267
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Kendra Bowman",
-          "Sandra Schwittau"
-        ],
-        [
-          "Huxley, Sittich",
-          "Achim Buch"
-        ],
-        [
-          "Matt",
-          "Manfred Liptow"
-        ],
-        [
-          "Carol",
-          "Gerlinde Dillge"
-        ],
-        [
-          "Trevor",
-          "Peter Kaempfe"
-        ],
-        [
-          "Officer",
-          "Torsten Münchow"
-        ],
-        [
-          "Reginald",
-          "Malte Janßen"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Kendra Bowman",
+          "sprecher" : "Sandra Schwittau"
+        },
+        {
+          "rolle" : "Huxley, Sittich",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Matt",
+          "sprecher" : "Manfred Liptow"
+        },
+        {
+          "rolle" : "Carol",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Trevor",
+          "sprecher" : "Peter Kaempfe"
+        },
+        {
+          "rolle" : "Officer",
+          "sprecher" : "Torsten Münchow"
+        },
+        {
+          "rolle" : "Reginald",
+          "sprecher" : "Malte Janßen"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/216/metadata.json",
@@ -27564,67 +27672,67 @@
           "end" : 4520653
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Julia Scott",
-          "Stephanie Kirchberger"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Gwendolyn",
-          "Maud Ackermann"
-        ],
-        [
-          "Nicholas",
-          "Max König"
-        ],
-        [
-          "Raphael Luca",
-          "Achim Buch"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Bronkowitz",
-          "Angela Stresemann"
-        ],
-        [
-          "Lady",
-          "Eva Monar"
-        ],
-        [
-          "Dame",
-          "Carolyn Walsh"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Hunter Scott",
-          "Hans-Jürgen Mende"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Julia Scott",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Gwendolyn",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Nicholas",
+          "sprecher" : "Max König"
+        },
+        {
+          "rolle" : "Raphael Luca",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Bronkowitz",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Lady",
+          "sprecher" : "Eva Monar"
+        },
+        {
+          "rolle" : "Dame",
+          "sprecher" : "Carolyn Walsh"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Hunter Scott",
+          "sprecher" : "Hans-Jürgen Mende"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/217/metadata.json",
@@ -27683,67 +27791,67 @@
           "end" : 4372133
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Olivia",
-          "Uschi Hugo"
-        ],
-        [
-          "Pamela Parker, Olivias Mutter",
-          "Katrin Decker"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Eudora Kretschmer",
-          "Monika Werner"
-        ],
-        [
-          "Barbara",
-          "Carolyn Walsh"
-        ],
-        [
-          "Canyon Brookside",
-          "Marek Erhardt"
-        ],
-        [
-          "Owens",
-          "Jan Langer"
-        ],
-        [
-          "Bernie Walters",
-          "Vadim Goldfeld"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Edgar Mulligan",
-          "Karsten Haase"
-        ],
-        [
-          "Swift",
-          "Tim Grobe"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Olivia",
+          "sprecher" : "Uschi Hugo"
+        },
+        {
+          "rolle" : "Pamela Parker, Olivias Mutter",
+          "sprecher" : "Katrin Decker"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Eudora Kretschmer",
+          "sprecher" : "Monika Werner"
+        },
+        {
+          "rolle" : "Barbara",
+          "sprecher" : "Carolyn Walsh"
+        },
+        {
+          "rolle" : "Canyon Brookside",
+          "sprecher" : "Marek Erhardt"
+        },
+        {
+          "rolle" : "Owens",
+          "sprecher" : "Jan Langer"
+        },
+        {
+          "rolle" : "Bernie Walters",
+          "sprecher" : "Vadim Goldfeld"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Edgar Mulligan",
+          "sprecher" : "Karsten Haase"
+        },
+        {
+          "rolle" : "Swift",
+          "sprecher" : "Tim Grobe"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/218/metadata.json",
@@ -27802,67 +27910,67 @@
           "end" : 4189547
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Detective Ella",
-          "Neda Rahmanian"
-        ],
-        [
-          "Officer James",
-          "Sascha Gutzeit"
-        ],
-        [
-          "Mr. Shaw",
-          "Michael Grimm"
-        ],
-        [
-          "Paul Forsters",
-          "Achim Buch"
-        ],
-        [
-          "Esprit",
-          "Matthias Keller"
-        ],
-        [
-          "Anthony Spring",
-          "Douglas Welbat"
-        ],
-        [
-          "Butch",
-          "Tom Pidde"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ],
-        [
-          "Godween",
-          "André Minninger"
-        ],
-        [
-          "Polizist",
-          "Frank Meyer-Brockmann"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Detective Ella",
+          "sprecher" : "Neda Rahmanian"
+        },
+        {
+          "rolle" : "Officer James",
+          "sprecher" : "Sascha Gutzeit"
+        },
+        {
+          "rolle" : "Mr. Shaw",
+          "sprecher" : "Michael Grimm"
+        },
+        {
+          "rolle" : "Paul Forsters",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Esprit",
+          "sprecher" : "Matthias Keller"
+        },
+        {
+          "rolle" : "Anthony Spring",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Butch",
+          "sprecher" : "Tom Pidde"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Goodween",
+          "sprecher" : "André Minninger"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Frank Meyer-Brockmann"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/219/metadata.json",
@@ -27931,59 +28039,59 @@
           "end" : 4446747
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Bill Greyfield",
-          "Gordon Piedesack"
-        ],
-        [
-          "Karen Greyfield",
-          "Beate Rysopp"
-        ],
-        [
-          "Ralph Sanders",
-          "Jens Böttcher"
-        ],
-        [
-          "Dylan Reid",
-          "Matthias Keller"
-        ],
-        [
-          "Zoe",
-          "Marion Martienzen"
-        ],
-        [
-          "Simon Cobby",
-          "Pat Murphy"
-        ],
-        [
-          "Angela van Limbeek",
-          "Malin Steffen"
-        ],
-        [
-          "John Addington",
-          "Andreas Birnbaum"
-        ],
-        [
-          "Doktor Williams",
-          "Holger Wemhoff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Bill Greyfield",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Karen Greyfield",
+          "sprecher" : "Beate Rysopp"
+        },
+        {
+          "rolle" : "Ralph Sanders",
+          "sprecher" : "Jens Böttcher"
+        },
+        {
+          "rolle" : "Dylan Reid",
+          "sprecher" : "Matthias Keller"
+        },
+        {
+          "rolle" : "Zoe",
+          "sprecher" : "Marion Martienzen"
+        },
+        {
+          "rolle" : "Simon Cobby",
+          "sprecher" : "Pat Murphy"
+        },
+        {
+          "rolle" : "Angela van Limbeek",
+          "sprecher" : "Malin Steffen"
+        },
+        {
+          "rolle" : "John Addington",
+          "sprecher" : "Andreas Birnbaum"
+        },
+        {
+          "rolle" : "Doktor Williams",
+          "sprecher" : "Holger Wemhoff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/220/metadata.json",
@@ -28047,47 +28155,47 @@
           "end" : 3932520
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Professor Douglas Bancroft",
-          "Jürgen Thormann"
-        ],
-        [
-          "Butler Vernom",
-          "Jürgen Holdorf"
-        ],
-        [
-          "Miss Mortimer",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Elwood Shoreland",
-          "Martin May"
-        ],
-        [
-          "Darian",
-          "Marc Zabinski"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Professor Douglas Bancroft",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Butler Vernom",
+          "sprecher" : "Jürgen Holdorf"
+        },
+        {
+          "rolle" : "Miss Mortimer",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Elwood Shoreland",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Darian",
+          "sprecher" : "Marc Zabinski"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/221/metadata.json",
@@ -28146,67 +28254,67 @@
           "end" : 4615480
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Amanda Blunt",
-          "Katy Karrenbauer"
-        ],
-        [
-          "Quinn",
-          "Till Hagen"
-        ],
-        [
-          "Lyn",
-          "Henrike Fehrs"
-        ],
-        [
-          "Opossum",
-          "Reinhold Kammerer"
-        ],
-        [
-          "Nancy",
-          "Britta Steffenhagen"
-        ],
-        [
-          "Odo",
-          "Sebastian König"
-        ],
-        [
-          "Dimwitt",
-          "Achim Schülke"
-        ],
-        [
-          "Telefonstimme",
-          "Nico König"
-        ],
-        [
-          "Colstone",
-          "Peter G. Dirmeier"
-        ],
-        [
-          "Moderatorin",
-          "Petra Kleinert"
-        ],
-        [
-          "Sheriff",
-          "Konstantin Graudus"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Amanda Blunt",
+          "sprecher" : "Katy Karrenbauer"
+        },
+        {
+          "rolle" : "Quinn",
+          "sprecher" : "Till Hagen"
+        },
+        {
+          "rolle" : "Lyn",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Opossum",
+          "sprecher" : "Reinhold Kammerer"
+        },
+        {
+          "rolle" : "Nancy",
+          "sprecher" : "Britta Steffenhagen"
+        },
+        {
+          "rolle" : "Odo",
+          "sprecher" : "Sebastian König"
+        },
+        {
+          "rolle" : "Dimwitt",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Telefonstimme",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Colstone",
+          "sprecher" : "Peter G. Dirmeier"
+        },
+        {
+          "rolle" : "Moderatorin",
+          "sprecher" : "Petra Kleinert"
+        },
+        {
+          "rolle" : "Sheriff",
+          "sprecher" : "Konstantin Graudus"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/222/metadata.json",
@@ -28265,71 +28373,72 @@
           "end" : 4799880
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Trenton",
-          "Marco Steeger"
-        ],
-        [
-          "Buzzy",
-          "Merete Brettschneider"
-        ],
-        [
-          "Harold",
-          "Leonhard Mahlich"
-        ],
-        [
-          "George",
-          "Robin Brosch"
-        ],
-        [
-          "Roberta",
-          "Pamela Punti"
-        ],
-        [
-          "Evander Prettyman",
-          "Nicolas Böll"
-        ],
-        [
-          "Liam",
-          "Stefan Brönneke"
-        ],
-        [
-          "Lincoln",
-          "Hans Peter Korff"
-        ],
-        [
-          "Maya",
-          "Manuela Eifrig"
-        ],
-        [
-          "Haylie",
-          "Barbara Schipper"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Trenton",
+          "sprecher" : "Marco Steeger"
+        },
+        {
+          "rolle" : "Buzzy",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Harold",
+          "sprecher" : "Leonhard Mahlich"
+        },
+        {
+          "rolle" : "George",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Roberta",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Evander Prettyman",
+          "sprecher" : "Nicolas Böll"
+        },
+        {
+          "rolle" : "Liam",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Lincoln",
+          "sprecher" : "Hans Peter Korff"
+        },
+        {
+          "rolle" : "Maya",
+          "sprecher" : "Manuela Eifrig"
+        },
+        {
+          "rolle" : "Haylie",
+          "sprecher" : "Barbara Schipper"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/223/metadata.json",
@@ -28388,55 +28497,55 @@
           "end" : 4363613
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ian Carew",
-          "Sascha Draeger"
-        ],
-        [
-          "Mambo Mawu",
-          "Regina Lemnitz"
-        ],
-        [
-          "Kommissarin Martinez",
-          "Caroline Kiesewetter"
-        ],
-        [
-          "Larry",
-          "Stephan Schad"
-        ],
-        [
-          "Morton",
-          "Michael Prelle"
-        ],
-        [
-          "Thabani Mathoho",
-          "Tim Grobe"
-        ],
-        [
-          "Clayton Badu",
-          "Frank Roder"
-        ],
-        [
-          "Cumba Balewa",
-          "Heidi Berndt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ian Carew",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Mambo Mawu",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Kommissarin Martinez",
+          "sprecher" : "Caroline Kiesewetter"
+        },
+        {
+          "rolle" : "Larry",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Michael Prelle"
+        },
+        {
+          "rolle" : "Thabani Mathoho",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Clayton Badu",
+          "sprecher" : "Frank Roder"
+        },
+        {
+          "rolle" : "Cumba Balewa",
+          "sprecher" : "Heidi Berndt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/224/metadata.json",
@@ -28664,83 +28773,83 @@
           "end" : 10696453
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Kenneth",
-          "Till Huster"
-        ],
-        [
-          "Chief Householder",
-          "Gordon Piedesack"
-        ],
-        [
-          "Tricia Cooper",
-          "Anna Carlsson"
-        ],
-        [
-          "Mr. Rice",
-          "Stephan Schad"
-        ],
-        [
-          "Katee",
-          "Anne Moll"
-        ],
-        [
-          "Sergeant Murray",
-          "Achim Buch"
-        ],
-        [
-          "Mary",
-          "Svantje Wascher"
-        ],
-        [
-          "Scott",
-          "John Wesley Zielmann"
-        ],
-        [
-          "Johnson",
-          "Wanja Mues"
-        ],
-        [
-          "Nigel",
-          "Tim Mälzer"
-        ],
-        [
-          "Patrick",
-          "Christian Rudolf"
-        ],
-        [
-          "Dolly Craig",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Mrs. Cooper",
-          "Angelika Berg"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Kenneth",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Chief Householder",
+          "sprecher" : "Gordon Piedesack"
+        },
+        {
+          "rolle" : "Tricia Cooper",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Mr. Rice",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Katee",
+          "sprecher" : "Anne Moll"
+        },
+        {
+          "rolle" : "Sergeant Murray",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Mary",
+          "sprecher" : "Svantje Wascher"
+        },
+        {
+          "rolle" : "Scott",
+          "sprecher" : "John Wesley Zielmann"
+        },
+        {
+          "rolle" : "Johnson",
+          "sprecher" : "Wanja Mues"
+        },
+        {
+          "rolle" : "Nigel",
+          "sprecher" : "Tim Mälzer"
+        },
+        {
+          "rolle" : "Patrick",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Dolly Craig",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Mrs. Cooper",
+          "sprecher" : "Angelika Berg"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/225/metadata.json",
@@ -28788,59 +28897,59 @@
           "end" : 4953600
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Clarissa Franklin",
-          "Judy Winter"
-        ],
-        [
-          "Jack Cliffwater",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Mr. Bumblebee",
-          "Tim Grobe"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Evans",
-          "Merete Brettschneider"
-        ],
-        [
-          "Mr. Powers",
-          "Achim Buch"
-        ],
-        [
-          "Meyer",
-          "Tim Helssen"
-        ],
-        [
-          "Polizist",
-          "John Wesley Zielmann"
-        ],
-        [
-          "Polizistin",
-          "Merle Tucholka"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Clarissa Franklin",
+          "sprecher" : "Judy Winter"
+        },
+        {
+          "rolle" : "Jack Cliffwater",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Mr. Bumblebee",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Evans",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Mr. Powers",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Meyer",
+          "sprecher" : "Tim Helssen"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "John Wesley Zielmann"
+        },
+        {
+          "rolle" : "Polizistin",
+          "sprecher" : "Merle Tucholka"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/226/metadata.json",

--- a/web/data/Serie/001/metadata.json
+++ b/web/data/Serie/001/metadata.json
@@ -47,55 +47,57 @@
       "end" : 3144160
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Fentriss, Schriftsteller",
-      "Richard Lauffen"
-    ],
-    [
-      "Mr. Claudius, Kunsthändler",
-      "Gerlach Fiedler"
-    ],
-    [
-      "Mrs. Claudius",
-      "Ingrid Andree"
-    ],
-    [
-      "Miss Waggoner",
-      "Katharina Brauren"
-    ],
-    [
-      "Carlos",
-      "Stefan Brönneke"
-    ],
-    [
-      "Onkel Ramos",
-      "Juan Perez [Karl-Ulrich Meves]"
-    ],
-    [
-      "Hugenay",
-      "Albert Giro [Wolfgang Kubach]"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Fentriss, Schriftsteller",
+      "sprecher" : "Richard Lauffen"
+    },
+    {
+      "rolle" : "Mr. Claudius, Kunsthändler",
+      "sprecher" : "Gerlach Fiedler"
+    },
+    {
+      "rolle" : "Mrs. Claudius",
+      "sprecher" : "Ingrid Andree"
+    },
+    {
+      "rolle" : "Miss Waggoner",
+      "sprecher" : "Katharina Brauren"
+    },
+    {
+      "rolle" : "Carlos",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Onkel Ramos",
+      "sprecher" : "Karl-Ulrich Meves",
+      "pseudonym" : "Juan Perez"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Albert Giro"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/001/metadata.json",

--- a/web/data/Serie/002/metadata.json
+++ b/web/data/Serie/002/metadata.json
@@ -47,63 +47,66 @@
       "end" : 2738933
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Patrick Kenneth",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Java-Jim",
-      "Heinz Überreiter [Gottfried Kramer]"
-    ],
-    [
-      "Mrs. Flora Gunn",
-      "Veronika Weckler"
-    ],
-    [
-      "Cluny Gunn",
-      "Fabian Harloff"
-    ],
-    [
-      "Rory",
-      "Klaus-Peter Reisch [Peter Buchholz]"
-    ],
-    [
-      "Stebins",
-      "Hans Meinhardt [Karl-Ulrich Meves]"
-    ],
-    [
-      "Mr. Widner",
-      "Ernst von Klipstein"
-    ],
-    [
-      "Verwalter von Powder Gulch",
-      "Reiner Brönneke"
-    ],
-    [
-      "Bibliothekarin",
-      "Katharina Brauren"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Patrick Kenneth",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Java-Jim",
+      "sprecher" : "Gottfried Kramer",
+      "pseudonym" : "Heinz Überreiter"
+    },
+    {
+      "rolle" : "Mrs. Flora Gunn",
+      "sprecher" : "Veronika Weckler"
+    },
+    {
+      "rolle" : "Cluny Gunn",
+      "sprecher" : "Fabian Harloff"
+    },
+    {
+      "rolle" : "Rory",
+      "sprecher" : "Peter Buchholz",
+      "pseudonym" : "Klaus-Peter Reisch"
+    },
+    {
+      "rolle" : "Stebins",
+      "sprecher" : "Karl-Ulrich Meves",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Mr. Widner",
+      "sprecher" : "Ernst von Klipstein"
+    },
+    {
+      "rolle" : "Verwalter von Powder Gulch",
+      "sprecher" : "Reiner Brönneke"
+    },
+    {
+      "rolle" : "Bibliothekarin",
+      "sprecher" : "Katharina Brauren"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/002/metadata.json",

--- a/web/data/Serie/003/metadata.json
+++ b/web/data/Serie/003/metadata.json
@@ -47,59 +47,62 @@
       "end" : 2748440
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Prentice",
-      "Hans Hessling"
-    ],
-    [
-      "Niedland",
-      "Gerlach Fiedler"
-    ],
-    [
-      "Pfarrer",
-      "Ernst von Klipstein"
-    ],
-    [
-      "Mrs. Boogle",
-      "Katharina Brauren"
-    ],
-    [
-      "Sonny Elmquist",
-      "Philip Kunzmann [Gernot Endemann]"
-    ],
-    [
-      "Mr. Murphy",
-      "Karl-Ulrich Meves"
-    ],
-    [
-      "Miss Chalmers",
-      "Pamela Punti"
-    ],
-    [
-      "Mr. Hassel",
-      "Rolf Hundertwasser"
-    ],
-    [
-      "Polizist",
-      "Rolf Mamero"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Prentice",
+      "sprecher" : "Hans Hessling"
+    },
+    {
+      "rolle" : "Niedland",
+      "sprecher" : "Gerlach Fiedler"
+    },
+    {
+      "rolle" : "Pfarrer",
+      "sprecher" : "Ernst von Klipstein"
+    },
+    {
+      "rolle" : "Mrs. Boogle",
+      "sprecher" : "Katharina Brauren"
+    },
+    {
+      "rolle" : "Sonny Elmquist",
+      "sprecher" : "Gernot Endemann",
+      "pseudonym" : "Philip Kunzmann"
+    },
+    {
+      "rolle" : "Mr. Murphy",
+      "sprecher" : "Karl-Ulrich Meves"
+    },
+    {
+      "rolle" : "Miss Chalmers",
+      "sprecher" : "Heikedine Körting",
+      "pseudonym" : "Pamela Punti"
+    },
+    {
+      "rolle" : "Mr. Hassel",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Rolf Hundertwasser"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Rolf Mamero"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/003/metadata.json",

--- a/web/data/Serie/004/metadata.json
+++ b/web/data/Serie/004/metadata.json
@@ -47,71 +47,74 @@
       "end" : 2662960
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Andy Carson",
-      "Stefan Schwade"
-    ],
-    [
-      "Mr. Carson",
-      "Reiner Brönneke"
-    ],
-    [
-      "Khan, der Kraftmensch",
-      "René Genesis"
-    ],
-    [
-      "Einzigartiger Gabbo",
-      "Iwan Raszinsky [Karl-Ulrich Meves]"
-    ],
-    [
-      "Iwan",
-      "Boris Stepin [Wolfgang Kubach]"
-    ],
-    [
-      "Junge",
-      "Philip Baader"
-    ],
-    [
-      "Hauptkommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Der alte Mann",
-      "Lothar Grützner"
-    ],
-    [
-      "Wachmann",
-      "Peter Buchholz"
-    ],
-    [
-      "Jungen",
-      "Stefan Brönneke, Alexander Körting"
-    ],
-    [
-      "Jahrmarktfrau",
-      "Heikedine Körting"
-    ],
-    [
-      "Funksprecher",
-      "Gernot Endemann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Andy Carson",
+      "sprecher" : "Stefan Schwade"
+    },
+    {
+      "rolle" : "Mr. Carson",
+      "sprecher" : "Reiner Brönneke"
+    },
+    {
+      "rolle" : "Khan, der Kraftmensch",
+      "sprecher" : "René Genesis"
+    },
+    {
+      "rolle" : "Einzigartiger Gabbo",
+      "sprecher" : "Karl-Ulrich Meves",
+      "pseudonym" : "Iwan Raszinsky"
+    },
+    {
+      "rolle" : "Iwan",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Boris Stepin"
+    },
+    {
+      "rolle" : "Junge 1",
+      "sprecher" : "Stefan Brönneke",
+      "pseudonym" : "Philip Baader"
+    },
+    {
+      "rolle" : "Junge 2",
+      "sprecher" : "Alexander Körting"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Der alte Mann",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Wachmann",
+      "sprecher" : "Peter Buchholz"
+    },
+    {
+      "rolle" : "Jahrmarktfrau",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Funksprecher",
+      "sprecher" : "Gernot Endemann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/004/metadata.json",

--- a/web/data/Serie/005/metadata.json
+++ b/web/data/Serie/005/metadata.json
@@ -47,59 +47,59 @@
       "end" : 2960987
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "August August, genannt Gus",
-      "Stephan Chreszinski"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Mr. Dwiggins",
-      "Joachim Wolff"
-    ],
-    [
-      "Mr. Rhandur",
-      "Gottfried Kramer"
-    ],
-    [
-      "Joe",
-      "Peter Buchholz"
-    ],
-    [
-      "Lisa",
-      "Madeleine Stolze"
-    ],
-    [
-      "Mutter",
-      "Renate Pichler"
-    ],
-    [
-      "Patrick Kenneth",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Bauarbeiter",
-      "Gernot Endemann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "August August, genannt Gus",
+      "sprecher" : "Stephan Chrzescinski"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Mr. Dwiggins",
+      "sprecher" : "Joachim Wolff"
+    },
+    {
+      "rolle" : "Mr. Rhandur",
+      "sprecher" : "Gottfried Kramer"
+    },
+    {
+      "rolle" : "Joe",
+      "sprecher" : "Peter Buchholz"
+    },
+    {
+      "rolle" : "Lisa",
+      "sprecher" : "Madeleine Stolze"
+    },
+    {
+      "rolle" : "Mutter",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Patrick Kenneth",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Bauarbeiter",
+      "sprecher" : "Gernot Endemann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/005/metadata.json",

--- a/web/data/Serie/006/metadata.json
+++ b/web/data/Serie/006/metadata.json
@@ -47,67 +47,69 @@
       "end" : 2752640
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Patrick Kenneth",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Gulliver",
-      "Joachim Wolff"
-    ],
-    [
-      "Mr. Maximillian",
-      "Richard Lauffen"
-    ],
-    [
-      "Hauptkommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Mrs. Miller",
-      "Marianne Wolters [Marianne Kehlau]"
-    ],
-    [
-      "Mr. Grant",
-      "Hans Meinhardt [Lothar Grützner]"
-    ],
-    [
-      "Auktionator",
-      "Gerlach Fiedler"
-    ],
-    [
-      "Fred Brown",
-      "Peter Buchholz"
-    ],
-    [
-      "Hauswirt",
-      "Reiner Brönneke"
-    ],
-    [
-      "Mann",
-      "Karl-Ulrich Meves"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Patrick Kenneth",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Gulliver",
+      "sprecher" : "Joachim Wolff"
+    },
+    {
+      "rolle" : "Mr. Maximillian",
+      "sprecher" : "Richard Lauffen"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Mrs. Miller",
+      "sprecher" : "Marianne Kehlau",
+      "pseudonym" : "Marianne Wolters"
+    },
+    {
+      "rolle" : "Mr. Grant",
+      "sprecher" : "Lothar Grützner",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Auktionator",
+      "sprecher" : "Gerlach Fiedler"
+    },
+    {
+      "rolle" : "Fred Brown",
+      "sprecher" : "Peter Buchholz"
+    },
+    {
+      "rolle" : "Hauswirt",
+      "sprecher" : "Reiner Brönneke"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Karl-Ulrich Meves"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/006/metadata.json",

--- a/web/data/Serie/007/metadata.json
+++ b/web/data/Serie/007/metadata.json
@@ -47,47 +47,48 @@
       "end" : 2721773
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "H. H. Allen",
-      "Werner Cartano"
-    ],
-    [
-      "Mr. Shelby",
-      "Richard Lauffen"
-    ],
-    [
-      "Mr. Carter",
-      "F. J. Steffens"
-    ],
-    [
-      "Jack Morgan",
-      "Klaus Klein [Wolfgang Kubach]"
-    ],
-    [
-      "Harry Morgan",
-      "Reiner Brönneke"
-    ],
-    [
-      "Telephonistin",
-      "Reinhild Schneider"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "H. H. Allen",
+      "sprecher" : "Werner Cartano"
+    },
+    {
+      "rolle" : "Mr. Shelby",
+      "sprecher" : "Richard Lauffen"
+    },
+    {
+      "rolle" : "Mr. Carter",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "Jack Morgan",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Klaus Klein"
+    },
+    {
+      "rolle" : "Harry Morgan",
+      "sprecher" : "Reiner Brönneke"
+    },
+    {
+      "rolle" : "Telephonistin",
+      "sprecher" : "Reinhilt Schneider"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/007/metadata.json",

--- a/web/data/Serie/008/metadata.json
+++ b/web/data/Serie/008/metadata.json
@@ -47,67 +47,69 @@
       "end" : 3203720
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Chang",
-      "Torsten Sense"
-    ],
-    [
-      "Patrick Kenneth",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Miss Lydia Green",
-      "Marianne Kehlau"
-    ],
-    [
-      "Harold Carlson",
-      "Alexander Stubbe [Peter Kirchberger]"
-    ],
-    [
-      "Hauptkommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Jensen",
-      "Rolf Mamero"
-    ],
-    [
-      "Won",
-      "Victor Bernard [Ernst von Klipstein]"
-    ],
-    [
-      "Wongs Diener",
-      "Karl-Ulrich Meves"
-    ],
-    [
-      "Li",
-      "Renate Pichler"
-    ],
-    [
-      "Männer bei Greens Haus",
-      "Reiner Brönneke, Gernot Endemann"
-    ],
-    [
-      "Polizist",
-      "Peter Buchholz"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Chang",
+      "sprecher" : "Torsten Sense"
+    },
+    {
+      "rolle" : "Patrick Kenneth",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Miss Lydia Green",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Harold Carlson",
+      "sprecher" : "Peter Kirchberger",
+      "pseudonym" : "Alexander Stubbe"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Jensen",
+      "sprecher" : "Rolf Mamero"
+    },
+    {
+      "rolle" : "Won",
+      "sprecher" : "Ernst von Klipstein",
+      "pseudonym" : "Victor Bernard"
+    },
+    {
+      "rolle" : "Wongs Diener",
+      "sprecher" : "Karl-Ulrich Meves"
+    },
+    {
+      "rolle" : "Li",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Männer bei Greens Haus",
+      "sprecher" : "Reiner Brönneke, Gernot Endemann"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Peter Buchholz"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/008/metadata.json",

--- a/web/data/Serie/009/metadata.json
+++ b/web/data/Serie/009/metadata.json
@@ -47,63 +47,66 @@
       "end" : 2832680
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Professor Carswell",
-      "Theodor Anzinger"
-    ],
-    [
-      "Hal Carswell",
-      "Oliver Mink"
-    ],
-    [
-      "Gräfin",
-      "Henriette Bischoff [Gisela Trowe]"
-    ],
-    [
-      "Armand Marechal",
-      "Joachim Wolff"
-    ],
-    [
-      "De Groot",
-      "René Genesis"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Maxwell James",
-      "Werner Cartano"
-    ],
-    [
-      "Hauptkommissar Reynolds",
-      "Horst Frank"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Professor Carswell",
+      "sprecher" : "Volker Bogdan",
+      "pseudonym" : "Theodor Anzinger"
+    },
+    {
+      "rolle" : "Hal Carswell",
+      "sprecher" : "Oliver Mink"
+    },
+    {
+      "rolle" : "Gräfin",
+      "sprecher" : "Gisela Trowe",
+      "pseudonym" : "Henriette Bischoff"
+    },
+    {
+      "rolle" : "Armand Marechal",
+      "sprecher" : "Joachim Wolff"
+    },
+    {
+      "rolle" : "De Groot",
+      "sprecher" : "René Genesis"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Maxwell James",
+      "sprecher" : "Werner Cartano"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/009/metadata.json",

--- a/web/data/Serie/010/metadata.json
+++ b/web/data/Serie/010/metadata.json
@@ -47,63 +47,65 @@
       "end" : 3043693
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Patrick",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Professor Yarborough",
-      "Karl Walter Diess"
-    ],
-    [
-      "Wilkins, sein Butler",
-      "Ulrich Matschoss"
-    ],
-    [
-      "Professor Freeman",
-      "Joachim Wolff [Klaus Stieringer]"
-    ],
-    [
-      "Achmed",
-      "Ali Branowitch [Joachim Wolff]"
-    ],
-    [
-      "Hamid",
-      "Alexander Körting"
-    ],
-    [
-      "Harry",
-      "Peter Buchholz"
-    ],
-    [
-      "Joe",
-      "Reiner Brönneke"
-    ],
-    [
-      "Uhrenmacher",
-      "Gernot Endemann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Patrick",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Professor Yarborough",
+      "sprecher" : "Karl Walter Diess"
+    },
+    {
+      "rolle" : "Wilkins, sein Butler",
+      "sprecher" : "Ulrich Matschoss"
+    },
+    {
+      "rolle" : "Professor Freeman",
+      "sprecher" : "Klaus Stieringer",
+      "pseudonym" : "Viktor Bramer"
+    },
+    {
+      "rolle" : "Achmed",
+      "sprecher" : "Joachim Wolff",
+      "pseudonym" : "Ali Branowitch"
+    },
+    {
+      "rolle" : "Hamid",
+      "sprecher" : "Alexander Körting"
+    },
+    {
+      "rolle" : "Harry",
+      "sprecher" : "Peter Buchholz"
+    },
+    {
+      "rolle" : "Joe",
+      "sprecher" : "Reiner Brönneke"
+    },
+    {
+      "rolle" : "Uhrenmacher",
+      "sprecher" : "Gernot Endemann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/010/metadata.json",

--- a/web/data/Serie/011/metadata.json
+++ b/web/data/Serie/011/metadata.json
@@ -47,43 +47,43 @@
       "end" : 2894907
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Stephen Terrill",
-      "Wolf Rahtjen"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Mr. Grant",
-      "Horst Breiter"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Stephen Terrill",
+      "sprecher" : "Wolf Rahtjen"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Mr. Grant",
+      "sprecher" : "Horst Breiter"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/011/metadata.json",

--- a/web/data/Serie/012/metadata.json
+++ b/web/data/Serie/012/metadata.json
@@ -47,71 +47,75 @@
       "end" : 2736347
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Felix",
-      "Karl-Ulrich Meves"
-    ],
-    [
-      "Mrs. Smith",
-      "Maria Benders"
-    ],
-    [
-      "Harry",
-      "Marco Beddis"
-    ],
-    [
-      "Mrs. King",
-      "Helga Bammert"
-    ],
-    [
-      "Julie Taylor",
-      "Renate Pichler"
-    ],
-    [
-      "Martha Harris",
-      "Marga Maasberg"
-    ],
-    [
-      "Carlos",
-      "Hans-Werner Kuhn [Günter Heising]"
-    ],
-    [
-      "Gerald Cramer",
-      "Volker Brandt"
-    ],
-    [
-      "Gerald Watson",
-      "Werner van Thiel [Werner Cartano]"
-    ],
-    [
-      "Hugenay",
-      "Albert Giro [Wolfgang Kubach]"
-    ],
-    [
-      "Hauptkommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Mr Jankins",
-      "Lothar Zibell"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Felix",
+      "sprecher" : "Karl-Ulrich Meves"
+    },
+    {
+      "rolle" : "Mrs. Smith",
+      "sprecher" : "Brigitte Alexis",
+      "pseudonym" : "Maria Benders"
+    },
+    {
+      "rolle" : "Harry",
+      "sprecher" : "Marco Beddies"
+    },
+    {
+      "rolle" : "Mrs. King",
+      "sprecher" : "Helga Bammert"
+    },
+    {
+      "rolle" : "Julie Taylor",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Martha Harris",
+      "sprecher" : "Eva Gelb"
+    },
+    {
+      "rolle" : "Carlos",
+      "sprecher" : "Günther Heising",
+      "pseudonym" : "Hans-Werner Kuhn"
+    },
+    {
+      "rolle" : "Gerald Cramer",
+      "sprecher" : "Volker Brandt"
+    },
+    {
+      "rolle" : "Gerald Watson",
+      "sprecher" : "Werner Cartano",
+      "pseudonym" : "Werner van Thiel"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Albert Giro"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Mr. Jankins",
+      "sprecher" : "Lothar Zibell"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/012/metadata.json",

--- a/web/data/Serie/013/metadata.json
+++ b/web/data/Serie/013/metadata.json
@@ -47,67 +47,68 @@
       "end" : 2640320
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Mr. Harris",
-      "Günter Heising"
-    ],
-    [
-      "Miss Sanchez",
-      "Marlene Lindner [Ursula Vogel]"
-    ],
-    [
-      "Ted Sanchez",
-      "Nikolas Körting"
-    ],
-    [
-      "Sanders",
-      "Torsten Sense"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Natches",
-      "Gernot Endermann"
-    ],
-    [
-      "Hauptkommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Prof. Meeker",
-      "Josef Dahmen"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Polizist",
-      "Joachim Wolff"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Mr. Harris",
+      "sprecher" : "Günther Heising"
+    },
+    {
+      "rolle" : "Miss Sanchez",
+      "sprecher" : "Cordula Hubrich",
+      "pseudonym" : "Marlene Lindner"
+    },
+    {
+      "rolle" : "Ted Sanchez",
+      "sprecher" : "Nicolas Körting"
+    },
+    {
+      "rolle" : "Sanders",
+      "sprecher" : "Torsten Sense"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Natches",
+      "sprecher" : "Gernot Endemann"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Prof. Meeker",
+      "sprecher" : "Josef Dahmen"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Joachim Wolff"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/013/metadata.json",

--- a/web/data/Serie/014/metadata.json
+++ b/web/data/Serie/014/metadata.json
@@ -47,63 +47,63 @@
       "end" : 2550187
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Smathers",
-      "Josef Dahmen"
-    ],
-    [
-      "Mr. Jensen",
-      "Wolf Rahtjen"
-    ],
-    [
-      "Patrick",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Kenneth",
-      "Lutz Mackensy"
-    ],
-    [
-      "Kathleen",
-      "Brigitte Alexis"
-    ],
-    [
-      "Mr. Joe Hammond",
-      "Volker Brandt"
-    ],
-    [
-      "Mrs. Hammond",
-      "Hanni Vanhaiden"
-    ],
-    [
-      "Richardsen",
-      "Joachim Wolff"
-    ],
-    [
-      "Polizist",
-      "Horst Stark"
-    ],
-    [
-      "Lieferant",
-      "F.-J. Steffens"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Smathers",
+      "sprecher" : "Josef Dahmen"
+    },
+    {
+      "rolle" : "Mr. Jensen",
+      "sprecher" : "Wolf Rahtjen"
+    },
+    {
+      "rolle" : "Patrick",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Kenneth",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Kathleen",
+      "sprecher" : "Brigitte Alexis"
+    },
+    {
+      "rolle" : "Mr. Joe Hammond",
+      "sprecher" : "Volker Brandt"
+    },
+    {
+      "rolle" : "Mrs. Hammond",
+      "sprecher" : "Hanni Vanhaiden"
+    },
+    {
+      "rolle" : "Richardsen",
+      "sprecher" : "Joachim Wolff"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Lieferant",
+      "sprecher" : "Franz-Josef Steffens"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/014/metadata.json",

--- a/web/data/Serie/015/metadata.json
+++ b/web/data/Serie/015/metadata.json
@@ -47,67 +47,68 @@
       "end" : 2385253
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Miss Larson",
-      "Reinhilt Schneider"
-    ],
-    [
-      "Jim Hall",
-      "Horst Stark"
-    ],
-    [
-      "Mike Hall",
-      "Mathias Lorenz"
-    ],
-    [
-      "Eastland",
-      "Karl Walter Diess"
-    ],
-    [
-      "Olsen",
-      "Karl-Ulrich Meves"
-    ],
-    [
-      "Hank Murphy",
-      "Harald Pages"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Doc Dawson",
-      "Wolfgang Jürgen"
-    ],
-    [
-      "Dobbsie",
-      "Joachim Wolff"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Miss Larson",
+      "sprecher" : "Reinhilt Schneider"
+    },
+    {
+      "rolle" : "Jim Hall",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Mike Hall",
+      "sprecher" : "Mathias Lorenz"
+    },
+    {
+      "rolle" : "Eastland",
+      "sprecher" : "Karl Walter Diess"
+    },
+    {
+      "rolle" : "Olsen",
+      "sprecher" : "Karl-Ulrich Meves"
+    },
+    {
+      "rolle" : "Hank Murphy",
+      "sprecher" : "Harald Pages"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Doc Dawson",
+      "sprecher" : "Wolfgang Jürgen"
+    },
+    {
+      "rolle" : "Dobbsie",
+      "sprecher" : "Joachim Wolff"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/015/metadata.json",

--- a/web/data/Serie/016/metadata.json
+++ b/web/data/Serie/016/metadata.json
@@ -47,55 +47,56 @@
       "end" : 2551347
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Darnley",
-      "Gisela Trowe"
-    ],
-    [
-      "Jeff Darnley",
-      "Mike Henning"
-    ],
-    [
-      "Jenny Darnley",
-      "Marlen Krause"
-    ],
-    [
-      "Senior Santora",
-      "Jürgen Thormann"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Gomez",
-      "Karl-Heinz Gerdesmann"
-    ],
-    [
-      "Brotverkäufer",
-      "Harald Pages"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Darnley",
+      "sprecher" : "Gisela Trowe"
+    },
+    {
+      "rolle" : "Jeff Darnley",
+      "sprecher" : "Mike Henning"
+    },
+    {
+      "rolle" : "Jenny Darnley",
+      "sprecher" : "Marlen Krause"
+    },
+    {
+      "rolle" : "Senior Santora",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Gomez",
+      "sprecher" : "Karl-Heinz Gerdesmann"
+    },
+    {
+      "rolle" : "Brotverkäufer",
+      "sprecher" : "Harald Pages"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/016/metadata.json",

--- a/web/data/Serie/017/metadata.json
+++ b/web/data/Serie/017/metadata.json
@@ -47,59 +47,60 @@
       "end" : 2524840
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Hauptkommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Nelly Towne",
-      "Pamela Punti [Heikedine Körting]"
-    ],
-    [
-      "Billy Towne",
-      "Peer Siegel"
-    ],
-    [
-      "Ordner",
-      "Lothar Grützner"
-    ],
-    [
-      "Lopez",
-      "Hans Irle"
-    ],
-    [
-      "Dillon",
-      "Gottfried Kramer"
-    ],
-    [
-      "Roger Callow",
-      "Hans Daniel"
-    ],
-    [
-      "Kellnerin",
-      "Heidi Schaffrath"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Nelly Towne",
+      "sprecher" : "Heikedine Körting",
+      "pseudonym" : "Pamela Punti"
+    },
+    {
+      "rolle" : "Billy Towne",
+      "sprecher" : "Peer Siegel"
+    },
+    {
+      "rolle" : "Ordner",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Lopez",
+      "sprecher" : "Hans Irle"
+    },
+    {
+      "rolle" : "Dillon",
+      "sprecher" : "Gottfried Kramer"
+    },
+    {
+      "rolle" : "Roger Callow",
+      "sprecher" : "Hans Daniel"
+    },
+    {
+      "rolle" : "Kellnerin",
+      "sprecher" : "Heidi Schaffrath"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/017/metadata.json",

--- a/web/data/Serie/018/metadata.json
+++ b/web/data/Serie/018/metadata.json
@@ -47,67 +47,68 @@
       "end" : 2606493
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Sam",
-      "Joachim Wolff"
-    ],
-    [
-      "Chris Markos",
-      "Stephan Chrzeszinski"
-    ],
-    [
-      "Kommissar Nostigon",
-      "Volker Brandt"
-    ],
-    [
-      "Mr. Shaw",
-      "Joachim Richert"
-    ],
-    [
-      "Denton",
-      "Karl-Heinz Gerdesmann"
-    ],
-    [
-      "Farraday",
-      "Gottfried Kramer"
-    ],
-    [
-      "Jeff",
-      "Harald Pages"
-    ],
-    [
-      "Bill Ballinger",
-      "Günter Flesh"
-    ],
-    [
-      "Jim Ballinger",
-      "Heinz Werder"
-    ],
-    [
-      "Mr. Norris",
-      "Horst Schick"
-    ],
-    [
-      "Mrs. Barton",
-      "Marianne Kehlau"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Sam",
+      "sprecher" : "Joachim Wolff"
+    },
+    {
+      "rolle" : "Chris Markos",
+      "sprecher" : "Stephan Chrzescinski"
+    },
+    {
+      "rolle" : "Kommissar Nostigon",
+      "sprecher" : "Volker Brandt"
+    },
+    {
+      "rolle" : "Mr. Shaw",
+      "sprecher" : "Joachim Richert"
+    },
+    {
+      "rolle" : "Denton",
+      "sprecher" : "Karl-Heinz Gerdesmann"
+    },
+    {
+      "rolle" : "Farraday",
+      "sprecher" : "Gottfried Kramer"
+    },
+    {
+      "rolle" : "Jeff",
+      "sprecher" : "Harald Pages"
+    },
+    {
+      "rolle" : "Bill Ballinger",
+      "sprecher" : "Günther Flesch"
+    },
+    {
+      "rolle" : "Jim Ballinger",
+      "sprecher" : "Hans Irle",
+      "pseudonym" : "Heinz Werder"
+    },
+    {
+      "rolle" : "Mr. Norris",
+      "sprecher" : "Horst Schick"
+    },
+    {
+      "rolle" : "Mrs. Barton",
+      "sprecher" : "Marianne Kehlau"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/018/metadata.json",

--- a/web/data/Serie/019/metadata.json
+++ b/web/data/Serie/019/metadata.json
@@ -47,59 +47,59 @@
       "end" : 2676573
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Dalton",
-      "Jürgen Thormann"
-    ],
-    [
-      "Mrs. Dalton",
-      "Helga Bammert"
-    ],
-    [
-      "Hardin",
-      "Christian Mey"
-    ],
-    [
-      "Prof. Walsh",
-      "Joachim Rake"
-    ],
-    [
-      "Ben Jackson",
-      "Günter Flesh"
-    ],
-    [
-      "Wreston",
-      "Ulrich Benthin"
-    ],
-    [
-      "Cardigo",
-      "Harald Pages"
-    ],
-    [
-      "Waldo Turner",
-      "Lothar Grützner"
-    ],
-    [
-      "Taucher",
-      "Joachim Richert"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Dalton",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Mrs. Dalton",
+      "sprecher" : "Helga Bammert"
+    },
+    {
+      "rolle" : "Hardin",
+      "sprecher" : "Christian Mey"
+    },
+    {
+      "rolle" : "Prof. Walsh",
+      "sprecher" : "Joachim Rake"
+    },
+    {
+      "rolle" : "Ben Jackson",
+      "sprecher" : "Günther Flesch"
+    },
+    {
+      "rolle" : "Wreston",
+      "sprecher" : "Ulrich Benthien"
+    },
+    {
+      "rolle" : "Cardigo",
+      "sprecher" : "Harald Pages"
+    },
+    {
+      "rolle" : "Waldo Turner",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Taucher",
+      "sprecher" : "Joachim Richert"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/019/metadata.json",

--- a/web/data/Serie/020/metadata.json
+++ b/web/data/Serie/020/metadata.json
@@ -47,63 +47,63 @@
       "end" : 2816907
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Hauptkommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Mihai Eftimin",
-      "Volker Brandt"
-    ],
-    [
-      "Dr. Radulescu",
-      "Günter Flesh"
-    ],
-    [
-      "Potter",
-      "Karl-Heinz Gerdesmann"
-    ],
-    [
-      "Mrs. Dobson",
-      "Marianne Kehlau"
-    ],
-    [
-      "Tom Dobson",
-      "Alexander Körting"
-    ],
-    [
-      "Farrier",
-      "Gottfried Kramer"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Polizist",
-      "Hans Irle"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Mihai Eftimin",
+      "sprecher" : "Volker Brandt"
+    },
+    {
+      "rolle" : "Dr. Radulescu",
+      "sprecher" : "Günther Flesch"
+    },
+    {
+      "rolle" : "Potter",
+      "sprecher" : "Karl-Heinz Gerdesmann"
+    },
+    {
+      "rolle" : "Mrs. Dobson",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Tom Dobson",
+      "sprecher" : "Alexander Körting"
+    },
+    {
+      "rolle" : "Farrier",
+      "sprecher" : "Gottfried Kramer"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Hans Irle"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/020/metadata.json",

--- a/web/data/Serie/021/metadata.json
+++ b/web/data/Serie/021/metadata.json
@@ -47,67 +47,70 @@
       "end" : 2547813
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Dalton",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Christina Dalton",
-      "Karina Leising [Heikedine Körting]"
-    ],
-    [
-      "Frankie Bender",
-      "Oliver Mink"
-    ],
-    [
-      "H. P. Clay",
-      "Lothar Grützner"
-    ],
-    [
-      "Jim Clay",
-      "Marcus Meiering"
-    ],
-    [
-      "Walter Quail",
-      "Christian Mey"
-    ],
-    [
-      "Trödler Hummer",
-      "Joachim Richert"
-    ],
-    [
-      "Jason Wilkes",
-      "Joachim Rake"
-    ],
-    [
-      "Chiang",
-      "Tom Barrows [Hans Irle]"
-    ],
-    [
-      "Diakon Kastner",
-      "Hans Irle"
-    ],
-    [
-      "Butler",
-      "Hans Daniel"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Dalton",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Christina Dalton",
+      "sprecher" : "Heikedine Körting",
+      "pseudonym" : "Karina Leising"
+    },
+    {
+      "rolle" : "Frankie Bender",
+      "sprecher" : "Oliver Mink"
+    },
+    {
+      "rolle" : "H. P. Clay",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Jim Clay",
+      "sprecher" : "Dieter B. Gerlach",
+      "pseudonym" : "Markus Meiering"
+    },
+    {
+      "rolle" : "Walter Quail",
+      "sprecher" : "Christian Mey"
+    },
+    {
+      "rolle" : "Trödler Hummer",
+      "sprecher" : "Joachim Richert"
+    },
+    {
+      "rolle" : "Jason Wilkes",
+      "sprecher" : "Joachim Rake"
+    },
+    {
+      "rolle" : "Chiang",
+      "sprecher" : "Jürgen Thormann",
+      "pseudonym" : "Tom Barrows"
+    },
+    {
+      "rolle" : "Diakon Kastner",
+      "sprecher" : "Hans Irle"
+    },
+    {
+      "rolle" : "Butler",
+      "sprecher" : "Hans Daniel"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/021/metadata.json",

--- a/web/data/Serie/022/metadata.json
+++ b/web/data/Serie/022/metadata.json
@@ -47,71 +47,74 @@
       "end" : 2635960
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Rawley",
-      "Horst Stark"
-    ],
-    [
-      "Mr. Frank",
-      "Siegfried Wald"
-    ],
-    [
-      "Mr. Togati",
-      "Reiner Brönnecke"
-    ],
-    [
-      "Taro",
-      "Stefan Brönnecke"
-    ],
-    [
-      "Patrick",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Miss Agawam",
-      "Ursula Vogel"
-    ],
-    [
-      "Jordan",
-      "Hans Meinhardt [Franz Josef Steffens]"
-    ],
-    [
-      "Chuck",
-      "Roland Fabricius [Edgar Bessen?]"
-    ],
-    [
-      "Liliputaner",
-      "Erich Büttner [Joachim Wolff]"
-    ],
-    [
-      "Wachmann im Museum",
-      "Gottfried Kramer"
-    ],
-    [
-      "Hafenpolizist",
-      "Peter Kirchberger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Rawley",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Mr. Frank",
+      "sprecher" : "Siegfried Wald"
+    },
+    {
+      "rolle" : "Mr. Togati",
+      "sprecher" : "Reiner Brönneke"
+    },
+    {
+      "rolle" : "Taro",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Patrick",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Miss Agawam",
+      "sprecher" : "Ursula Vogel"
+    },
+    {
+      "rolle" : "Jordan",
+      "sprecher" : "Franz-Josef Steffens",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Chuck",
+      "sprecher" : "Wolfgang Kaven",
+      "pseudonym" : "Roland Fabricius"
+    },
+    {
+      "rolle" : "Liliputaner",
+      "sprecher" : "Joachim Wolff",
+      "pseudonym" : "Erich Büttner"
+    },
+    {
+      "rolle" : "Wachmann im Museum",
+      "sprecher" : "Gottfried Kramer"
+    },
+    {
+      "rolle" : "Hafenpolizist",
+      "sprecher" : "Peter Kirchberger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/022/metadata.json",

--- a/web/data/Serie/023/metadata.json
+++ b/web/data/Serie/023/metadata.json
@@ -47,67 +47,73 @@
       "end" : 2565680
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Skinny",
-      "Andreas von der Meden"
-    ],
-    [
-      "Cody",
-      "Simon Schuchadt [Wolfgang Kaven]"
-    ],
-    [
-      "Diego Alvaro",
-      "Jan Odle"
-    ],
-    [
-      "Pico Alvaro",
-      "Mathias Lorenz"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Assistent",
-      "Claes Holmcrantz [Gernot Endemann]"
-    ],
-    [
-      "Sheriff",
-      "F.J. Steffens"
-    ],
-    [
-      "Tulsa",
-      "Klaus Klein [F.J. Steffens]"
-    ],
-    [
-      "Cap",
-      "Fritz Wegely [Siegfried Wald]"
-    ],
-    [
-      "Pike",
-      "Philip Mehringer [Joachim Wolff]"
-    ],
-    [
-      "Mr. Shaw",
-      "F.J. Steffens"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Cody",
+      "sprecher" : "Wolfgang Kaven",
+      "pseudonym" : "Simon Schuchardt"
+    },
+    {
+      "rolle" : "Diego Alvaro",
+      "sprecher" : "Jan Odle"
+    },
+    {
+      "rolle" : "Pico Alvaro",
+      "sprecher" : "Mathias Lorenz"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Assistent",
+      "sprecher" : "Gernot Endemann",
+      "pseudonym" : "Claes Holmcrantz"
+    },
+    {
+      "rolle" : "Sheriff",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "Tulsa",
+      "sprecher" : "Siegfried Wald",
+      "pseudonym" : "Klaus Klein"
+    },
+    {
+      "rolle" : "Cap",
+      "sprecher" : "Joachim Wolff",
+      "pseudonym" : "Fritz Wegely"
+    },
+    {
+      "rolle" : "Pike",
+      "sprecher" : "Franz-Josef Steffens",
+      "pseudonym" : "Philip Mehringer"
+    },
+    {
+      "rolle" : "Mr. Shaw",
+      "sprecher" : "Franz-Josef Steffens"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/023/metadata.json",

--- a/web/data/Serie/024/metadata.json
+++ b/web/data/Serie/024/metadata.json
@@ -47,71 +47,73 @@
       "end" : 2537893
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Bengt",
-      "Charles Regnier"
-    ],
-    [
-      "Britta",
-      "Ingeborg Kanstein"
-    ],
-    [
-      "Lars Holmqvist",
-      "Gernot Endemann"
-    ],
-    [
-      "Young",
-      "Horst Stark"
-    ],
-    [
-      "Forsborg",
-      "Richard Heelel [F.J. Steffens]"
-    ],
-    [
-      "Mann",
-      "Siegfried Wald"
-    ],
-    [
-      "Frau",
-      "Brigitte Alexis"
-    ],
-    [
-      "Köhler",
-      "Hans Meinhardt [Reiner Brönneke]"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Wärter",
-      "Joachim Wolff"
-    ],
-    [
-      "Kellner",
-      "Peter Kirchberger"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Bengt",
+      "sprecher" : "Charles Regnier"
+    },
+    {
+      "rolle" : "Britta",
+      "sprecher" : "Ingeburg Kanstein"
+    },
+    {
+      "rolle" : "Lars Holmqvist",
+      "sprecher" : "Gernot Endemann"
+    },
+    {
+      "rolle" : "Young",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Forsborg",
+      "sprecher" : "Franz-Josef Steffens",
+      "pseudonym" : "Richard Heelel"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Siegfried Wald"
+    },
+    {
+      "rolle" : "Frau",
+      "sprecher" : "Brigitte Alexis"
+    },
+    {
+      "rolle" : "Köhler",
+      "sprecher" : "Reiner Brönneke",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Wärter",
+      "sprecher" : "Joachim Wolff"
+    },
+    {
+      "rolle" : "Kellner",
+      "sprecher" : "Peter Kirchberger"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/024/metadata.json",

--- a/web/data/Serie/025/metadata.json
+++ b/web/data/Serie/025/metadata.json
@@ -47,67 +47,67 @@
       "end" : 2782427
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Allie Jamison",
-      "Katrin Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Asmodi",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Dr. Shaitan",
-      "Lutz Mackensy"
-    ],
-    [
-      "Noxworth",
-      "Christian Rode"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Prof. Barrister",
-      "F. J. Steffens"
-    ],
-    [
-      "Marie",
-      "Susanne Wulkow"
-    ],
-    [
-      "der \"Clochard\"",
-      "Karl-Heinz Gerdesmann"
-    ],
-    [
-      "Patricia Osborne",
-      "Barbara Focke"
-    ],
-    [
-      "Mann am Grundstück",
-      "Wolfgang Kaven"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Allie Jamison",
+      "sprecher" : "Katrin Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Asmodi",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Dr. Shaitan",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Noxworth",
+      "sprecher" : "Christian Rode"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Prof. Barrister",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "Marie",
+      "sprecher" : "Susanne Wulkow"
+    },
+    {
+      "rolle" : "der \"Clochard\"",
+      "sprecher" : "Karl-Heinz Gerdesmann"
+    },
+    {
+      "rolle" : "Patricia Osborne",
+      "sprecher" : "Barbara Focke"
+    },
+    {
+      "rolle" : "Mann am Grundstück",
+      "sprecher" : "Wolfgang Kaven"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/025/metadata.json",

--- a/web/data/Serie/026/metadata.json
+++ b/web/data/Serie/026/metadata.json
@@ -47,55 +47,55 @@
       "end" : 2628080
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Allie Jamison",
-      "Katrin Fröhlich"
-    ],
-    [
-      "Harrison Osborne",
-      "F.J. Steffens"
-    ],
-    [
-      "Thurgood",
-      "Jürgen Thormann"
-    ],
-    [
-      "Sheriff",
-      "Gottfried Kramer"
-    ],
-    [
-      "Mrs. Macomber",
-      "Gisela Trowe"
-    ],
-    [
-      "Atkinson",
-      "Klaus Stieringer"
-    ],
-    [
-      "Manny",
-      "Lothar Grützner"
-    ],
-    [
-      "Gasper",
-      "Rolf Mamero"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Allie Jamison",
+      "sprecher" : "Katrin Fröhlich"
+    },
+    {
+      "rolle" : "Harrison Osborne",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "Thurgood",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Sheriff",
+      "sprecher" : "Gottfried Kramer"
+    },
+    {
+      "rolle" : "Mrs. Macomber",
+      "sprecher" : "Gisela Trowe"
+    },
+    {
+      "rolle" : "Atkinson",
+      "sprecher" : "Klaus Stieringer"
+    },
+    {
+      "rolle" : "Manny",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Gasper",
+      "sprecher" : "Rolf Mamero"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/026/metadata.json",

--- a/web/data/Serie/027/metadata.json
+++ b/web/data/Serie/027/metadata.json
@@ -47,59 +47,60 @@
       "end" : 3108893
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Horace Tremayne",
-      "Karl-Ulrich Meves"
-    ],
-    [
-      "William Tremayne",
-      "Günther Flesh"
-    ],
-    [
-      "Marvin Gray",
-      "Horst Stark"
-    ],
-    [
-      "Madeline Bainbridge",
-      "Ursula Vogel"
-    ],
-    [
-      "Mr. Thomas",
-      "Lothar Grützner"
-    ],
-    [
-      "Jefferson",
-      "Christian Rode"
-    ],
-    [
-      "Clara Adams",
-      "Ingeborg Kanstein"
-    ],
-    [
-      "Grean",
-      "Manuel Hümpel [Rüdiger Schulzki]"
-    ],
-    [
-      "Schrottplatzwart",
-      "Siegfried Wald"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Horace Tremayne",
+      "sprecher" : "Karl-Ulrich Meves"
+    },
+    {
+      "rolle" : "William Tremayne",
+      "sprecher" : "Günther Flesch"
+    },
+    {
+      "rolle" : "Marvin Gray",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Madeline Bainbridge",
+      "sprecher" : "Ursula Vogel"
+    },
+    {
+      "rolle" : "Mr. Thomas",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Jefferson",
+      "sprecher" : "Christian Rode"
+    },
+    {
+      "rolle" : "Clara Adams",
+      "sprecher" : "Ingeburg Kanstein"
+    },
+    {
+      "rolle" : "Grean",
+      "sprecher" : "Rüdiger Schulzki",
+      "pseudonym" : "Manuel Hümpel"
+    },
+    {
+      "rolle" : "Schrottplatzwart",
+      "sprecher" : "Siegfried Wald"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/027/metadata.json",

--- a/web/data/Serie/028/metadata.json
+++ b/web/data/Serie/028/metadata.json
@@ -47,67 +47,70 @@
       "end" : 2875787
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Reporter",
-      "Peter Kirchberger"
-    ],
-    [
-      "Fred, Extremist",
-      "Heinrich Baum [Karl-Walter Diess]"
-    ],
-    [
-      "Walt, Extremist",
-      "Friedhelm Hubertus [Siegfried Wald]"
-    ],
-    [
-      "Gordon Mackenzie",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Adam Ndula",
-      "Hans Meinhardt [Henry Kielmann]"
-    ],
-    [
-      "Jan Carew",
-      "Sascha Draeger"
-    ],
-    [
-      "Polizist im Suchtrupp",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Hauswirt",
-      "Hubert Mittendorf"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Reporter",
+      "sprecher" : "Peter Kirchberger"
+    },
+    {
+      "rolle" : "Fred, Extremist",
+      "sprecher" : "Karl-Walter Diess",
+      "pseudonym" : "Heinrich Baum"
+    },
+    {
+      "rolle" : "Walt, Extremist",
+      "sprecher" : "Siegfried Wald",
+      "pseudonym" : "Friedhelm Hubertus"
+    },
+    {
+      "rolle" : "Gordon Mackenzie",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Adam Ndula",
+      "sprecher" : "Henry Kielmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Jan Carew",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Polizist im Suchtrupp",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Hauswirt",
+      "sprecher" : "Hubert Mittendorf"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/028/metadata.json",

--- a/web/data/Serie/030/metadata.json
+++ b/web/data/Serie/030/metadata.json
@@ -47,63 +47,64 @@
       "end" : 2522293
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Andrews",
-      "Joachim Richert"
-    ],
-    [
-      "Crowe",
-      "Henry Kielmann"
-    ],
-    [
-      "Käptn Jason",
-      "Karl Walter Diess"
-    ],
-    [
-      "MacGruder",
-      "Siegfried Wald"
-    ],
-    [
-      "Hanley",
-      "Lothar Grützner"
-    ],
-    [
-      "Torao",
-      "Joko Talmann [Rüdiger Schulzki]"
-    ],
-    [
-      "Berg",
-      "Andreas Beurmann / Wolfgang Draeger"
-    ],
-    [
-      "Yamura",
-      "Hubert Mittendorf"
-    ],
-    [
-      "Die Gebrüder Connors",
-      "Nicolas Körting, Lothar Grützner"
-    ],
-    [
-      "Weston",
-      "Joachim Richert"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Joachim Richert"
+    },
+    {
+      "rolle" : "Crowe",
+      "sprecher" : "Henry Kielmann"
+    },
+    {
+      "rolle" : "Käptn Jason",
+      "sprecher" : "Karl Walter Diess"
+    },
+    {
+      "rolle" : "MacGruder",
+      "sprecher" : "Siegfried Wald"
+    },
+    {
+      "rolle" : "Hanley",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Torao",
+      "sprecher" : "Rüdiger Schulzki",
+      "pseudonym" : "Joko Talmann"
+    },
+    {
+      "rolle" : "Berg",
+      "sprecher" : "Andreas E. Beurmann / Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Yamura",
+      "sprecher" : "Hubert Mittendorf"
+    },
+    {
+      "rolle" : "Die Gebrüder Connors",
+      "sprecher" : "Nicolas Körting, Lothar Grützner"
+    },
+    {
+      "rolle" : "Weston",
+      "sprecher" : "Joachim Richert"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/030/metadata.json",

--- a/web/data/Serie/031/metadata.json
+++ b/web/data/Serie/031/metadata.json
@@ -47,67 +47,69 @@
       "end" : 2984573
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Shelby Tuckerman",
-      "Pinkas Braun"
-    ],
-    [
-      "Mr. Hitfield",
-      "Christian Riege [Manfred Steffen]"
-    ],
-    [
-      "Mr. Bonestell",
-      "Joachim Richert"
-    ],
-    [
-      "Mrs. Denicola",
-      "Katharina Brauren"
-    ],
-    [
-      "Eileen",
-      "Ruth Niehaus"
-    ],
-    [
-      "Ernie",
-      "Helmut Zierl"
-    ],
-    [
-      "Polizist",
-      "Harald Pages"
-    ],
-    [
-      "Hoang Van Dong",
-      "Chen Lung Chung [Volker Brandt]"
-    ],
-    [
-      "Frau an der Bushaltestelle",
-      "Ursula Vogel"
-    ],
-    [
-      "Nachrichtensprecher",
-      "Joachim Wolff"
-    ],
-    [
-      "Patrick",
-      "Joachim Richert"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Shelby Tuckerman",
+      "sprecher" : "Pinkas Braun"
+    },
+    {
+      "rolle" : "Mr. Hitfield",
+      "sprecher" : "Manfred Steffen",
+      "pseudonym" : "Christian Riege"
+    },
+    {
+      "rolle" : "Mr. Bonestell",
+      "sprecher" : "Joachim Richert"
+    },
+    {
+      "rolle" : "Mrs. Denicola",
+      "sprecher" : "Katharina Brauren"
+    },
+    {
+      "rolle" : "Eileen",
+      "sprecher" : "Ruth Niehaus"
+    },
+    {
+      "rolle" : "Ernie",
+      "sprecher" : "Helmut Zierl"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Harald Pages"
+    },
+    {
+      "rolle" : "Hoang Van Dong",
+      "sprecher" : "Volker Brandt",
+      "pseudonym" : "Chen Lung Chung"
+    },
+    {
+      "rolle" : "Frau an der Bushaltestelle",
+      "sprecher" : "Ursula Vogel"
+    },
+    {
+      "rolle" : "Nachrichtensprecher",
+      "sprecher" : "Joachim Wolff"
+    },
+    {
+      "rolle" : "Patrick",
+      "sprecher" : "Joachim Richert"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/031/metadata.json",

--- a/web/data/Serie/032/metadata.json
+++ b/web/data/Serie/032/metadata.json
@@ -47,63 +47,65 @@
       "end" : 2652653
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Dr. Woolley",
-      "Manfred Steffen"
-    ],
-    [
-      "Larry Conklin",
-      "Sylvester Merten [Helmut Zierl]"
-    ],
-    [
-      "Letitia Radford",
-      "Marianne Kehlau"
-    ],
-    [
-      "Mrs. Chumley",
-      "Renate Pichler"
-    ],
-    [
-      "Mrs. Burroughs",
-      "Katharina Brauren"
-    ],
-    [
-      "Mr. Burroughs",
-      "Martin Fichte [Joachim Wolff]"
-    ],
-    [
-      "Gary Malz",
-      "Volker Brandt"
-    ],
-    [
-      "Mr. Agnier",
-      "Willem Fricke"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Patrick",
-      "Joachim Richert"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Dr. Woolley",
+      "sprecher" : "Manfred Steffen"
+    },
+    {
+      "rolle" : "Larry Conklin",
+      "sprecher" : "Helmut Zierl",
+      "pseudonym" : "Sylvester Merten"
+    },
+    {
+      "rolle" : "Letitia Radford",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Mrs. Chumley",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Mrs. Burroughs",
+      "sprecher" : "Katharina Brauren"
+    },
+    {
+      "rolle" : "Mr. Burroughs",
+      "sprecher" : "Joachim Wolff",
+      "pseudonym" : "Martin Fichte"
+    },
+    {
+      "rolle" : "Gary Malz",
+      "sprecher" : "Volker Brandt"
+    },
+    {
+      "rolle" : "Mr. Agnier",
+      "sprecher" : "Willem Fricke"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Patrick",
+      "sprecher" : "Joachim Richert"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/032/metadata.json",

--- a/web/data/Serie/033/metadata.json
+++ b/web/data/Serie/033/metadata.json
@@ -47,63 +47,64 @@
       "end" : 2657067
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Patrick",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Peter Kirchberger"
-    ],
-    [
-      "Mr. Barron",
-      "Pinkas Braun"
-    ],
-    [
-      "Mrs. Barron",
-      "Monika Peitsch"
-    ],
-    [
-      "Hank Detweiler",
-      "Siegfried Wald"
-    ],
-    [
-      "Elsie Spratt",
-      "Pia Werfel [Barbara Focke]"
-    ],
-    [
-      "Leutnant Ferrante",
-      "Volkert Kraeft"
-    ],
-    [
-      "Bones",
-      "Siegfried Meyerheim [Helmut Zierl]"
-    ],
-    [
-      "vermeintlicher US-Präsident",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Horst Frank"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Patrick",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Peter Kirchberger"
+    },
+    {
+      "rolle" : "Mr. Barron",
+      "sprecher" : "Pinkas Braun"
+    },
+    {
+      "rolle" : "Mrs. Barron",
+      "sprecher" : "Monika Peitsch"
+    },
+    {
+      "rolle" : "Hank Detweiler",
+      "sprecher" : "Siegfried Wald"
+    },
+    {
+      "rolle" : "Elsie Spratt",
+      "sprecher" : "Barbara Focke"
+    },
+    {
+      "rolle" : "Leutnant Ferrante",
+      "sprecher" : "Volkert Kraeft"
+    },
+    {
+      "rolle" : "Bones",
+      "sprecher" : "Helmut Zierl",
+      "pseudonym" : "Siegfried Meyerheim"
+    },
+    {
+      "rolle" : "vermeintlicher US-Präsident",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/033/metadata.json",

--- a/web/data/Serie/034/metadata.json
+++ b/web/data/Serie/034/metadata.json
@@ -47,47 +47,47 @@
       "end" : 2640213
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Shaw",
-      "Horst Schick"
-    ],
-    [
-      "Kapitän Joy",
-      "Helmut Ahner"
-    ],
-    [
-      "Jeremy Joy",
-      "Philip Siegel"
-    ],
-    [
-      "Joshua Evans",
-      "Douglas Welbat"
-    ],
-    [
-      "Major Karnes",
-      "Manfred Schermutzki"
-    ],
-    [
-      "Sam Davis",
-      "Utz Richter"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Shaw",
+      "sprecher" : "Horst Schick"
+    },
+    {
+      "rolle" : "Kapitän Joy",
+      "sprecher" : "Helmut Ahner"
+    },
+    {
+      "rolle" : "Jeremy Joy",
+      "sprecher" : "Philip Siegel"
+    },
+    {
+      "rolle" : "Joshua Evans",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Major Karnes",
+      "sprecher" : "Manfred Schermutzki"
+    },
+    {
+      "rolle" : "Sam Davis",
+      "sprecher" : "Utz Richter"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/034/metadata.json",

--- a/web/data/Serie/035/metadata.json
+++ b/web/data/Serie/035/metadata.json
@@ -47,75 +47,76 @@
       "end" : 3255933
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Eleonor",
-      "Susanne Wulkow"
-    ],
-    [
-      "Birkensteen",
-      "Oskar Kluge [Günter König]"
-    ],
-    [
-      "Terreano",
-      "Günter König"
-    ],
-    [
-      "Brandon",
-      "Douglas Welbat"
-    ],
-    [
-      "Hoffer",
-      "Eckart Dux"
-    ],
-    [
-      "McGee",
-      "Utz Richter"
-    ],
-    [
-      "Thalia",
-      "Ingeborg Kanstein"
-    ],
-    [
-      "Stefano",
-      "Andreas von der Meden"
-    ],
-    [
-      "John",
-      "Edgar Bessen"
-    ],
-    [
-      "Tankwart",
-      "F.-J. Steffens"
-    ],
-    [
-      "LKW-Fahrer",
-      "Andreas von der Meden"
-    ],
-    [
-      "Mann am Bahnhof",
-      "Christian Rode"
-    ],
-    [
-      "Bürgermeister",
-      "Edgar Bessen"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Eleonor",
+      "sprecher" : "Susanne Wulkow"
+    },
+    {
+      "rolle" : "Birkensteen",
+      "sprecher" : "Günter König",
+      "pseudonym" : "Oskar Kluge"
+    },
+    {
+      "rolle" : "Terreano",
+      "sprecher" : "Günter König"
+    },
+    {
+      "rolle" : "Brandon",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Hoffer",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "McGee",
+      "sprecher" : "Utz Richter"
+    },
+    {
+      "rolle" : "Thalia",
+      "sprecher" : "Ingeburg Kanstein"
+    },
+    {
+      "rolle" : "Stefano",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "John",
+      "sprecher" : "Edgar Bessen"
+    },
+    {
+      "rolle" : "Tankwart",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "LKW-Fahrer",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Mann am Bahnhof",
+      "sprecher" : "Christian Rode"
+    },
+    {
+      "rolle" : "Bürgermeister",
+      "sprecher" : "Edgar Bessen"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/035/metadata.json",

--- a/web/data/Serie/036/metadata.json
+++ b/web/data/Serie/036/metadata.json
@@ -47,47 +47,47 @@
       "end" : 2896187
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Constance",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Slater",
-      "Helmut Ahner"
-    ],
-    [
-      "Donner",
-      "Jürgen Thormann"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Horst Frank"
-    ],
-    [
-      "Fischer",
-      "F.-J. Steffens"
-    ],
-    [
-      "Ocean-World-Mitarbeiter",
-      "Peter Lakenmacher, Christian Rode"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Constance",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Slater",
+      "sprecher" : "Helmut Ahner"
+    },
+    {
+      "rolle" : "Donner",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Horst Frank"
+    },
+    {
+      "rolle" : "Fischer",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "Ocean-World-Mitarbeiter",
+      "sprecher" : "Peter Lakenmacher, Christian Rode"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/036/metadata.json",

--- a/web/data/Serie/037/metadata.json
+++ b/web/data/Serie/037/metadata.json
@@ -47,55 +47,55 @@
       "end" : 3293027
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Regina",
-      "Ursela Monn"
-    ],
-    [
-      "Teddy",
-      "Simon Jäger"
-    ],
-    [
-      "Mrs. Peabody",
-      "Gisela Trowe"
-    ],
-    [
-      "Burton",
-      "Günther Pfitzmann"
-    ],
-    [
-      "Kommissar",
-      "Günther Flesh"
-    ],
-    [
-      "Mooch",
-      "Joachim Richert"
-    ],
-    [
-      "Mr. Conine",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Fergus",
-      "Günter Dockerill"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Regina",
+      "sprecher" : "Ursela Monn"
+    },
+    {
+      "rolle" : "Teddy",
+      "sprecher" : "Simon Jäger"
+    },
+    {
+      "rolle" : "Mrs. Peabody",
+      "sprecher" : "Gisela Trowe"
+    },
+    {
+      "rolle" : "Burton",
+      "sprecher" : "Günter Pfitzmann"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Günther Flesch"
+    },
+    {
+      "rolle" : "Mooch",
+      "sprecher" : "Joachim Richert"
+    },
+    {
+      "rolle" : "Mr. Conine",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Fergus",
+      "sprecher" : "Günther Dockerill"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/037/metadata.json",

--- a/web/data/Serie/038/metadata.json
+++ b/web/data/Serie/038/metadata.json
@@ -47,47 +47,47 @@
       "end" : 2552053
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Shaw",
-      "Marianne Kehlau"
-    ],
-    [
-      "Mr. Peck",
-      "Wolfgang Völz"
-    ],
-    [
-      "Ed Snabel",
-      "Horst Naumann"
-    ],
-    [
-      "Bartlett",
-      "Jochen Sehrndt"
-    ],
-    [
-      "FBI-Agent Anderson",
-      "Lutz Mackensy"
-    ],
-    [
-      "Passantin",
-      "Ingrid Andree"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Shaw",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Mr. Peck",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Ed Snabel",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Bartlett",
+      "sprecher" : "Jochen Sehrndt"
+    },
+    {
+      "rolle" : "FBI-Agent Anderson",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Passantin",
+      "sprecher" : "Ingrid Andree"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/038/metadata.json",

--- a/web/data/Serie/039/metadata.json
+++ b/web/data/Serie/039/metadata.json
@@ -47,35 +47,35 @@
       "end" : 2873960
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Blinky",
-      "Günter König"
-    ],
-    [
-      "Miss Melody",
-      "Gisela Trowe"
-    ],
-    [
-      "Frisbee",
-      "Hans Paetsch"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Blinky",
+      "sprecher" : "Günter König"
+    },
+    {
+      "rolle" : "Miss Melody",
+      "sprecher" : "Gisela Trowe"
+    },
+    {
+      "rolle" : "Frisbee",
+      "sprecher" : "Hans Paetsch"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/039/metadata.json",

--- a/web/data/Serie/040/metadata.json
+++ b/web/data/Serie/040/metadata.json
@@ -47,75 +47,75 @@
       "end" : 2821360
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Jacobs",
-      "Horst Naumann"
-    ],
-    [
-      "Paul Jacobs",
-      "Sascha Draeger"
-    ],
-    [
-      "Onkel Titus",
-      "Gottfried Kramer"
-    ],
-    [
-      "Tante Mathilda",
-      "Ingeborg Kallweit"
-    ],
-    [
-      "Mr. Temple",
-      "Jochen Sehrndt"
-    ],
-    [
-      "Sarah Temple",
-      "Svenja Pages"
-    ],
-    [
-      "Willard Temple",
-      "Ben Becker"
-    ],
-    [
-      "Polizeileutnant",
-      "Günter König"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Hauptkomm. Reynolds",
-      "Günter Flesch"
-    ],
-    [
-      "Margon",
-      "Henry Kielmann"
-    ],
-    [
-      "William Margon",
-      "Michael Grimm"
-    ],
-    [
-      "Passanten",
-      "Lothar Grützner, Hans Hessling"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Jacobs",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Paul Jacobs",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Gottfried Kramer"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Ingeborg Kallweit"
+    },
+    {
+      "rolle" : "Mr. Temple",
+      "sprecher" : "Jochen Sehrndt"
+    },
+    {
+      "rolle" : "Sarah Temple",
+      "sprecher" : "Svenja Pages"
+    },
+    {
+      "rolle" : "Willard Temple",
+      "sprecher" : "Ben Becker"
+    },
+    {
+      "rolle" : "Polizeileutnant",
+      "sprecher" : "Günter König"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Günther Flesch"
+    },
+    {
+      "rolle" : "Margon",
+      "sprecher" : "Henry Kielmann"
+    },
+    {
+      "rolle" : "William Margon",
+      "sprecher" : "Michael Grimm"
+    },
+    {
+      "rolle" : "Passanten",
+      "sprecher" : "Lothar Grützner, Hans Hessling"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/040/metadata.json",

--- a/web/data/Serie/041/metadata.json
+++ b/web/data/Serie/041/metadata.json
@@ -47,55 +47,55 @@
       "end" : 3214520
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Brewster",
-      "Horst Naumann"
-    ],
-    [
-      "Clifford",
-      "Douglas Welbat"
-    ],
-    [
-      "Marie",
-      "Svenja Pages"
-    ],
-    [
-      "Zindler",
-      "Karl Walter Diess"
-    ],
-    [
-      "Pamir",
-      "Manfred Steffen"
-    ],
-    [
-      "Martin",
-      "Frank-Dieter Tausch"
-    ],
-    [
-      "Botin",
-      "Beate Hasenau"
-    ],
-    [
-      "Kellner",
-      "Helmut Ahner"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Brewster",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Clifford",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Marie",
+      "sprecher" : "Svenja Pages"
+    },
+    {
+      "rolle" : "Zindler",
+      "sprecher" : "Karl Walter Diess"
+    },
+    {
+      "rolle" : "Pamir",
+      "sprecher" : "Manfred Steffen"
+    },
+    {
+      "rolle" : "Martin",
+      "sprecher" : "Frank-Dieter Tausch"
+    },
+    {
+      "rolle" : "Botin",
+      "sprecher" : "Beate Hasenau"
+    },
+    {
+      "rolle" : "Kellner",
+      "sprecher" : "Helmut Ahner"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/041/metadata.json",

--- a/web/data/Serie/042/metadata.json
+++ b/web/data/Serie/042/metadata.json
@@ -47,71 +47,71 @@
       "end" : 2869227
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Michael Cross",
-      "Matthias Klimser"
-    ],
-    [
-      "Mrs. Cross",
-      "Marianne Kehlau"
-    ],
-    [
-      "Mr. Cross",
-      "Horst Naumann"
-    ],
-    [
-      "Grady Markels",
-      "Gerd Baltus"
-    ],
-    [
-      "Brackmann",
-      "F. J. Steffens"
-    ],
-    [
-      "Margie",
-      "Monika Gabriel"
-    ],
-    [
-      "Nachrichtensprecher",
-      "Diess Günter Flesh"
-    ],
-    [
-      "Sawyer",
-      "Jürgen Thormann"
-    ],
-    [
-      "Museumsbesucherin",
-      "Beate Hasenau"
-    ],
-    [
-      "Gärtner",
-      "Günter Dockerill"
-    ],
-    [
-      "Mr. Rossing",
-      "Eric Vaessen"
-    ],
-    [
-      "Rossings Assistentin",
-      "Claudia Schermutzki"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Michael Cross",
+      "sprecher" : "Matthias Klimsa"
+    },
+    {
+      "rolle" : "Mrs. Cross",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Mr. Cross",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Grady Markels",
+      "sprecher" : "Gerd Baltus"
+    },
+    {
+      "rolle" : "Brackmann",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "Margie",
+      "sprecher" : "Monika Gabriel"
+    },
+    {
+      "rolle" : "Nachrichtensprecher",
+      "sprecher" : "Günther Flesch"
+    },
+    {
+      "rolle" : "Sawyer",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Museumsbesucherin",
+      "sprecher" : "Beate Hasenau"
+    },
+    {
+      "rolle" : "Gärtner",
+      "sprecher" : "Günther Dockerill"
+    },
+    {
+      "rolle" : "Mr. Rossing",
+      "sprecher" : "Eric Vaessen"
+    },
+    {
+      "rolle" : "Rossings Assistentin",
+      "sprecher" : "Claudia Schermutzki"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/042/metadata.json",

--- a/web/data/Serie/043/metadata.json
+++ b/web/data/Serie/043/metadata.json
@@ -47,79 +47,79 @@
       "end" : 3050920
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Lucille",
-      "Petra Kaminski"
-    ],
-    [
-      "Charles",
-      "Henry Kielmann"
-    ],
-    [
-      "McLain",
-      "Rolf Jülich"
-    ],
-    [
-      "Verleiher",
-      "Hartmut Kollakowsky"
-    ],
-    [
-      "Kellnerin",
-      "Beate Hasenau"
-    ],
-    [
-      "Sears",
-      "Manfred Liptow"
-    ],
-    [
-      "Evans",
-      "Bernd Fallske"
-    ],
-    [
-      "Pelzhändler",
-      "Eric Vaessen"
-    ],
-    [
-      "Kom. Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Lucilles Mutter",
-      "Astrid Kollex"
-    ],
-    [
-      "Sekretärin",
-      "Eva Gelb"
-    ],
-    [
-      "Mädchen",
-      "Veronika Neugebauer"
-    ],
-    [
-      "Junge 1",
-      "Manou Lubowski"
-    ],
-    [
-      "Junge 2",
-      "Niki Nowotny"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Lucille",
+      "sprecher" : "Petra Kaminski"
+    },
+    {
+      "rolle" : "Charles",
+      "sprecher" : "Henry Kielmann"
+    },
+    {
+      "rolle" : "McLain",
+      "sprecher" : "Rolf Jülich"
+    },
+    {
+      "rolle" : "Verleiher",
+      "sprecher" : "Hartmut Kollakowsky"
+    },
+    {
+      "rolle" : "Kellnerin",
+      "sprecher" : "Beate Hasenau"
+    },
+    {
+      "rolle" : "Sears",
+      "sprecher" : "Manfred Liptow"
+    },
+    {
+      "rolle" : "Evans",
+      "sprecher" : "Bernd Fallske"
+    },
+    {
+      "rolle" : "Pelzhändler",
+      "sprecher" : "Eric Vaessen"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Lucilles Mutter",
+      "sprecher" : "Astrid Kollex"
+    },
+    {
+      "rolle" : "Sekretärin",
+      "sprecher" : "Eva Gelb"
+    },
+    {
+      "rolle" : "Mädchen",
+      "sprecher" : "Veronika Neugebauer"
+    },
+    {
+      "rolle" : "Junge 1",
+      "sprecher" : "Manou Lubowski"
+    },
+    {
+      "rolle" : "Junge 2",
+      "sprecher" : "Niki Nowotny"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/043/metadata.json",

--- a/web/data/Serie/044/metadata.json
+++ b/web/data/Serie/044/metadata.json
@@ -47,55 +47,56 @@
       "end" : 3012147
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Milton",
-      "Horst Naumann"
-    ],
-    [
-      "Bonehead",
-      "Sascha Draeger"
-    ],
-    [
-      "Peggy",
-      "Veronika Neugebauer"
-    ],
-    [
-      "Footsie",
-      "Niki Nowotny"
-    ],
-    [
-      "Bloodhound",
-      "Manou Lubowski"
-    ],
-    [
-      "Lomax",
-      "Peter Pantel [Wolf Rahtjen]"
-    ],
-    [
-      "Tante Mathilda",
-      "Dorothea Kaiser"
-    ],
-    [
-      "Gordon Harker",
-      "Stefan Brönneke"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Milton",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Bonehead",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Peggy",
+      "sprecher" : "Veronika Neugebauer"
+    },
+    {
+      "rolle" : "Footsie",
+      "sprecher" : "Niki Nowotny"
+    },
+    {
+      "rolle" : "Bloodhound",
+      "sprecher" : "Manou Lubowski"
+    },
+    {
+      "rolle" : "Lomax",
+      "sprecher" : "Wolf Rahtjen",
+      "pseudonym" : "Peter Pantel"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Dorothea Kaiser"
+    },
+    {
+      "rolle" : "Gordon Harker",
+      "sprecher" : "Stefan Brönneke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/044/metadata.json",

--- a/web/data/Serie/045/metadata.json
+++ b/web/data/Serie/045/metadata.json
@@ -47,59 +47,62 @@
       "end" : 2827347
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ingmar Ragnarson",
-      "Rolf E. Schenker"
-    ],
-    [
-      "Karl Ragnarson",
-      "Utz Richter"
-    ],
-    [
-      "Sam Ragnarson",
-      "Marco Kröger"
-    ],
-    [
-      "Mr. Manning",
-      "Achim Schülke"
-    ],
-    [
-      "Mrs. Manning",
-      "Julia Mahnkopf"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Mrs. Andrews",
-      "Renate Pichler"
-    ],
-    [
-      "Mr. Andrews",
-      "Manfred Bendixen"
-    ],
-    [
-      "Mathilda",
-      "Ursula Vogel"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ingmar Ragnarson",
+      "sprecher" : "Rolf E. Schenker"
+    },
+    {
+      "rolle" : "Karl Ragnarson",
+      "sprecher" : "Utz Richter"
+    },
+    {
+      "rolle" : "Sam Ragnarson",
+      "sprecher" : "Lutz Harder",
+      "pseudonym" : "Marco Kröger"
+    },
+    {
+      "rolle" : "Mr. Manning",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Mrs. Manning",
+      "sprecher" : "Micaëla Kreißler",
+      "pseudonym" : "Julia Mahnkopf"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Mrs. Andrews",
+      "sprecher" : "Anne Schermutzki"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Günter König",
+      "pseudonym" : "Manfred Bendixen"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Ursula Vogel"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/045/metadata.json",

--- a/web/data/Serie/046/metadata.json
+++ b/web/data/Serie/046/metadata.json
@@ -47,63 +47,63 @@
       "end" : 2853253
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Harry Burnside",
-      "Thomas Naumann"
-    ],
-    [
-      "Millionär Pilcher",
-      "Michael von Raspatt"
-    ],
-    [
-      "Marilyn Pilcher",
-      "Gabi Libbach"
-    ],
-    [
-      "Sekretär Sanchez",
-      "Walter Eltz"
-    ],
-    [
-      "Harald Durham",
-      "Ernst A. Frantz"
-    ],
-    [
-      "Frau Durham",
-      "Micaela Kreißler"
-    ],
-    [
-      "Jim Westerbrook",
-      "Michael Quiatkowski"
-    ],
-    [
-      "Mrs. Westerbrook",
-      "Gerlinde Dillge"
-    ],
-    [
-      "Dr. Gonzaga",
-      "Michael Liptow"
-    ],
-    [
-      "Ramon Navarro",
-      "Norbert Lange"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Harry Burnside",
+      "sprecher" : "Thomas Naumann"
+    },
+    {
+      "rolle" : "Millionär Pilcher",
+      "sprecher" : "Michael von Rospatt"
+    },
+    {
+      "rolle" : "Marilyn Pilcher",
+      "sprecher" : "Gabriele Libbach"
+    },
+    {
+      "rolle" : "Sekretär Sanchez",
+      "sprecher" : "Walter Eltz"
+    },
+    {
+      "rolle" : "Harald Durham",
+      "sprecher" : "Ernst A. Frantz"
+    },
+    {
+      "rolle" : "Frau Durham",
+      "sprecher" : "Micaëla Kreißler"
+    },
+    {
+      "rolle" : "Jim Westerbrook",
+      "sprecher" : "Michael Quiatkowsky"
+    },
+    {
+      "rolle" : "Mrs. Westerbrook",
+      "sprecher" : "Gerlinde Dillge"
+    },
+    {
+      "rolle" : "Dr. Gonzaga",
+      "sprecher" : "Manfred Liptow"
+    },
+    {
+      "rolle" : "Ramon Navarro",
+      "sprecher" : "Norbert Lange"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/046/metadata.json",

--- a/web/data/Serie/047/metadata.json
+++ b/web/data/Serie/047/metadata.json
@@ -47,55 +47,55 @@
       "end" : 2842373
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Kelly",
-      "Kerstin Draeger"
-    ],
-    [
-      "Julia Crown",
-      "Tessa Gasser"
-    ],
-    [
-      "Big Barney Crown",
-      "Wolfgang Völz"
-    ],
-    [
-      "Schwester Lazar",
-      "Hildegard Krekel"
-    ],
-    [
-      "Don Dellasandro",
-      "Jürgen Thormann"
-    ],
-    [
-      "Pandro Mischkin",
-      "Michael Hark"
-    ],
-    [
-      "Kranführer Dick",
-      "Ernst von Klippstein"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "Julia Crown",
+      "sprecher" : "Tessa Gasser"
+    },
+    {
+      "rolle" : "Big Barney Crown",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Schwester Lazar",
+      "sprecher" : "Hildegard Krekel"
+    },
+    {
+      "rolle" : "Don Dellasandro",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Pandro Mischkin",
+      "sprecher" : "Michael Harck"
+    },
+    {
+      "rolle" : "Kranführer Dick",
+      "sprecher" : "Ernst von Klipstein"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/047/metadata.json",

--- a/web/data/Serie/048/metadata.json
+++ b/web/data/Serie/048/metadata.json
@@ -47,55 +47,55 @@
       "end" : 2878867
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Herr Andrews",
-      "Günter König"
-    ],
-    [
-      "Daniel",
-      "Gosta Liptow"
-    ],
-    [
-      "Mary",
-      "Anja Ziemer"
-    ],
-    [
-      "Häuptling Turner",
-      "Norbert Lange"
-    ],
-    [
-      "Schamane",
-      "Douglas Welbat"
-    ],
-    [
-      "Unternehmer Mancarrow",
-      "Holger Mahlich"
-    ],
-    [
-      "Ganove Biff",
-      "Lutz Harder"
-    ],
-    [
-      "Ganove George",
-      "Manfred Liptow"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Günter König"
+    },
+    {
+      "rolle" : "Daniel",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Mary",
+      "sprecher" : "Anja Ziemer"
+    },
+    {
+      "rolle" : "Häuptling Turner",
+      "sprecher" : "Norbert Lange"
+    },
+    {
+      "rolle" : "Schamane",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Unternehmer Mancarrow",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Ganove Biff",
+      "sprecher" : "Lutz Harder"
+    },
+    {
+      "rolle" : "Ganove George",
+      "sprecher" : "Manfred Liptow"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/048/metadata.json",

--- a/web/data/Serie/049/metadata.json
+++ b/web/data/Serie/049/metadata.json
@@ -47,51 +47,52 @@
       "end" : 2670120
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Axel Griswold",
-      "Helgo Liebig"
-    ],
-    [
-      "Purvis",
-      "Heiner Kramm"
-    ],
-    [
-      "Dan DeMento",
-      "Peter Heinrich"
-    ],
-    [
-      "Leo Rottweiler",
-      "Rainer Brönneke"
-    ],
-    [
-      "Steve Trash",
-      "Thomas Naumann"
-    ],
-    [
-      "Rainey Fields",
-      "Xenia Hey"
-    ],
-    [
-      "Junge",
-      "Leonhard Mahlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Axel Griswold",
+      "sprecher" : "Helgo Liebig"
+    },
+    {
+      "rolle" : "Purvis",
+      "sprecher" : "Michael Quiatkowsky",
+      "pseudonym" : "Heiner Kramm"
+    },
+    {
+      "rolle" : "Dan DeMento",
+      "sprecher" : "Peter Heinrich"
+    },
+    {
+      "rolle" : "Leo Rottweiler",
+      "sprecher" : "Reiner Brönneke"
+    },
+    {
+      "rolle" : "Steve Trash",
+      "sprecher" : "Michael Griem"
+    },
+    {
+      "rolle" : "Rainey Fields",
+      "sprecher" : "Xenia Hey"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "Leonhard Mahlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/049/metadata.json",

--- a/web/data/Serie/050/metadata.json
+++ b/web/data/Serie/050/metadata.json
@@ -47,51 +47,51 @@
       "end" : 3435173
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jon Travis",
-      "Rolf Becker"
-    ],
-    [
-      "Marty Morningbaum",
-      "Helmut Ahner"
-    ],
-    [
-      "Diller Rourke",
-      "Michael Quiatkowsky"
-    ],
-    [
-      "Marble Ackbourne-Smith",
-      "Wolf Rathjen"
-    ],
-    [
-      "Margo",
-      "Hanni Vanhaiden"
-    ],
-    [
-      "Kevin",
-      "Fred Maire"
-    ],
-    [
-      "Herr Andrews",
-      "Günter König"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jon Travis",
+      "sprecher" : "Rolf Becker"
+    },
+    {
+      "rolle" : "Marty Morningbaum",
+      "sprecher" : "Helmut Ahner"
+    },
+    {
+      "rolle" : "Diller Rourke",
+      "sprecher" : "Michael Quiatkowsky"
+    },
+    {
+      "rolle" : "Marble Ackbourne-Smith",
+      "sprecher" : "Wolf Rahtjen"
+    },
+    {
+      "rolle" : "Margo",
+      "sprecher" : "Hanni Vanhaiden"
+    },
+    {
+      "rolle" : "Kevin",
+      "sprecher" : "Fred Maire"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Günter König"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/050/metadata.json",

--- a/web/data/Serie/051/metadata.json
+++ b/web/data/Serie/051/metadata.json
@@ -47,39 +47,39 @@
       "end" : 3270107
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mercedes",
-      "Marianne Kehlau"
-    ],
-    [
-      "Brit",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Dusty Rice",
-      "Achim Schülke"
-    ],
-    [
-      "Ascension",
-      "Eckart Dux"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mercedes",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Brit",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Dusty Rice",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Ascension",
+      "sprecher" : "Eckart Dux"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/051/metadata.json",

--- a/web/data/Serie/052/metadata.json
+++ b/web/data/Serie/052/metadata.json
@@ -47,71 +47,71 @@
       "end" : 3267773
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Brick",
-      "Rainer Schmitt"
-    ],
-    [
-      "Thanom",
-      "Peter Heinrich"
-    ],
-    [
-      "Prem",
-      "Lutz Mackensy"
-    ],
-    [
-      "Butler",
-      "Gerd Baltus"
-    ],
-    [
-      "Sax",
-      "Andreas Mannkopff"
-    ],
-    [
-      "Celeste",
-      "Michaela Gröger"
-    ],
-    [
-      "Lara",
-      "Gerlach Fiedler"
-    ],
-    [
-      "Rivers",
-      "Wolfgang Völz"
-    ],
-    [
-      "Hansen",
-      "Verena Wiet"
-    ],
-    [
-      "Maxi",
-      "Hildegard Krekel"
-    ],
-    [
-      "Quill",
-      "Matthias Bullach"
-    ],
-    [
-      "Tony",
-      "Michael Quiatkowsky"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Brick",
+      "sprecher" : "Rainer Schmitt"
+    },
+    {
+      "rolle" : "Thanom",
+      "sprecher" : "Peter Heinrich"
+    },
+    {
+      "rolle" : "Prem",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Butler",
+      "sprecher" : "Gerd Baltus"
+    },
+    {
+      "rolle" : "Sax Sandler",
+      "sprecher" : "Andreas Mannkopff"
+    },
+    {
+      "rolle" : "Celeste",
+      "sprecher" : "Michaela Gröger"
+    },
+    {
+      "rolle" : "Lara",
+      "sprecher" : "Gerlach Fiedler"
+    },
+    {
+      "rolle" : "Rivers",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Hansen",
+      "sprecher" : "Verena Wiet"
+    },
+    {
+      "rolle" : "Maxi",
+      "sprecher" : "Hildegard Krekel"
+    },
+    {
+      "rolle" : "Quill",
+      "sprecher" : "Matthias Bullach"
+    },
+    {
+      "rolle" : "Tony",
+      "sprecher" : "Michael Quiatkowsky"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/052/metadata.json",

--- a/web/data/Serie/053/metadata.json
+++ b/web/data/Serie/053/metadata.json
@@ -47,59 +47,59 @@
       "end" : 3203173
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "Ty Cassey",
-      "Stefan Brönneke"
-    ],
-    [
-      "Inspektor Cole",
-      "Wolfgang Schimmelpfennig [Günter König]"
-    ],
-    [
-      "Kommissar Maxim",
-      "Peter Matic"
-    ],
-    [
-      "Gilbar",
-      "Rolf Becker"
-    ],
-    [
-      "Torres",
-      "Douglas Welbat"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Jake Hatch",
-      "Hans Barein"
-    ],
-    [
-      "Tiburon",
-      "Michael Quiatkowsky"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Ty Cassey",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Inspektor Cole",
+      "sprecher" : "Wolfgang Schimmelpfennig"
+    },
+    {
+      "rolle" : "Kommissar Maxim",
+      "sprecher" : "Peter Matić"
+    },
+    {
+      "rolle" : "Gilbar",
+      "sprecher" : "Rolf Becker"
+    },
+    {
+      "rolle" : "Torres",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Jake Hatch",
+      "sprecher" : "Hans Barein"
+    },
+    {
+      "rolle" : "Tiburon",
+      "sprecher" : "Michael Quiatkowsky"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/053/metadata.json",

--- a/web/data/Serie/054/metadata.json
+++ b/web/data/Serie/054/metadata.json
@@ -47,59 +47,60 @@
       "end" : 3048040
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "Buzz Newman",
-      "Manou Lubowski"
-    ],
-    [
-      "George Brandon",
-      "Fabian Harloff"
-    ],
-    [
-      "Jim Bernardie",
-      "Holger Mahlich"
-    ],
-    [
-      "Firestone",
-      "Peter Schiff"
-    ],
-    [
-      "Crocker",
-      "Lothar Grützner"
-    ],
-    [
-      "Lovell Madeira",
-      "Rainer Schmitt"
-    ],
-    [
-      "Vic Hammell",
-      "Ben Tappé"
-    ],
-    [
-      "Dan",
-      "Henry König"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Buzz Newman",
+      "sprecher" : "Manou Lubowski",
+      "pseudonym" : "Christian Weber"
+    },
+    {
+      "rolle" : "George Brandon",
+      "sprecher" : "Fabian Harloff"
+    },
+    {
+      "rolle" : "Jim Bernardie",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Firestone",
+      "sprecher" : "Peter Schiff"
+    },
+    {
+      "rolle" : "Crocker",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Lovell Madeira",
+      "sprecher" : "Rainer Schmitt"
+    },
+    {
+      "rolle" : "Vic Hammell",
+      "sprecher" : "Ben Tappé"
+    },
+    {
+      "rolle" : "Dan",
+      "sprecher" : "Henry König"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/054/metadata.json",

--- a/web/data/Serie/055/metadata.json
+++ b/web/data/Serie/055/metadata.json
@@ -47,63 +47,63 @@
       "end" : 3056533
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "Trainer Tong",
-      "Michael Hark"
-    ],
-    [
-      "Trainer Duggan",
-      "Douglas Welbat"
-    ],
-    [
-      "Präsident Harper",
-      "Eric Vaessen"
-    ],
-    [
-      "Jerri",
-      "Samira Chanfir"
-    ],
-    [
-      "Nora",
-      "Ann Montenbruck"
-    ],
-    [
-      "Cory",
-      "Ben Tappé"
-    ],
-    [
-      "Norman",
-      "Henry König"
-    ],
-    [
-      "Powers",
-      "Hans Clarin"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Trainer Tong",
+      "sprecher" : "Michael Harck"
+    },
+    {
+      "rolle" : "Trainer Duggan",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Präsident Harper",
+      "sprecher" : "Eric Vaessen"
+    },
+    {
+      "rolle" : "Jerri",
+      "sprecher" : "Samira Chanfir"
+    },
+    {
+      "rolle" : "Nora",
+      "sprecher" : "Ann Montenbruck"
+    },
+    {
+      "rolle" : "Cory",
+      "sprecher" : "Ben Tappé"
+    },
+    {
+      "rolle" : "Norman",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Powers",
+      "sprecher" : "Hans Clarin"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/055/metadata.json",

--- a/web/data/Serie/056/metadata.json
+++ b/web/data/Serie/056/metadata.json
@@ -47,63 +47,63 @@
       "end" : 2967587
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "Liz",
-      "Verena Großer"
-    ],
-    [
-      "Harold",
-      "Willi Röbke"
-    ],
-    [
-      "Dose",
-      "Jan-Friedrich Conrad"
-    ],
-    [
-      "Silas Ek",
-      "Hans Sievers"
-    ],
-    [
-      "Sekretär",
-      "Eckart Dux"
-    ],
-    [
-      "Jan",
-      "Stefan Brönneke"
-    ],
-    [
-      "Lys",
-      "Anika Pages"
-    ],
-    [
-      "Branson Barr",
-      "Michael Harck"
-    ],
-    [
-      "Norton Rome",
-      "Douglas Welbat"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Liz",
+      "sprecher" : "Verena Großer"
+    },
+    {
+      "rolle" : "Harold",
+      "sprecher" : "Willi Röbke"
+    },
+    {
+      "rolle" : "Dose",
+      "sprecher" : "Jan-Friedrich Conrad"
+    },
+    {
+      "rolle" : "Silas Ek",
+      "sprecher" : "Hans Sievers"
+    },
+    {
+      "rolle" : "Sekretär",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Jan",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Lys",
+      "sprecher" : "Annika Pages"
+    },
+    {
+      "rolle" : "Branson Barr",
+      "sprecher" : "Michael Harck"
+    },
+    {
+      "rolle" : "Norton Rome",
+      "sprecher" : "Douglas Welbat"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/056/metadata.json",

--- a/web/data/Serie/057/metadata.json
+++ b/web/data/Serie/057/metadata.json
@@ -47,55 +47,55 @@
       "end" : 2605187
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mary, Artistin",
-      "Heidrun von Goessel"
-    ],
-    [
-      "Winkler, Zirkusdirektor",
-      "Helmut Ahner"
-    ],
-    [
-      "Pipo, Clown",
-      "Arthur Brauss"
-    ],
-    [
-      "Morton, Chauffeur",
-      "Andreas von der Meden"
-    ],
-    [
-      "Cotta, Polizeiinspektor",
-      "Michael Poelchau"
-    ],
-    [
-      "Alma",
-      "Eva Zlomitzky"
-    ],
-    [
-      "Schwester",
-      "Gerda Maria Jürgens"
-    ],
-    [
-      "[Shirley Kubinski]",
-      "Thea Frank"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mary, Artistin",
+      "sprecher" : "Heidrun von Goessel"
+    },
+    {
+      "rolle" : "Winkler, Zirkusdirektor",
+      "sprecher" : "Helmut Ahner"
+    },
+    {
+      "rolle" : "Pipo, Clown",
+      "sprecher" : "Arthur Brauss"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Michael Poelchau"
+    },
+    {
+      "rolle" : "Alma",
+      "sprecher" : "Eva Zlonitzky"
+    },
+    {
+      "rolle" : "Schwester",
+      "sprecher" : "Gerda-Maria Jürgens"
+    },
+    {
+      "rolle" : "Shirley Kubinski",
+      "sprecher" : "Thea Frank"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/057/metadata.json",

--- a/web/data/Serie/058/metadata.json
+++ b/web/data/Serie/058/metadata.json
@@ -47,59 +47,60 @@
       "end" : 2711893
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "William Ashley",
-      "Franz Rudnick"
-    ],
-    [
-      "Burt Ashley",
-      "Knut Basewitz"
-    ],
-    [
-      "Pecker, Angestellter",
-      "Lutz Büschken"
-    ],
-    [
-      "Axel",
-      "Tobias Pauls"
-    ],
-    [
-      "Lys",
-      "Kerstin Draeger"
-    ],
-    [
-      "Mrs. Bloomingdale",
-      "Eva Zlomitzky"
-    ],
-    [
-      "Stella",
-      "Rebecca Völz"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "William Ashley",
+      "sprecher" : "Franz Rudnick"
+    },
+    {
+      "rolle" : "Burt Ashley",
+      "sprecher" : "Knut Basewitz"
+    },
+    {
+      "rolle" : "Pecker, Angestellter",
+      "sprecher" : "Lutz Büschken"
+    },
+    {
+      "rolle" : "Axel",
+      "sprecher" : "Tobias Pauls"
+    },
+    {
+      "rolle" : "Lys",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "Mrs. Bloomingdale",
+      "sprecher" : "Eva Zlonitzky"
+    },
+    {
+      "rolle" : "Stella",
+      "sprecher" : "Rebecca Völz"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/058/metadata.json",

--- a/web/data/Serie/059/metadata.json
+++ b/web/data/Serie/059/metadata.json
@@ -47,59 +47,59 @@
       "end" : 2667307
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ruth, Zeitungs-Journalistin",
-      "Hansi Jochmann"
-    ],
-    [
-      "Jean Baxter, TV-Journalistin",
-      "Heidrun von Goessel"
-    ],
-    [
-      "Van Well, Pressechef",
-      "Ulrich Faulhaber"
-    ],
-    [
-      "Sinagua, Indianerin",
-      "Samira Chanfir"
-    ],
-    [
-      "Chosmo, Journalist",
-      "Mathias Bullach"
-    ],
-    [
-      "Monsieur Jaubert",
-      "Michael Poelchau"
-    ],
-    [
-      "René Hancock",
-      "Thomas Schüler"
-    ],
-    [
-      "Joan Brown",
-      "Rebecca Völz"
-    ],
-    [
-      "Hendrik Walton, Fabrikant",
-      "Karl Michael Mechel"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ruth, Zeitungs-Journalistin",
+      "sprecher" : "Hansi Jochmann"
+    },
+    {
+      "rolle" : "Jean Baxter, TV-Journalistin",
+      "sprecher" : "Heidrun von Goessel"
+    },
+    {
+      "rolle" : "Van Well, Pressechef",
+      "sprecher" : "Ulrich Faulhaber"
+    },
+    {
+      "rolle" : "Sinagua, Indianerin",
+      "sprecher" : "Samira Chanfir"
+    },
+    {
+      "rolle" : "Chosmo, Journalist",
+      "sprecher" : "Matthias Bullach"
+    },
+    {
+      "rolle" : "Monsieur Jaubert",
+      "sprecher" : "Michael Poelchau"
+    },
+    {
+      "rolle" : "René Hancock",
+      "sprecher" : "Thomas Schüler"
+    },
+    {
+      "rolle" : "Joan Brown",
+      "sprecher" : "Rebecca Völz"
+    },
+    {
+      "rolle" : "Hendrik Walton, Fabrikant",
+      "sprecher" : "Michael Mechel"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/059/metadata.json",

--- a/web/data/Serie/060/metadata.json
+++ b/web/data/Serie/060/metadata.json
@@ -47,63 +47,64 @@
       "end" : 2826880
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Andrews",
-      "Günter König"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Glenn Miles",
-      "Christian Stark"
-    ],
-    [
-      "Benny",
-      "Tobias Pauls"
-    ],
-    [
-      "Tom Descanso, Trainer",
-      "Prof. Justus Frantz"
-    ],
-    [
-      "Field, Lehrer",
-      "Michael Quiatkowsky"
-    ],
-    [
-      "Hutchins, Sport-Reporter",
-      "Uwe Büschken"
-    ],
-    [
-      "Dr. Landman, Schuldirektor",
-      "Gerd Duwner"
-    ],
-    [
-      "Stan",
-      "Tilman Madaus"
-    ],
-    [
-      "Eleonore Sharp",
-      "Margot Linde"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Günter König"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Glenn Miles",
+      "sprecher" : "Christian Stark"
+    },
+    {
+      "rolle" : "Benny",
+      "sprecher" : "Tobias Pauls"
+    },
+    {
+      "rolle" : "Tom Descanso, Trainer",
+      "sprecher" : "Prof. Justus Frantz"
+    },
+    {
+      "rolle" : "Field, Lehrer",
+      "sprecher" : "Michael Quiatkowsky"
+    },
+    {
+      "rolle" : "Hutchins, Sport-Reporter",
+      "sprecher" : "Uwe Büschken"
+    },
+    {
+      "rolle" : "Dr. Landman, Schuldirektor",
+      "sprecher" : "Gerd Duwner"
+    },
+    {
+      "rolle" : "Stan",
+      "sprecher" : "Tilman Madaus"
+    },
+    {
+      "rolle" : "Eleonore Sharp",
+      "sprecher" : "Eva Maria Bauer",
+      "pseudonym" : "Margot Linde"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/060/metadata.json",

--- a/web/data/Serie/061/metadata.json
+++ b/web/data/Serie/061/metadata.json
@@ -47,63 +47,63 @@
       "end" : 3569320
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Milton Mitchell",
-      "Holger Mahlich"
-    ],
-    [
-      "Fred Hall",
-      "Thomas Thomé"
-    ],
-    [
-      "Anne",
-      "Janina Richter"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Kellner",
-      "Thomas Stein"
-    ],
-    [
-      "Portland",
-      "Wolfgang Völz"
-    ],
-    [
-      "Inspektor Cotta",
-      "Willem Fricke"
-    ],
-    [
-      "Charlie",
-      "Anne Marr"
-    ],
-    [
-      "Kundin",
-      "Ursula Sieg"
-    ],
-    [
-      "Adams",
-      "Hans Hessling"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Milton Mitchell",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Fred Hall",
+      "sprecher" : "Thomas Thomé"
+    },
+    {
+      "rolle" : "Anne",
+      "sprecher" : "Janina Richter"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Kellner",
+      "sprecher" : "Thomas M. Stein"
+    },
+    {
+      "rolle" : "Portland",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Willem Fricke"
+    },
+    {
+      "rolle" : "Charlie",
+      "sprecher" : "Anne Marr"
+    },
+    {
+      "rolle" : "Kundin",
+      "sprecher" : "Ursula Sieg"
+    },
+    {
+      "rolle" : "Adams",
+      "sprecher" : "Hans Hessling"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/061/metadata.json",

--- a/web/data/Serie/062/metadata.json
+++ b/web/data/Serie/062/metadata.json
@@ -47,63 +47,63 @@
       "end" : 3563227
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Amanda Black",
-      "Beate Hasenau"
-    ],
-    [
-      "Mrs. Silverstone",
-      "Barbara Ratthay"
-    ],
-    [
-      "Mr. Garfield",
-      "Holger Mahlich [Utz Richter]"
-    ],
-    [
-      "Mr. Hartford",
-      "Hans Hessling"
-    ],
-    [
-      "Mrs. Hartford",
-      "Ursula Sieg"
-    ],
-    [
-      "Mrs. Green",
-      "Monika Werner"
-    ],
-    [
-      "Henry",
-      "Lutz Schnell"
-    ],
-    [
-      "Lys",
-      "Kerstin Draeger"
-    ],
-    [
-      "Linda",
-      "Janina Richter"
-    ],
-    [
-      "Inspektor Cotta",
-      "Willem Fricke"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Amanda Black",
+      "sprecher" : "Beate Hasenau"
+    },
+    {
+      "rolle" : "Mrs. Silverstone",
+      "sprecher" : "Barbara Ratthey"
+    },
+    {
+      "rolle" : "Mr. Garfield",
+      "sprecher" : "Utz Richter"
+    },
+    {
+      "rolle" : "Mr. Hartford",
+      "sprecher" : "Hans Hessling"
+    },
+    {
+      "rolle" : "Mrs. Hartford",
+      "sprecher" : "Ursula Sieg"
+    },
+    {
+      "rolle" : "Mrs. Green",
+      "sprecher" : "Monika Werner"
+    },
+    {
+      "rolle" : "Henry",
+      "sprecher" : "Lutz Schnell"
+    },
+    {
+      "rolle" : "Lys",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "Linda",
+      "sprecher" : "Janina Richter"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Willem Fricke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/062/metadata.json",

--- a/web/data/Serie/063/metadata.json
+++ b/web/data/Serie/063/metadata.json
@@ -47,63 +47,64 @@
       "end" : 4014467
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Jimboy-Jonas",
-      "Frank Meyer-Brockmann"
-    ],
-    [
-      "Mr. Bow",
-      "Klaus Sonnenschein"
-    ],
-    [
-      "Eric Randolph",
-      "Achim Schülke"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Elizabeth",
-      "Verena Großer"
-    ],
-    [
-      "Lys",
-      "Kerstin Draeger"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Tamara Mostowsky",
-      "Astrid Kollex"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Jimboy-Jonas",
+      "sprecher" : "Frank Meyer-Brockmann"
+    },
+    {
+      "rolle" : "Mr. Bow",
+      "sprecher" : "Klaus Sonnenschein"
+    },
+    {
+      "rolle" : "Eric Randolph",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Elizabeth",
+      "sprecher" : "Verena Großer"
+    },
+    {
+      "rolle" : "Lys",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Tamara Mostowsky",
+      "sprecher" : "Astrid Kollex"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/063/metadata.json",

--- a/web/data/Serie/064/metadata.json
+++ b/web/data/Serie/064/metadata.json
@@ -47,63 +47,64 @@
       "end" : 3969547
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Peter Pasetti"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Morton, Chauffeur",
-      "Andreas von der Meden"
-    ],
-    [
-      "Inspektor Capistrano",
-      "Hans Sievers"
-    ],
-    [
-      "Sergeant Hawthrone",
-      "Jürgen Kopp"
-    ],
-    [
-      "Simon Oames",
-      "Peter Kirchberger"
-    ],
-    [
-      "Silvie Oames",
-      "Edith Hancke"
-    ],
-    [
-      "Michael Julius Oames",
-      "Günther Jerschke"
-    ],
-    [
-      "Mandy Taylor",
-      "Micaela Kreißler"
-    ],
-    [
-      "Deborah Street",
-      "Astrid Kollex"
-    ],
-    [
-      "Greenwater",
-      "Norman Messer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Peter Pasetti"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Inspektor Capistrano",
+      "sprecher" : "Hans Sievers"
+    },
+    {
+      "rolle" : "Sergeant Hawthrone",
+      "sprecher" : "Jürgen Kopp"
+    },
+    {
+      "rolle" : "Simon Oames",
+      "sprecher" : "Peter Kirchberger"
+    },
+    {
+      "rolle" : "Silvie Oames",
+      "sprecher" : "Edith Hancke"
+    },
+    {
+      "rolle" : "Michael Julius Oames",
+      "sprecher" : "Günther Jerschke"
+    },
+    {
+      "rolle" : "Mandy Taylor",
+      "sprecher" : "Micaëla Kreißler"
+    },
+    {
+      "rolle" : "Deborah Street",
+      "sprecher" : "Astrid Kollex"
+    },
+    {
+      "rolle" : "Greenwater",
+      "sprecher" : "André Minninger",
+      "pseudonym" : "Norman Messer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/064/metadata.json",

--- a/web/data/Serie/065/metadata.json
+++ b/web/data/Serie/065/metadata.json
@@ -47,71 +47,71 @@
       "end" : 3579173
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Alex Burlington",
-      "Klaus Sonnenschein"
-    ],
-    [
-      "Richard Applebloome",
-      "Tilman Madaus"
-    ],
-    [
-      "Robert Applebloome",
-      "Franz Rudnick"
-    ],
-    [
-      "Mary",
-      "Edith Hancke"
-    ],
-    [
-      "Elizabeth",
-      "Marianne Kehlau"
-    ],
-    [
-      "John Smith",
-      "Dirk Anton"
-    ],
-    [
-      "Jenkins",
-      "Douglas Welbat"
-    ],
-    [
-      "Thomas",
-      "Stephan Chreszinsky"
-    ],
-    [
-      "Andrew",
-      "Michael Rospat"
-    ],
-    [
-      "Mrs. Rodriguez",
-      "Katja Brügger"
-    ],
-    [
-      "Hoteldirektor",
-      "Hans Sievers"
-    ],
-    [
-      "Blondine",
-      "Veronika Neugebauer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Alex Burlington",
+      "sprecher" : "Klaus Sonnenschein"
+    },
+    {
+      "rolle" : "Richard Applebloome",
+      "sprecher" : "Tilman Madaus"
+    },
+    {
+      "rolle" : "Robert Applebloome",
+      "sprecher" : "Franz Rudnick"
+    },
+    {
+      "rolle" : "Mary",
+      "sprecher" : "Edith Hancke"
+    },
+    {
+      "rolle" : "Elizabeth",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "John Smith",
+      "sprecher" : "Dirk Anton"
+    },
+    {
+      "rolle" : "Jenkins",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Thomas",
+      "sprecher" : "Stephan Chrzescinski"
+    },
+    {
+      "rolle" : "Andrew",
+      "sprecher" : "Michael von Rospatt"
+    },
+    {
+      "rolle" : "Mrs. Rodriguez",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Hoteldirektor",
+      "sprecher" : "Hans Sievers"
+    },
+    {
+      "rolle" : "Blondine",
+      "sprecher" : "Veronika Neugebauer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/065/metadata.json",

--- a/web/data/Serie/066/metadata.json
+++ b/web/data/Serie/066/metadata.json
@@ -47,55 +47,55 @@
       "end" : 3555013
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Alberto Bergamelli, Fotograf",
-      "Holger Mahlich"
-    ],
-    [
-      "Alexandra",
-      "Reinhilt Schneider"
-    ],
-    [
-      "Ignazio, Pensionswirt",
-      "Leonardo Cuseneza"
-    ],
-    [
-      "Sofia, Pensionswirtin",
-      "Maria Chirivi"
-    ],
-    [
-      "Franca",
-      "Samira Chanfir"
-    ],
-    [
-      "Italienerin",
-      "Francesca Chiavon"
-    ],
-    [
-      "1. Italiener",
-      "Marcello Grassi"
-    ],
-    [
-      "2. Italiener",
-      "Luigi Pane"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Alberto Bergamelli, Fotograf",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Alexandra",
+      "sprecher" : "Reinhilt Schneider"
+    },
+    {
+      "rolle" : "Ignazio, Pensionswirt",
+      "sprecher" : "Leonardo Cusenza"
+    },
+    {
+      "rolle" : "Sofia, Pensionswirtin",
+      "sprecher" : "Maria Chirivi"
+    },
+    {
+      "rolle" : "Franca",
+      "sprecher" : "Samira Chanfir"
+    },
+    {
+      "rolle" : "Italienerin",
+      "sprecher" : "Francesca Chiavon"
+    },
+    {
+      "rolle" : "Italiener 1",
+      "sprecher" : "Marcello Grassi"
+    },
+    {
+      "rolle" : "Italiener 2",
+      "sprecher" : "Luigi Pane"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/066/metadata.json",

--- a/web/data/Serie/067/metadata.json
+++ b/web/data/Serie/067/metadata.json
@@ -47,59 +47,59 @@
       "end" : 3799320
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Babette Eberle",
-      "M. Rospat"
-    ],
-    [
-      "Bruder Benedikt",
-      "Tassilo Jelde"
-    ],
-    [
-      "Mylná",
-      "Utz Richter"
-    ],
-    [
-      "Alexandra",
-      "Reinhilt Schneider"
-    ],
-    [
-      "Wirt",
-      "Hans Paetsch"
-    ],
-    [
-      "Wirtin",
-      "Ingeborg Ottmann"
-    ],
-    [
-      "Max",
-      "Lutz Schnell"
-    ],
-    [
-      "1. Polizist",
-      "Boris Sychowsky"
-    ],
-    [
-      "2. Polizist",
-      "Frank Meyer-Brockmann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Babette Eberle",
+      "sprecher" : "Michael von Rospatt"
+    },
+    {
+      "rolle" : "Bruder Benedikt",
+      "sprecher" : "Tassilo Jelde"
+    },
+    {
+      "rolle" : "Mylná",
+      "sprecher" : "Utz Richter"
+    },
+    {
+      "rolle" : "Alexandra",
+      "sprecher" : "Reinhilt Schneider"
+    },
+    {
+      "rolle" : "Wirt",
+      "sprecher" : "Hans Paetsch"
+    },
+    {
+      "rolle" : "Wirtin",
+      "sprecher" : "Ingeborg Ottmann"
+    },
+    {
+      "rolle" : "Max",
+      "sprecher" : "Lutz Schnell"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Boris von Sychowski"
+    },
+    {
+      "rolle" : "Polizist 2",
+      "sprecher" : "Frank Meyer-Brockmann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/067/metadata.json",

--- a/web/data/Serie/068/metadata.json
+++ b/web/data/Serie/068/metadata.json
@@ -47,39 +47,39 @@
       "end" : 3581227
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jerzy",
-      "Michael Bideller"
-    ],
-    [
-      "Mariana",
-      "Antje Roosch"
-    ],
-    [
-      "1. Mann",
-      "Nico König"
-    ],
-    [
-      "2. Mann",
-      "Lutz Schnell"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jerzy",
+      "sprecher" : "Michael Bideller"
+    },
+    {
+      "rolle" : "Mariana",
+      "sprecher" : "Antje Roosch"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Lutz Schnell"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/068/metadata.json",

--- a/web/data/Serie/069/metadata.json
+++ b/web/data/Serie/069/metadata.json
@@ -47,71 +47,72 @@
       "end" : 3942387
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Erna Fiedler",
-      "Ursula Gompf"
-    ],
-    [
-      "Dr. Ferguson",
-      "Antje Cornelius"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "John Brady",
-      "Dirk Anton"
-    ],
-    [
-      "Matt Brady",
-      "Volker Bogdan"
-    ],
-    [
-      "Mr. Andrews",
-      "Günter König"
-    ],
-    [
-      "Mr. Shaw",
-      "Eberhard Haar"
-    ],
-    [
-      "Mrs. Shaw",
-      "Heikedine Körting"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Erna Fiedler",
+      "sprecher" : "Ursula Gompf"
+    },
+    {
+      "rolle" : "Dr. Ferguson",
+      "sprecher" : "Antje Cornelius"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "John Brady",
+      "sprecher" : "Dirk Anton"
+    },
+    {
+      "rolle" : "Matt Brady",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Günter König"
+    },
+    {
+      "rolle" : "Mr. Shaw",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Mrs. Shaw",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/069/metadata.json",

--- a/web/data/Serie/070/metadata.json
+++ b/web/data/Serie/070/metadata.json
@@ -47,63 +47,63 @@
       "end" : 3784293
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Alan",
-      "Oliver Reinhardt"
-    ],
-    [
-      "Sally Samson",
-      "Cornelia Meinhardt"
-    ],
-    [
-      "Sofie Samson",
-      "Samira Chanfir"
-    ],
-    [
-      "Dr. Harris",
-      "Hansi Jochmann"
-    ],
-    [
-      "John Davis",
-      "Tim Wieck"
-    ],
-    [
-      "Homer Washington",
-      "Hans Sievers"
-    ],
-    [
-      "Fahrer",
-      "Klaus-Peter Kaehler"
-    ],
-    [
-      "Brenda",
-      "Micaela Kreißler"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Junge",
-      "Jona Mues"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Alan",
+      "sprecher" : "Oliver Reinhard"
+    },
+    {
+      "rolle" : "Sally Samson",
+      "sprecher" : "Cornelia Meinhardt"
+    },
+    {
+      "rolle" : "Sofie Samson",
+      "sprecher" : "Samira Chanfir"
+    },
+    {
+      "rolle" : "Dr. Harris",
+      "sprecher" : "Hansi Jochmann"
+    },
+    {
+      "rolle" : "John Davis",
+      "sprecher" : "Tim Wieck"
+    },
+    {
+      "rolle" : "Homer Washington",
+      "sprecher" : "Hans Sievers"
+    },
+    {
+      "rolle" : "Fahrer",
+      "sprecher" : "Klaus-Peter Kaehler"
+    },
+    {
+      "rolle" : "Brenda",
+      "sprecher" : "Micaëla Kreißler"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "Jona Mues"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/070/metadata.json",

--- a/web/data/Serie/071/metadata.json
+++ b/web/data/Serie/071/metadata.json
@@ -47,75 +47,76 @@
       "end" : 3994440
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Andrews",
-      "Günter König"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Lu Kwan",
-      "Susanne von Loessel"
-    ],
-    [
-      "Jefferson",
-      "Christian Redl"
-    ],
-    [
-      "Dimitrios, Bankdirektor",
-      "Wilhelm Wieben"
-    ],
-    [
-      "Dan Jordan, Reporter",
-      "Michael Lott"
-    ],
-    [
-      "Olivia",
-      "Eva Weißmann"
-    ],
-    [
-      "Santoria",
-      "Holger Ohlendieck"
-    ],
-    [
-      "Pertier",
-      "Johann Herstermann"
-    ],
-    [
-      "Sergeant",
-      "Ingvar Jensen"
-    ],
-    [
-      "Irma",
-      "Konstanze Ulmer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Günter König"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Lu Kwan",
+      "sprecher" : "Susanne von Loessl"
+    },
+    {
+      "rolle" : "Jefferson",
+      "sprecher" : "Christian Redl"
+    },
+    {
+      "rolle" : "Dimitrios, Bankdirektor",
+      "sprecher" : "Wilhelm Wieben"
+    },
+    {
+      "rolle" : "Dan Jordan, Reporter",
+      "sprecher" : "Michael Lott"
+    },
+    {
+      "rolle" : "Olivia",
+      "sprecher" : "Eva Weissmann"
+    },
+    {
+      "rolle" : "Santoria",
+      "sprecher" : "Dieter Ohlendiek"
+    },
+    {
+      "rolle" : "Pertier",
+      "sprecher" : "Johann Herstermann"
+    },
+    {
+      "rolle" : "Sergeant",
+      "sprecher" : "Ingvar Jensen"
+    },
+    {
+      "rolle" : "Irma",
+      "sprecher" : "Konstanze Ullmer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/071/metadata.json",

--- a/web/data/Serie/072/metadata.json
+++ b/web/data/Serie/072/metadata.json
@@ -47,71 +47,71 @@
       "end" : 3477893
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Laura McLaughin",
-      "Marianne Kehlau"
-    ],
-    [
-      "Malcolm King",
-      "Jörg Gillner"
-    ],
-    [
-      "Lansana King",
-      "Sabine Hahn"
-    ],
-    [
-      "Hester Dalton",
-      "Marianne Bernhardt"
-    ],
-    [
-      "Billie",
-      "Stefan Conradi"
-    ],
-    [
-      "Polizist",
-      "Oliver Reinhardt"
-    ],
-    [
-      "Wachmann",
-      "Dieter Ohlendieck"
-    ],
-    [
-      "2. Wächter",
-      "Michael Lott"
-    ],
-    [
-      "1. Polizist",
-      "Torben Liebrecht"
-    ],
-    [
-      "2. Polizist",
-      "Rene Spiegelberger"
-    ],
-    [
-      "Kellnerin",
-      "Doris Jahn"
-    ],
-    [
-      "Kundin",
-      "Susann Jarling"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Laura McLaughin",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Malcolm King",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Lansana King",
+      "sprecher" : "Sabine Hahn"
+    },
+    {
+      "rolle" : "Hester Dalton",
+      "sprecher" : "Marianne Bernhardt"
+    },
+    {
+      "rolle" : "Billie",
+      "sprecher" : "Stefan Conradi"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Oliver Reinhard"
+    },
+    {
+      "rolle" : "Wachmann",
+      "sprecher" : "Dieter Ohlendiek"
+    },
+    {
+      "rolle" : "Wächter 2",
+      "sprecher" : "Michael Lott"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Torben Liebrecht"
+    },
+    {
+      "rolle" : "Polizist 2",
+      "sprecher" : "Rene Spiegelberger"
+    },
+    {
+      "rolle" : "Kellnerin",
+      "sprecher" : "Doris Jahn"
+    },
+    {
+      "rolle" : "Kundin",
+      "sprecher" : "Susan Jarling"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/072/metadata.json",

--- a/web/data/Serie/073/metadata.json
+++ b/web/data/Serie/073/metadata.json
@@ -47,55 +47,55 @@
       "end" : 3997320
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Madigan",
-      "Anne Marks-Rocke"
-    ],
-    [
-      "Eathon Easton, ihr Untermieter",
-      "Helmo Liebig"
-    ],
-    [
-      "Mrs. Lydia Cartier",
-      "Gerda Gmelin"
-    ],
-    [
-      "Sigourney, ihr Dienstmädchen",
-      "Susanne Beck"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "Inspektor Kershaw",
-      "Frank Felicetti"
-    ],
-    [
-      "Hugenay",
-      "Hans Irle"
-    ],
-    [
-      "Museumswärterin",
-      "Marianne Kehlau"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Madigan",
+      "sprecher" : "Annemarie Marks-Rocke"
+    },
+    {
+      "rolle" : "Eathon Easton, ihr Untermieter",
+      "sprecher" : "Helgo Liebig"
+    },
+    {
+      "rolle" : "Mrs. Lydia Cartier",
+      "sprecher" : "Gerda Gmelin"
+    },
+    {
+      "rolle" : "Sigourney, ihr Dienstmädchen",
+      "sprecher" : "Susanne Beck"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Inspektor Kershaw",
+      "sprecher" : "Frank Felicetti"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Hans Irle"
+    },
+    {
+      "rolle" : "Museumswärterin",
+      "sprecher" : "Marianne Kehlau"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/073/metadata.json",

--- a/web/data/Serie/074/metadata.json
+++ b/web/data/Serie/074/metadata.json
@@ -47,71 +47,72 @@
       "end" : 4442107
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Mr. Whitehead",
-      "Uwe Friedrichsen"
-    ],
-    [
-      "Steven Robinshaw, Anwalt",
-      "Helmo Liebig"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mary",
-      "Victoria Voncampe"
-    ],
-    [
-      "Stan",
-      "Georg Tryphon"
-    ],
-    [
-      "Jeffrey",
-      "Michael Quiatkowsky"
-    ],
-    [
-      "John",
-      "Andreas Martens"
-    ],
-    [
-      "Dr. Wright",
-      "Dietmar Mues"
-    ],
-    [
-      "Carrie Hanson",
-      "Helga Osten-Sacken"
-    ],
-    [
-      "Tim Conrad",
-      "Moritz Gentsch"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Mr. Whitehead",
+      "sprecher" : "Uwe Friedrichsen"
+    },
+    {
+      "rolle" : "Steven Robinshaw, Anwalt",
+      "sprecher" : "Helgo Liebig"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mary",
+      "sprecher" : "Victoria Voncampe"
+    },
+    {
+      "rolle" : "Stan",
+      "sprecher" : "Georg Tryphon"
+    },
+    {
+      "rolle" : "Jeffrey",
+      "sprecher" : "Michael Quiatkowsky"
+    },
+    {
+      "rolle" : "John",
+      "sprecher" : "Andreas Martens"
+    },
+    {
+      "rolle" : "Dr. Wright",
+      "sprecher" : "Dietmar Mues"
+    },
+    {
+      "rolle" : "Carrie Hanson",
+      "sprecher" : "Hella von der Osten-Sacken"
+    },
+    {
+      "rolle" : "Tim Conrad",
+      "sprecher" : "Moritz Gentsch"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/074/metadata.json",

--- a/web/data/Serie/075/metadata.json
+++ b/web/data/Serie/075/metadata.json
@@ -47,51 +47,51 @@
       "end" : 3339600
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Shaw",
-      "Heikedine Körting"
-    ],
-    [
-      "Amanda Black",
-      "Beate Hasenau"
-    ],
-    [
-      "Detective Gregston",
-      "Wolf-Dietrich Berg"
-    ],
-    [
-      "Nora Sethons",
-      "Ursula Sieg"
-    ],
-    [
-      "Mrs. Aston",
-      "J.S."
-    ],
-    [
-      "Mr. Krieger",
-      "Jörg Gillner"
-    ],
-    [
-      "Lisa Manninger",
-      "Katja Stichel"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Shaw",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Amanda Black",
+      "sprecher" : "Beate Hasenau"
+    },
+    {
+      "rolle" : "Detective Gregston",
+      "sprecher" : "Wolf-Dietrich Berg"
+    },
+    {
+      "rolle" : "Nora Sethons",
+      "sprecher" : "Ursula Sieg"
+    },
+    {
+      "rolle" : "Mrs. Aston",
+      "sprecher" : "Joyceline Schmidt"
+    },
+    {
+      "rolle" : "Mr. Krieger",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Lisa Manninger",
+      "sprecher" : "Katja Stichel"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/075/metadata.json",

--- a/web/data/Serie/076/metadata.json
+++ b/web/data/Serie/076/metadata.json
@@ -47,59 +47,59 @@
       "end" : 4184827
     }
   ],
-  "sprecher" : [
-    [
-      "Hitchcock, Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Abigail Holligan",
-      "Katharina Brauren"
-    ],
-    [
-      "Metzla Holligan",
-      "Beate Hasenau"
-    ],
-    [
-      "Dr. Franklin",
-      "Judy Winter"
-    ],
-    [
-      "Dr. Miller",
-      "Marianne Kehlau"
-    ],
-    [
-      "Mrs. Petersen",
-      "Victoria Voncampe"
-    ],
-    [
-      "Sekretariat",
-      "\"Fettes Brot\""
-    ],
-    [
-      "Mr. Brian",
-      "Peter Schubert"
-    ],
-    [
-      "Mrs. Dream",
-      "Petra Ehlers"
-    ],
-    [
-      "Jack Cliffwater",
-      "Thomas Schüler"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Hitchcock, Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Abigail Holligan",
+      "sprecher" : "Katharina Brauren"
+    },
+    {
+      "rolle" : "Metzla Holligan",
+      "sprecher" : "Beate Hasenau"
+    },
+    {
+      "rolle" : "Clarissa Franklin",
+      "sprecher" : "Judy Winter"
+    },
+    {
+      "rolle" : "Dr. Miller",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Mrs. Petersen",
+      "sprecher" : "Victoria Voncampe"
+    },
+    {
+      "rolle" : "Sekretariat",
+      "sprecher" : "\"Fettes Brot\""
+    },
+    {
+      "rolle" : "Mr. Brian",
+      "sprecher" : "Peter Schubert"
+    },
+    {
+      "rolle" : "Mrs. Dream",
+      "sprecher" : "Petra Ehlers"
+    },
+    {
+      "rolle" : "Jack Cliffwater",
+      "sprecher" : "Thomas Schüler"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/076/metadata.json",

--- a/web/data/Serie/077/metadata.json
+++ b/web/data/Serie/077/metadata.json
@@ -37,67 +37,68 @@
       "end" : 3559333
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Karen Sulzenberger",
-      "Kristina von Welzin"
-    ],
-    [
-      "Nicola",
-      "Maria Fuchs"
-    ],
-    [
-      "McMannoman",
-      "Wolfgang Noack"
-    ],
-    [
-      "Tony",
-      "Martin Lohmann"
-    ],
-    [
-      "Mrs. Seven",
-      "Eva Gelb"
-    ],
-    [
-      "Trainer",
-      "Hans Sievers"
-    ],
-    [
-      "Roger",
-      "H. P. Kaehler"
-    ],
-    [
-      "1. Mann",
-      "Helmut Ahner"
-    ],
-    [
-      "2. Mann",
-      "Richard Ems"
-    ],
-    [
-      "Kellnerin",
-      "Micaela Kreißler"
-    ],
-    [
-      "Uli",
-      "Norman Messer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Karen Sulzenberger",
+      "sprecher" : "Kristina von Weltzien"
+    },
+    {
+      "rolle" : "Nicola",
+      "sprecher" : "Maria Fuchs"
+    },
+    {
+      "rolle" : "McMannoman",
+      "sprecher" : "Wolfgang Noack"
+    },
+    {
+      "rolle" : "Tony",
+      "sprecher" : "Martin Lohmann"
+    },
+    {
+      "rolle" : "Mrs. Seven",
+      "sprecher" : "Eva Gelb"
+    },
+    {
+      "rolle" : "Trainer",
+      "sprecher" : "Hans Sievers"
+    },
+    {
+      "rolle" : "Roger",
+      "sprecher" : "Klaus-Peter Kaehler"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Helmut Ahner"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Richard Ems"
+    },
+    {
+      "rolle" : "Kellnerin",
+      "sprecher" : "Micaëla Kreißler"
+    },
+    {
+      "rolle" : "Uli",
+      "sprecher" : "André Minninger",
+      "pseudonym" : "Norman Messer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/077/metadata.json",

--- a/web/data/Serie/078/metadata.json
+++ b/web/data/Serie/078/metadata.json
@@ -37,63 +37,64 @@
       "end" : 3448987
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Albert Hitfield",
-      "Manfred Steffen"
-    ],
-    [
-      "Morton, Chauffeur",
-      "Andreas von der Meden"
-    ],
-    [
-      "Lys",
-      "Kerstin Draeger"
-    ],
-    [
-      "J.J.",
-      "Gregor Reisch"
-    ],
-    [
-      "Julius Jonas",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Catherine Jonas",
-      "Anne Moll"
-    ],
-    [
-      "Arturo",
-      "Carlos Goiach"
-    ],
-    [
-      "Autovermieter",
-      "Richard Ems"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Albert Hitfield",
+      "sprecher" : "Manfred Steffen"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Lys",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "J.J.",
+      "sprecher" : "Gregor Reisch"
+    },
+    {
+      "rolle" : "Julius Jonas",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Catherine Jonas",
+      "sprecher" : "Anne Moll"
+    },
+    {
+      "rolle" : "Arturo",
+      "sprecher" : "Carlos Goiach"
+    },
+    {
+      "rolle" : "Autovermieter",
+      "sprecher" : "Richard Ems"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/078/metadata.json",

--- a/web/data/Serie/079/metadata.json
+++ b/web/data/Serie/079/metadata.json
@@ -47,67 +47,70 @@
       "end" : 4612307
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Al Parker, Musikproduzent",
-      "Lennardt Krüger"
-    ],
-    [
-      "William Needle",
-      "Nico König"
-    ],
-    [
-      "Stevens",
-      "Lothar Behrendt"
-    ],
-    [
-      "Bart",
-      "Doktor Renz"
-    ],
-    [
-      "Luke",
-      "Schiffmeister"
-    ],
-    [
-      "Frank",
-      "König Boris"
-    ],
-    [
-      "Joan, Visagistin",
-      "Alida Gundlach"
-    ],
-    [
-      "Jeffrey",
-      "Niko Minninger"
-    ],
-    [
-      "Hank",
-      "Harvey Draeger"
-    ],
-    [
-      "Billy",
-      "Sven Stricker"
-    ],
-    [
-      "Angestellter",
-      "Jens Herrndorff"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Al Parker, Musikproduzent",
+      "sprecher" : "Lennardt Krüger"
+    },
+    {
+      "rolle" : "William Needle",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Stevens",
+      "sprecher" : "Lothar Behrendt"
+    },
+    {
+      "rolle" : "Bart",
+      "sprecher" : "Martin Vandreier",
+      "pseudonym" : "Dokter Renz"
+    },
+    {
+      "rolle" : "Luke",
+      "sprecher" : "Björn Warns",
+      "pseudonym" : "Schiffmeister"
+    },
+    {
+      "rolle" : "Frank",
+      "sprecher" : "Boris Lauterbach",
+      "pseudonym" : "König Boris"
+    },
+    {
+      "rolle" : "Joan, Visagistin",
+      "sprecher" : "Alida Gundlach"
+    },
+    {
+      "rolle" : "Jeffrey",
+      "sprecher" : "Niko Minninger"
+    },
+    {
+      "rolle" : "Hank",
+      "sprecher" : "Harvey Draeger"
+    },
+    {
+      "rolle" : "Billy",
+      "sprecher" : "Sven Stricker"
+    },
+    {
+      "rolle" : "Angestellter",
+      "sprecher" : "Jens Herrndorff"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/079/metadata.json",

--- a/web/data/Serie/080/metadata.json
+++ b/web/data/Serie/080/metadata.json
@@ -37,35 +37,36 @@
       "end" : 3560667
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Cosma",
-      "Elke Reissert"
-    ],
-    [
-      "Vladimir Contreras",
-      "Gerhart Hinze"
-    ],
-    [
-      "Roger Carpenter",
-      "Igmar Frentzen"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Cosma",
+      "sprecher" : "Elke Reissert"
+    },
+    {
+      "rolle" : "Vladimir Contreras",
+      "sprecher" : "Gerhart Hinze"
+    },
+    {
+      "rolle" : "Roger Carpenter",
+      "sprecher" : "Gustav-Adolph Artz",
+      "pseudonym" : "Igmar Frenzen"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/080/metadata.json",

--- a/web/data/Serie/081/metadata.json
+++ b/web/data/Serie/081/metadata.json
@@ -37,59 +37,59 @@
       "end" : 2983827
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kelly Madigan",
-      "Juliane Szalay"
-    ],
-    [
-      "DaElba",
-      "Ozanan Rocha"
-    ],
-    [
-      "Alberto",
-      "Antonio Luz"
-    ],
-    [
-      "Mr. Toll",
-      "Balduin Baas"
-    ],
-    [
-      "Franke",
-      "Wolfgang Noack"
-    ],
-    [
-      "Mr. Andrews",
-      "Günter König"
-    ],
-    [
-      "Mr. Burt",
-      "Gerd Baltus"
-    ],
-    [
-      "Boris",
-      "Carlos Goiach"
-    ],
-    [
-      "Papagei",
-      "Heikedine Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kelly Madigan",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "DaElba",
+      "sprecher" : "Ozanan Rocha"
+    },
+    {
+      "rolle" : "Alberto",
+      "sprecher" : "Antonio Luz"
+    },
+    {
+      "rolle" : "Mr. Toll",
+      "sprecher" : "Balduin Baas"
+    },
+    {
+      "rolle" : "Franke",
+      "sprecher" : "Wolfgang Noack"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Günter König"
+    },
+    {
+      "rolle" : "Mr. Burt",
+      "sprecher" : "Gerd Baltus"
+    },
+    {
+      "rolle" : "Boris",
+      "sprecher" : "Carlos Goiach"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/081/metadata.json",

--- a/web/data/Serie/082/metadata.json
+++ b/web/data/Serie/082/metadata.json
@@ -37,43 +37,43 @@
       "end" : 4199867
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Milva Summer, Astrologin",
-      "Elizabeth Volkmann"
-    ],
-    [
-      "Professor Steed, Tiermediziner",
-      "Henning Schlüter"
-    ],
-    [
-      "Daniel Art, Bodyguard",
-      "Monty Arnold"
-    ],
-    [
-      "Mike Hanson, Reporter",
-      "Corny Littmann"
-    ],
-    [
-      "Nachrichtensprecher",
-      "Werner Pohlenz"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Milva Summer, Astrologin",
+      "sprecher" : "Elisabeth Volkmann"
+    },
+    {
+      "rolle" : "Professor Steed, Tiermediziner",
+      "sprecher" : "Henning Schlüter"
+    },
+    {
+      "rolle" : "Daniel Art, Bodyguard",
+      "sprecher" : "Monty Arnold"
+    },
+    {
+      "rolle" : "Mike Hanson, Reporter",
+      "sprecher" : "Corny Littmann"
+    },
+    {
+      "rolle" : "Nachrichtensprecher",
+      "sprecher" : "Werner Pohlenz"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/082/metadata.json",

--- a/web/data/Serie/083/metadata.json
+++ b/web/data/Serie/083/metadata.json
@@ -37,51 +37,51 @@
       "end" : 3558427
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Käptn Jason",
-      "F.J. Steffens"
-    ],
-    [
-      "Professor Clark",
-      "Erich Krieg"
-    ],
-    [
-      "Carol Ford, Fernsehjournalistin",
-      "Claudia Schermutzki"
-    ],
-    [
-      "Dr. Helprin, Wissenschaftler",
-      "Rudolf Herget"
-    ],
-    [
-      "Mr. Evans",
-      "Peter Groß"
-    ],
-    [
-      "Enrique Serra",
-      "Jörg Gillner"
-    ],
-    [
-      "Mr. Andrews",
-      "Roland Becker"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Käptn Jason",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "Professor Clark",
+      "sprecher" : "Erich Krieg"
+    },
+    {
+      "rolle" : "Carol Ford, Fernsehjournalistin",
+      "sprecher" : "Claudia Schermutzki"
+    },
+    {
+      "rolle" : "Dr. Helprin, Wissenschaftler",
+      "sprecher" : "Rudolf H. Herget"
+    },
+    {
+      "rolle" : "Mr. Evans",
+      "sprecher" : "Peter Groß"
+    },
+    {
+      "rolle" : "Enrique Serra",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Roland Becker"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/083/metadata.json",

--- a/web/data/Serie/084/metadata.json
+++ b/web/data/Serie/084/metadata.json
@@ -37,43 +37,43 @@
       "end" : 3603107
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jelena",
-      "Alexandra Doerk"
-    ],
-    [
-      "Mr. Charkov, Jelenas Vater",
-      "Klaus Dittmann"
-    ],
-    [
-      "Vanderhell, Teufelsgeiger",
-      "Lutz Mackensy"
-    ],
-    [
-      "Mr. Andrews",
-      "Roland Becker"
-    ],
-    [
-      "Mrs. Andrews",
-      "Carola Lange"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jelena Charkova",
+      "sprecher" : "Alexandra Doerk"
+    },
+    {
+      "rolle" : "Mr. Charkov",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Vanderhell, Teufelsgeiger",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Roland Becker"
+    },
+    {
+      "rolle" : "Mrs. Andrews",
+      "sprecher" : "Carola Lange"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/084/metadata.json",

--- a/web/data/Serie/085/metadata.json
+++ b/web/data/Serie/085/metadata.json
@@ -37,51 +37,51 @@
       "end" : 3562000
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Walker",
-      "Lothar Grützner"
-    ],
-    [
-      "Monica",
-      "Hansi Jochmann"
-    ],
-    [
-      "Lady MacWeiden",
-      "Renate Pichler"
-    ],
-    [
-      "Mac George",
-      "Johann Schibli"
-    ],
-    [
-      "Chris",
-      "Daniel Kruth"
-    ],
-    [
-      "Campingwart",
-      "Helmut Ahner"
-    ],
-    [
-      "Frau des Campingwarts",
-      "Ingrid Weiß"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Walker",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Monica",
+      "sprecher" : "Hansi Jochmann"
+    },
+    {
+      "rolle" : "Lady MacWeiden",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Mac George",
+      "sprecher" : "Johann Schibli"
+    },
+    {
+      "rolle" : "Chris",
+      "sprecher" : "Daniel Kruth"
+    },
+    {
+      "rolle" : "Campingwart",
+      "sprecher" : "Helmut Ahner"
+    },
+    {
+      "rolle" : "Frau des Campingwarts",
+      "sprecher" : "Ingrid Weiß"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/085/metadata.json",

--- a/web/data/Serie/086/metadata.json
+++ b/web/data/Serie/086/metadata.json
@@ -37,51 +37,51 @@
       "end" : 3457213
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Mr. Peacock, Museumsdirektor",
-      "Helmut Ahner"
-    ],
-    [
-      "Alpha",
-      "Achim Schülke"
-    ],
-    [
-      "Beth",
-      "Katja Brügger"
-    ],
-    [
-      "Ernie",
-      "Wolfgang Hartmann"
-    ],
-    [
-      "Dog",
-      "Niko Minninger"
-    ],
-    [
-      "Ceewee",
-      "Michael Quiatkowski"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Mr. Peacock, Museumsdirektor",
+      "sprecher" : "Helmut Ahner"
+    },
+    {
+      "rolle" : "Alpha",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Beth",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Ernie",
+      "sprecher" : "Wolfgang Hartmann"
+    },
+    {
+      "rolle" : "Dog",
+      "sprecher" : "Niko Minninger"
+    },
+    {
+      "rolle" : "Ceewee",
+      "sprecher" : "Michael Quiatkowsky"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/086/metadata.json",

--- a/web/data/Serie/087/metadata.json
+++ b/web/data/Serie/087/metadata.json
@@ -37,59 +37,59 @@
       "end" : 3294627
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Harding, Polizeipsychologin",
-      "Katrin Wasow"
-    ],
-    [
-      "Mr. Ambler, Assistent",
-      "Rainer Schmitt"
-    ],
-    [
-      "Rodder, das Wolfsgesicht",
-      "Andreas Martens"
-    ],
-    [
-      "Mr. Laurent, Ladenbesitzer",
-      "Lutz Lukasz"
-    ],
-    [
-      "Mr. Stepelton, Ladenbesitzer",
-      "Harald Pages"
-    ],
-    [
-      "Ray, Praktikant",
-      "Marcel Rinkenauer"
-    ],
-    [
-      "Sandy, Verkäuferin",
-      "Kathi Robens"
-    ],
-    [
-      "Kundin",
-      "Cornelia Meinhardt"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Harding, Polizeipsychologin",
+      "sprecher" : "Katrin Wasow"
+    },
+    {
+      "rolle" : "Mr. Ambler, Assistent",
+      "sprecher" : "Rainer Schmitt"
+    },
+    {
+      "rolle" : "Rodder, das Wolfsgesicht",
+      "sprecher" : "Andreas Martens"
+    },
+    {
+      "rolle" : "Mr. Laurent, Ladenbesitzer",
+      "sprecher" : "Lutz Lukasz"
+    },
+    {
+      "rolle" : "Mr. Stepelton, Ladenbesitzer",
+      "sprecher" : "Harald Pages"
+    },
+    {
+      "rolle" : "Ray, Praktikant",
+      "sprecher" : "Marcel Rinkenauer"
+    },
+    {
+      "rolle" : "Sandy, Verkäuferin",
+      "sprecher" : "Cornelia Meinhardt"
+    },
+    {
+      "rolle" : "Kundin",
+      "sprecher" : "Kathi Robens"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/087/metadata.json",

--- a/web/data/Serie/088/metadata.json
+++ b/web/data/Serie/088/metadata.json
@@ -37,79 +37,79 @@
       "end" : 4496507
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Doe Dungeon, Programmierer",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Lili Buschfort",
-      "Christina Holsten"
-    ],
-    [
-      "Tom Beker",
-      "Wolfgang Hartmann"
-    ],
-    [
-      "Märchenerzähler",
-      "Hans Paetsch"
-    ],
-    [
-      "Königin Trulie",
-      "Hanna Reisch"
-    ],
-    [
-      "Vinton",
-      "Nils Noller"
-    ],
-    [
-      "Amme",
-      "Katharina Brauren"
-    ],
-    [
-      "Medusa",
-      "Marianne Kehlau"
-    ],
-    [
-      "Oinki Hinki",
-      "Niko Minninger"
-    ],
-    [
-      "Vampir-Frau",
-      "Julia von Spieß"
-    ],
-    [
-      "Hexe",
-      "Micaela Kreißler"
-    ],
-    [
-      "Oma",
-      "Beate Hasenau"
-    ],
-    [
-      "Wache",
-      "Michael Quiatkowsky"
-    ],
-    [
-      "Computerstimme",
-      "Sascha Gutzeit"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Doe Dungeon, Programmierer",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Lili Buschfort",
+      "sprecher" : "Christina Holsten"
+    },
+    {
+      "rolle" : "Tom Beker",
+      "sprecher" : "Wolfgang Hartmann"
+    },
+    {
+      "rolle" : "Märchenerzähler",
+      "sprecher" : "Hans Paetsch"
+    },
+    {
+      "rolle" : "Königin Trulie",
+      "sprecher" : "Hanna Reisch"
+    },
+    {
+      "rolle" : "Vinton",
+      "sprecher" : "Nils Noller"
+    },
+    {
+      "rolle" : "Amme",
+      "sprecher" : "Katharina Brauren"
+    },
+    {
+      "rolle" : "Medusa",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Oinki Hinki",
+      "sprecher" : "Niko Minninger"
+    },
+    {
+      "rolle" : "Vampir-Frau",
+      "sprecher" : "Julia von Spieß"
+    },
+    {
+      "rolle" : "Hexe",
+      "sprecher" : "Micaëla Kreißler"
+    },
+    {
+      "rolle" : "Oma",
+      "sprecher" : "Beate Hasenau"
+    },
+    {
+      "rolle" : "Wache",
+      "sprecher" : "Michael Quiatkowsky"
+    },
+    {
+      "rolle" : "Computerstimme",
+      "sprecher" : "Sascha Gutzeit"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/088/metadata.json",

--- a/web/data/Serie/089/metadata.json
+++ b/web/data/Serie/089/metadata.json
@@ -37,51 +37,51 @@
       "end" : 3586347
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mr. Gilbert",
-      "Manfred Reddemann"
-    ],
-    [
-      "Mrs. Grayson",
-      "Beate Hasenau"
-    ],
-    [
-      "Mr. Perkins",
-      "Marco Kröger"
-    ],
-    [
-      "Mac Dunno",
-      "Gerhard Marcel"
-    ],
-    [
-      "Wachmann",
-      "Ulli Plessmann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mr. Gilbert",
+      "sprecher" : "Manfred Reddemann"
+    },
+    {
+      "rolle" : "Mrs. Grayson",
+      "sprecher" : "Beate Hasenau"
+    },
+    {
+      "rolle" : "Mr. Perkins",
+      "sprecher" : "Marco Kröger"
+    },
+    {
+      "rolle" : "Mac Dunno",
+      "sprecher" : "Gerhard Marcel"
+    },
+    {
+      "rolle" : "Wachmann",
+      "sprecher" : "Uli Pleßmann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/089/metadata.json",

--- a/web/data/Serie/090/metadata.json
+++ b/web/data/Serie/090/metadata.json
@@ -37,35 +37,35 @@
       "end" : 3532947
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Aaron Moore",
-      "Reent Reins"
-    ],
-    [
-      "Roxanne",
-      "Regine Lamster"
-    ],
-    [
-      "Bruce Black",
-      "Til Demtröder"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Aaron Moore",
+      "sprecher" : "Reent Reins"
+    },
+    {
+      "rolle" : "Roxanne",
+      "sprecher" : "Regine Lamster"
+    },
+    {
+      "rolle" : "Bruce Black",
+      "sprecher" : "Till Demtrøder"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/090/metadata.json",

--- a/web/data/Serie/091/metadata.json
+++ b/web/data/Serie/091/metadata.json
@@ -37,39 +37,39 @@
       "end" : 3597147
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Stanley Truman",
-      "Horst Stark"
-    ],
-    [
-      "Mr. Shaw",
-      "Eberhard Haar"
-    ],
-    [
-      "Mrs. Jones",
-      "Gisela Trowe"
-    ],
-    [
-      "Mrs. Shoemaker",
-      "Barbara Schnipper"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Stanley Truman",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Mr. Shaw",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Mrs. Jones",
+      "sprecher" : "Gisela Trowe"
+    },
+    {
+      "rolle" : "Mrs. Shoemaker",
+      "sprecher" : "Barbara Schipper"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/091/metadata.json",

--- a/web/data/Serie/092/metadata.json
+++ b/web/data/Serie/092/metadata.json
@@ -37,39 +37,39 @@
       "end" : 3569347
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Gregstone",
-      "Wolf Rathjen"
-    ],
-    [
-      "Butch",
-      "Frank Felicetti"
-    ],
-    [
-      "Ramirez",
-      "Tobias Schmidt"
-    ],
-    [
-      "Radiosprecher",
-      "Hubertus Borck"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Gregstone",
+      "sprecher" : "Wolf Rahtjen"
+    },
+    {
+      "rolle" : "Butch",
+      "sprecher" : "Frank Felicetti"
+    },
+    {
+      "rolle" : "Ramirez",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Radiosprecher",
+      "sprecher" : "Hubertus Borck"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/092/metadata.json",

--- a/web/data/Serie/093/metadata.json
+++ b/web/data/Serie/093/metadata.json
@@ -37,43 +37,44 @@
       "end" : 3592133
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Quin",
-      "Rasmus Borowski"
-    ],
-    [
-      "Mr. Conrad Farnham",
-      "Lothar Grützner"
-    ],
-    [
-      "Mrs. Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Deborah Snell",
-      "Anja Topf"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Quin",
+      "sprecher" : "Rasmus Borowski"
+    },
+    {
+      "rolle" : "Mr. Conrad Farnham",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Deborah Snell",
+      "sprecher" : "Anja Topf"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/093/metadata.json",

--- a/web/data/Serie/094/metadata.json
+++ b/web/data/Serie/094/metadata.json
@@ -37,59 +37,60 @@
       "end" : 3262720
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Alois Copper",
-      "Werner Cartano"
-    ],
-    [
-      "Mr. Carter",
-      "Marius Berthold"
-    ],
-    [
-      "Miss Lilly",
-      "Jocelyn Boisseaux-Endemann"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Frau des Bürgermeisters",
-      "Wanda Osten"
-    ],
-    [
-      "Reporter",
-      "Jacky Nonnon"
-    ],
-    [
-      "Stewart",
-      "Till Madaus"
-    ],
-    [
-      "Pico, Clown",
-      "Hubertus Borck"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Alois Copper",
+      "sprecher" : "Werner Cartano"
+    },
+    {
+      "rolle" : "Mr. Carter",
+      "sprecher" : "Marius Berthold"
+    },
+    {
+      "rolle" : "Miss Lilly",
+      "sprecher" : "Jocelyne Boisseau"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Frau des Bürgermeisters",
+      "sprecher" : "Hella von der Osten-Sacken",
+      "pseudonym" : "Wanda Osten"
+    },
+    {
+      "rolle" : "Reporter",
+      "sprecher" : "Jacky Nonnon"
+    },
+    {
+      "rolle" : "Stewart",
+      "sprecher" : "Tilman Madaus"
+    },
+    {
+      "rolle" : "Pico, Clown",
+      "sprecher" : "Hubertus Borck"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/094/metadata.json",

--- a/web/data/Serie/095/metadata.json
+++ b/web/data/Serie/095/metadata.json
@@ -37,47 +37,47 @@
       "end" : 3603800
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jelena Charkov",
-      "Alexandra Doerk"
-    ],
-    [
-      "Mr. Charkov",
-      "Klaus Dittmann"
-    ],
-    [
-      "Dr. Arroway",
-      "Sona Cervena"
-    ],
-    [
-      "Janet, ihre Assistentin",
-      "Ute Rohrbeck"
-    ],
-    [
-      "Tom Gordon",
-      "Philip Hoier"
-    ],
-    [
-      "Dixon",
-      "Utz Richter"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jelena Charkova",
+      "sprecher" : "Alexandra Doerk"
+    },
+    {
+      "rolle" : "Mr. Charkov",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Dr. Arroway",
+      "sprecher" : "Soňa Červená"
+    },
+    {
+      "rolle" : "Janet, ihre Assistentin",
+      "sprecher" : "Ute Rohrbeck"
+    },
+    {
+      "rolle" : "Tom Gordon",
+      "sprecher" : "Philip Hoier"
+    },
+    {
+      "rolle" : "Dixon",
+      "sprecher" : "Utz Richter"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/095/metadata.json",

--- a/web/data/Serie/096/metadata.json
+++ b/web/data/Serie/096/metadata.json
@@ -47,55 +47,55 @@
       "end" : 3191000
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Detective Frank",
-      "Wolf Frass"
-    ],
-    [
-      "Dave Rawling",
-      "Helmut Gentsch"
-    ],
-    [
-      "Praktikantin Lesley",
-      "Ann Montenbruck"
-    ],
-    [
-      "Mrs. Shaw",
-      "Heikedine Körting"
-    ],
-    [
-      "Mr. Smith",
-      "Douglas Welbat"
-    ],
-    [
-      "Sheppard",
-      "Marius Kreissler"
-    ],
-    [
-      "Feuerwehrmann",
-      "Wolfgang Kaven"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Detective Frank",
+      "sprecher" : "Wolf Frass"
+    },
+    {
+      "rolle" : "Dave Rawling",
+      "sprecher" : "Helmut Gentsch"
+    },
+    {
+      "rolle" : "Praktikantin Lesley",
+      "sprecher" : "Ann Montenbruck"
+    },
+    {
+      "rolle" : "Mrs. Shaw",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Mr. Smith",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Sheppard",
+      "sprecher" : "Marius Kreissler"
+    },
+    {
+      "rolle" : "Feuerwehrmann",
+      "sprecher" : "Wolfgang Kaven"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/096/metadata.json",

--- a/web/data/Serie/097/metadata.json
+++ b/web/data/Serie/097/metadata.json
@@ -47,43 +47,44 @@
       "end" : 4066453
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Janet Hazelwood",
-      "Marianne Kehlau"
-    ],
-    [
-      "Laura Stryker",
-      "Regina Lemnitz"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Mrs. White",
-      "Brigitte Böttrich"
-    ],
-    [
-      "Mr. Collins",
-      "Daniel Eggers"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Janet Hazelwood",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Laura Stryker",
+      "sprecher" : "Regina Lemnitz"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Mrs. White",
+      "sprecher" : "Brigitte Böttrich"
+    },
+    {
+      "rolle" : "Mr. Collins",
+      "sprecher" : "Daniel Eggers"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/097/metadata.json",

--- a/web/data/Serie/098/metadata.json
+++ b/web/data/Serie/098/metadata.json
@@ -47,63 +47,64 @@
       "end" : 3772307
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ann Sullivan",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Mr. Martin",
-      "Christian Mey"
-    ],
-    [
-      "Mr. Caddy",
-      "Helmut Gentsch"
-    ],
-    [
-      "Kellnerin",
-      "Anna Carlsson"
-    ],
-    [
-      "Lady Day",
-      "Reinhilt Schneider"
-    ],
-    [
-      "Henry",
-      "Wilhelm Wieben"
-    ],
-    [
-      "Mann aus der Wüste",
-      "Wilhelm Hornbostel"
-    ],
-    [
-      "Miller",
-      "Lutz Mackensy"
-    ],
-    [
-      "Debby",
-      "Roswitha Benda"
-    ],
-    [
-      "Joe",
-      "Jakob Lichtblau [Eberhard Haar]"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ann Sullivan",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Mr. Martin",
+      "sprecher" : "Christian Mey"
+    },
+    {
+      "rolle" : "Mr. Caddy",
+      "sprecher" : "Helmut Gentsch"
+    },
+    {
+      "rolle" : "Kellnerin",
+      "sprecher" : "Anna Carlsson"
+    },
+    {
+      "rolle" : "Lady Day",
+      "sprecher" : "Reinhilt Schneider"
+    },
+    {
+      "rolle" : "Henry",
+      "sprecher" : "Wilhelm Wieben"
+    },
+    {
+      "rolle" : "Mann aus der Wüste",
+      "sprecher" : "Wilhelm Hornbostel"
+    },
+    {
+      "rolle" : "Miller",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Debby",
+      "sprecher" : "Roswitha Benda"
+    },
+    {
+      "rolle" : "Joe",
+      "sprecher" : "Fabian Harloff",
+      "pseudonym" : "Jakob Lichtblau"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/098/metadata.json",

--- a/web/data/Serie/099/metadata.json
+++ b/web/data/Serie/099/metadata.json
@@ -47,67 +47,67 @@
       "end" : 4573053
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Kevin Anderson",
-      "Thomas Bug"
-    ],
-    [
-      "Clarissa Franklin",
-      "Judy Winter"
-    ],
-    [
-      "Dr. Freeman",
-      "Jürgen Thormann"
-    ],
-    [
-      "Mrs. Brighton",
-      "Monika Werner"
-    ],
-    [
-      "Mrs. Wheel",
-      "Ines Sawatzki"
-    ],
-    [
-      "Schwester Whitney",
-      "Andrea Lange"
-    ],
-    [
-      "Besucher",
-      "Eckart Dux"
-    ],
-    [
-      "Bote",
-      "Stefan Rütter"
-    ],
-    [
-      "Goodween",
-      "André Minninger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Kevin Anderson",
+      "sprecher" : "Thomas Bug"
+    },
+    {
+      "rolle" : "Clarissa Franklin",
+      "sprecher" : "Judy Winter"
+    },
+    {
+      "rolle" : "Dr. Freeman",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Mrs. Brighton",
+      "sprecher" : "Monika Werner"
+    },
+    {
+      "rolle" : "Mrs. Wheel",
+      "sprecher" : "Ines Sawatzki"
+    },
+    {
+      "rolle" : "Schwester Whitney",
+      "sprecher" : "Andrea Lange"
+    },
+    {
+      "rolle" : "Besucher",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Bote",
+      "sprecher" : "Stefan Rüter"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/099/metadata.json",

--- a/web/data/Serie/100/1/metadata.json
+++ b/web/data/Serie/100/1/metadata.json
@@ -35,47 +35,47 @@
       "end" : 3204573
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Jelena",
-      "Alexandra Doerk"
-    ],
-    [
-      "Dr. Svenson",
-      "Antje Roosch"
-    ],
-    [
-      "Mr. Schwarz",
-      "Erik Schäffler"
-    ],
-    [
-      "Mr. Olin",
-      "Uli Krohm"
-    ],
-    [
-      "Juan",
-      "Oliver Böttcher"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Jelena Charkova",
+      "sprecher" : "Alexandra Doerk"
+    },
+    {
+      "rolle" : "Dr. Svenson",
+      "sprecher" : "Antje Roosch"
+    },
+    {
+      "rolle" : "Mr. Schwarz",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Mr. Olin",
+      "sprecher" : "Uli Krohm"
+    },
+    {
+      "rolle" : "Juan",
+      "sprecher" : "Oliver Böttcher"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/100/1/metadata.json",

--- a/web/data/Serie/100/2/metadata.json
+++ b/web/data/Serie/100/2/metadata.json
@@ -35,67 +35,67 @@
       "end" : 3376800
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Jelena",
-      "Alexandra Doerk"
-    ],
-    [
-      "Professor Phoenix",
-      "Wilfried Glatzeder"
-    ],
-    [
-      "Dr. Svenson",
-      "Antje Roosch"
-    ],
-    [
-      "Mr. Schwarz",
-      "Erik Schäffler"
-    ],
-    [
-      "Mr. Olin",
-      "Uli Krohm"
-    ],
-    [
-      "Juan",
-      "Oliver Böttcher"
-    ],
-    [
-      "Rachel Hadden",
-      "Anna Carlsson"
-    ],
-    [
-      "Al",
-      "Nico König"
-    ],
-    [
-      "Anne",
-      "Corinna Wodrich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Jelena Charkova",
+      "sprecher" : "Alexandra Doerk"
+    },
+    {
+      "rolle" : "Professor Phoenix",
+      "sprecher" : "Winfried Glatzeder"
+    },
+    {
+      "rolle" : "Dr. Svenson",
+      "sprecher" : "Antje Roosch"
+    },
+    {
+      "rolle" : "Mr. Schwarz",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Mr. Olin",
+      "sprecher" : "Uli Krohm"
+    },
+    {
+      "rolle" : "Juan",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Rachel Hadden",
+      "sprecher" : "Anna Carlsson"
+    },
+    {
+      "rolle" : "Al",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Anne",
+      "sprecher" : "Corinna Wodrich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/100/2/metadata.json",

--- a/web/data/Serie/100/3/metadata.json
+++ b/web/data/Serie/100/3/metadata.json
@@ -35,55 +35,55 @@
       "end" : 3410493
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jelena",
-      "Alexandra Doerk"
-    ],
-    [
-      "Professor Phoenix",
-      "Wilfried Glatzeder"
-    ],
-    [
-      "Dr. Svenson",
-      "Antje Roosch"
-    ],
-    [
-      "Mr. Schwarz",
-      "Erik Schäffler"
-    ],
-    [
-      "Mr. Olin",
-      "Uli Krohm"
-    ],
-    [
-      "Juan",
-      "Oliver Böttcher"
-    ],
-    [
-      "Al",
-      "Nico König"
-    ],
-    [
-      "Anne",
-      "Corinna Wodrich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jelena Charkova",
+      "sprecher" : "Alexandra Doerk"
+    },
+    {
+      "rolle" : "Professor Phoenix",
+      "sprecher" : "Winfried Glatzeder"
+    },
+    {
+      "rolle" : "Dr. Svenson",
+      "sprecher" : "Antje Roosch"
+    },
+    {
+      "rolle" : "Mr. Schwarz",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Mr. Olin",
+      "sprecher" : "Uli Krohm"
+    },
+    {
+      "rolle" : "Juan",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Al",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Anne",
+      "sprecher" : "Corinna Wodrich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/100/3/metadata.json",

--- a/web/data/Serie/100/metadata.json
+++ b/web/data/Serie/100/metadata.json
@@ -38,47 +38,47 @@
           "end" : 3204573
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Jelena",
-          "Alexandra Doerk"
-        ],
-        [
-          "Dr. Svenson",
-          "Antje Roosch"
-        ],
-        [
-          "Mr. Schwarz",
-          "Erik Schäffler"
-        ],
-        [
-          "Mr. Olin",
-          "Uli Krohm"
-        ],
-        [
-          "Juan",
-          "Oliver Böttcher"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Dr. Svenson",
+          "sprecher" : "Antje Roosch"
+        },
+        {
+          "rolle" : "Mr. Schwarz",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Mr. Olin",
+          "sprecher" : "Uli Krohm"
+        },
+        {
+          "rolle" : "Juan",
+          "sprecher" : "Oliver Böttcher"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/100/1/metadata.json",
@@ -123,67 +123,67 @@
           "end" : 3376800
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Jelena",
-          "Alexandra Doerk"
-        ],
-        [
-          "Professor Phoenix",
-          "Wilfried Glatzeder"
-        ],
-        [
-          "Dr. Svenson",
-          "Antje Roosch"
-        ],
-        [
-          "Mr. Schwarz",
-          "Erik Schäffler"
-        ],
-        [
-          "Mr. Olin",
-          "Uli Krohm"
-        ],
-        [
-          "Juan",
-          "Oliver Böttcher"
-        ],
-        [
-          "Rachel Hadden",
-          "Anna Carlsson"
-        ],
-        [
-          "Al",
-          "Nico König"
-        ],
-        [
-          "Anne",
-          "Corinna Wodrich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Professor Phoenix",
+          "sprecher" : "Winfried Glatzeder"
+        },
+        {
+          "rolle" : "Dr. Svenson",
+          "sprecher" : "Antje Roosch"
+        },
+        {
+          "rolle" : "Mr. Schwarz",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Mr. Olin",
+          "sprecher" : "Uli Krohm"
+        },
+        {
+          "rolle" : "Juan",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Rachel Hadden",
+          "sprecher" : "Anna Carlsson"
+        },
+        {
+          "rolle" : "Al",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Anne",
+          "sprecher" : "Corinna Wodrich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/100/2/metadata.json",
@@ -228,55 +228,55 @@
           "end" : 3410493
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Matthias Fuchs"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Jelena",
-          "Alexandra Doerk"
-        ],
-        [
-          "Professor Phoenix",
-          "Wilfried Glatzeder"
-        ],
-        [
-          "Dr. Svenson",
-          "Antje Roosch"
-        ],
-        [
-          "Mr. Schwarz",
-          "Erik Schäffler"
-        ],
-        [
-          "Mr. Olin",
-          "Uli Krohm"
-        ],
-        [
-          "Juan",
-          "Oliver Böttcher"
-        ],
-        [
-          "Al",
-          "Nico König"
-        ],
-        [
-          "Anne",
-          "Corinna Wodrich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Matthias Fuchs"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Jelena Charkova",
+          "sprecher" : "Alexandra Doerk"
+        },
+        {
+          "rolle" : "Professor Phoenix",
+          "sprecher" : "Winfried Glatzeder"
+        },
+        {
+          "rolle" : "Dr. Svenson",
+          "sprecher" : "Antje Roosch"
+        },
+        {
+          "rolle" : "Mr. Schwarz",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Mr. Olin",
+          "sprecher" : "Uli Krohm"
+        },
+        {
+          "rolle" : "Juan",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Al",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "Anne",
+          "sprecher" : "Corinna Wodrich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/100/3/metadata.json",
@@ -290,67 +290,67 @@
   "hörspielskriptautor" : "André Minninger",
   "beschreibung" : "Die drei ??? übernehmen ihren 100sten Fall Fall! In drei spannenden Folgen sind sie dem Geheimnis der Toteninsel auf der Spur.\nEine große Herausforderung für die Detektive. Weswegen sie gut beraten sind, die Hilfe alter Wegbegleiter anzunehmen, um Das Rätsel der Sphinx (Teil 1) zu lösen. Doch plötzlich ist Peter verschwunden und auch Das vergessene Volk (Teil 2) kann Justus und Bob bei ihrer Suche nicht weiterhelfen. Erst Der Fluch der Gräber (Teil 3) führt die drei ??? auf eine heiße Spur.",
   "veröffentlichungsdatum" : "2001-10-15",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Jelena",
-      "Alexandra Doerk"
-    ],
-    [
-      "Dr. Svenson",
-      "Antje Roosch"
-    ],
-    [
-      "Mr. Schwarz",
-      "Erik Schäffler"
-    ],
-    [
-      "Mr. Olin",
-      "Uli Krohm"
-    ],
-    [
-      "Juan",
-      "Oliver Böttcher"
-    ],
-    [
-      "Professor Phoenix",
-      "Wilfried Glatzeder"
-    ],
-    [
-      "Rachel Hadden",
-      "Anna Carlsson"
-    ],
-    [
-      "Al",
-      "Nico König"
-    ],
-    [
-      "Anne",
-      "Corinna Wodrich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Jelena Charkova",
+      "sprecher" : "Alexandra Doerk"
+    },
+    {
+      "rolle" : "Dr. Svenson",
+      "sprecher" : "Antje Roosch"
+    },
+    {
+      "rolle" : "Mr. Schwarz",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Mr. Olin",
+      "sprecher" : "Uli Krohm"
+    },
+    {
+      "rolle" : "Juan",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Professor Phoenix",
+      "sprecher" : "Winfried Glatzeder"
+    },
+    {
+      "rolle" : "Rachel Hadden",
+      "sprecher" : "Anna Carlsson"
+    },
+    {
+      "rolle" : "Al",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Anne",
+      "sprecher" : "Corinna Wodrich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/100/metadata.json",

--- a/web/data/Serie/101/metadata.json
+++ b/web/data/Serie/101/metadata.json
@@ -47,55 +47,55 @@
       "end" : 4313453
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Giorgio Cade",
-      "Bastian Pastewka"
-    ],
-    [
-      "Monique Carrera",
-      "Amanda Lear"
-    ],
-    [
-      "Mrs. Jones",
-      "Marianne Kehlau"
-    ],
-    [
-      "Jenny Collins",
-      "Anja Topf"
-    ],
-    [
-      "Jeremy Scott",
-      "Woody Mues"
-    ],
-    [
-      "Mrs. Scott",
-      "Hansi Jochmann"
-    ],
-    [
-      "Oma Scott",
-      "Apollonia Minniger"
-    ],
-    [
-      "Acer",
-      "Thomas Schüler"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Giorgio Cade",
+      "sprecher" : "Bastian Pastewka"
+    },
+    {
+      "rolle" : "Monique Carrera",
+      "sprecher" : "Amanda Lear"
+    },
+    {
+      "rolle" : "Mrs. Jones",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Jenny Collins",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "Jeremy Scott",
+      "sprecher" : "Woody Mues"
+    },
+    {
+      "rolle" : "Mrs. Scott",
+      "sprecher" : "Hansi Jochmann"
+    },
+    {
+      "rolle" : "Oma Scott",
+      "sprecher" : "Apollonia Jepsen"
+    },
+    {
+      "rolle" : "Acer",
+      "sprecher" : "Thomas Schüler"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/101/metadata.json",

--- a/web/data/Serie/102/metadata.json
+++ b/web/data/Serie/102/metadata.json
@@ -47,43 +47,43 @@
       "end" : 3560680
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "King",
-      "Wolfgang Condrus"
-    ],
-    [
-      "Jenny Collins",
-      "Anja Topf"
-    ],
-    [
-      "Tricia Wilson",
-      "Ursula Vogel"
-    ],
-    [
-      "Goodween",
-      "André Minninger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "King",
+      "sprecher" : "Wolfgang Condrus"
+    },
+    {
+      "rolle" : "Jenny Collins",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "Tricia Wilson",
+      "sprecher" : "Ursula Vogel"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/102/metadata.json",

--- a/web/data/Serie/103/metadata.json
+++ b/web/data/Serie/103/metadata.json
@@ -47,51 +47,52 @@
       "end" : 3810187
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Matthias Fuchs"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Brittany",
-      "Dorette Hugo"
-    ],
-    [
-      "Victor Hugenay",
-      "Albert Giro [Wolfgang Kubach]"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Wilbur Graham",
-      "Thomas Bammer"
-    ],
-    [
-      "Bruder Raphael",
-      "Siegfried Kernen"
-    ],
-    [
-      "Inspektor Berger",
-      "Jan Buchwald"
-    ],
-    [
-      "Baldwin",
-      "Gerhart Hinze"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Matthias Fuchs"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Brittany",
+      "sprecher" : "Dorette Hugo"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Albert Giro"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Wilbur Graham",
+      "sprecher" : "Thomas Bammer"
+    },
+    {
+      "rolle" : "Bruder Raphael",
+      "sprecher" : "Siegfried W. Kernen"
+    },
+    {
+      "rolle" : "Inspektor Berger",
+      "sprecher" : "Jan Buchwald"
+    },
+    {
+      "rolle" : "Baldwin",
+      "sprecher" : "Gerhart Hinze"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/103/metadata.json",

--- a/web/data/Serie/104/metadata.json
+++ b/web/data/Serie/104/metadata.json
@@ -47,51 +47,51 @@
       "end" : 4138120
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Dick Perry",
-      "Ernst Hilbich"
-    ],
-    [
-      "Mrs. Meg Baker",
-      "Lotti Krekel"
-    ],
-    [
-      "Mrs. Wood",
-      "Elga Schütz"
-    ],
-    [
-      "Jack Sharky",
-      "Stefan Babic"
-    ],
-    [
-      "Betty Shutton",
-      "Regina Pressler"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Dick Perry",
+      "sprecher" : "Ernst H. Hilbich"
+    },
+    {
+      "rolle" : "Mrs. Meg Baker",
+      "sprecher" : "Lotti Krekel"
+    },
+    {
+      "rolle" : "Mrs. Wood",
+      "sprecher" : "Elga Schütz"
+    },
+    {
+      "rolle" : "Jack Sharky",
+      "sprecher" : "Stefan Babic"
+    },
+    {
+      "rolle" : "Betty Shutton",
+      "sprecher" : "Regina Pressler"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/104/metadata.json",

--- a/web/data/Serie/105/metadata.json
+++ b/web/data/Serie/105/metadata.json
@@ -47,47 +47,47 @@
       "end" : 4545293
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Joanna Masterson",
-      "Barbara Marcks"
-    ],
-    [
-      "Jack Masterson",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Sarah Masterson",
-      "Nadja Reichardt"
-    ],
-    [
-      "Mr Harry Falkner",
-      "Wolfgang Hartmann"
-    ],
-    [
-      "Harvey Ashford",
-      "Rolf E. Schenker"
-    ],
-    [
-      "Marc",
-      "Hartmut Kollakowski"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Joanna Masterson",
+      "sprecher" : "Barbara Marcks"
+    },
+    {
+      "rolle" : "Jack Masterson",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Sarah Masterson",
+      "sprecher" : "Nadja Reichardt"
+    },
+    {
+      "rolle" : "Mr. Harry Falkner",
+      "sprecher" : "Wolfgang Hartmann"
+    },
+    {
+      "rolle" : "Harvey Ashford",
+      "sprecher" : "Rolf E. Schenker"
+    },
+    {
+      "rolle" : "Marc",
+      "sprecher" : "Hartmut Kollakowsky"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/105/metadata.json",

--- a/web/data/Serie/106/metadata.json
+++ b/web/data/Serie/106/metadata.json
@@ -47,75 +47,77 @@
       "end" : 4255213
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Amy Scream",
-      "Marianne Kehlau"
-    ],
-    [
-      "Monique Carrera",
-      "Amanda Lear"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Ellen",
-      "Celine Fontanges"
-    ],
-    [
-      "Pam",
-      "Enie van de Meiklokjes"
-    ],
-    [
-      "Jim Cowley",
-      "Cäsar"
-    ],
-    [
-      "Jeffrey",
-      "Kim Alexander Frank"
-    ],
-    [
-      "Mandy Robin",
-      "Manuela Dahm"
-    ],
-    [
-      "1. Sanitäter",
-      "Robert Missler"
-    ],
-    [
-      "2. Sanitäter",
-      "Hartmut Kollakowsky"
-    ],
-    [
-      "Bardame",
-      "Monique Carrera [Amanda Lear]"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Diskothekenbesucher",
-      "Echt"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Amy Scream",
+      "sprecher" : "Marianne Kehlau"
+    },
+    {
+      "rolle" : "Monique Carrera",
+      "sprecher" : "Amanda Lear"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Ellen",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Pam",
+      "sprecher" : "Enie van de Meiklokjes"
+    },
+    {
+      "rolle" : "Jim Cowley",
+      "sprecher" : "Marcus Kaiser",
+      "pseudonym" : "Cäsar"
+    },
+    {
+      "rolle" : "Jeffrey",
+      "sprecher" : "Kim Frank"
+    },
+    {
+      "rolle" : "Mandy Robin",
+      "sprecher" : "Manuela Dahm"
+    },
+    {
+      "rolle" : "Sanitäter 1",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Sanitäter 2",
+      "sprecher" : "Hartmut Kollakowsky"
+    },
+    {
+      "rolle" : "Bardame",
+      "sprecher" : "Amanda Lear",
+      "pseudonym" : "Monique Carrera"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Diskothekenbesucher",
+      "sprecher" : "Echt"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/106/metadata.json",

--- a/web/data/Serie/107/metadata.json
+++ b/web/data/Serie/107/metadata.json
@@ -47,55 +47,55 @@
       "end" : 3850840
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Lama Geshe",
-      "Rolf Nagel"
-    ],
-    [
-      "Tai Sutsi",
-      "Dr. Boo Young-Shin"
-    ],
-    [
-      "Chuck",
-      "Yan Kimsang"
-    ],
-    [
-      "Vinaya",
-      "Prof. Dr. Zhu"
-    ],
-    [
-      "Mr Zhang",
-      "Ingo Feder"
-    ],
-    [
-      "Lesley Dimple",
-      "Maja Stehli [Ingeborg Kantstein ?]"
-    ],
-    [
-      "Mrs. Wilbur",
-      "Ingeburg Kanstein"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Lama Geshe",
+      "sprecher" : "Rolf Nagel"
+    },
+    {
+      "rolle" : "Tai Sutsi",
+      "sprecher" : "Dr. Boo Young-Shin"
+    },
+    {
+      "rolle" : "Chuck",
+      "sprecher" : "Yan Kimsang"
+    },
+    {
+      "rolle" : "Vinaya",
+      "sprecher" : "Prof. Dr. Zhu"
+    },
+    {
+      "rolle" : "Mr. Zhang",
+      "sprecher" : "Ingo Feder"
+    },
+    {
+      "rolle" : "Lesley Dimple",
+      "sprecher" : "Ann Montenbruck"
+    },
+    {
+      "rolle" : "Mrs. Wilbur",
+      "sprecher" : "Ingeburg Kanstein"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/107/metadata.json",

--- a/web/data/Serie/108/metadata.json
+++ b/web/data/Serie/108/metadata.json
@@ -52,39 +52,39 @@
       "end" : 4004480
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Caspar Carter",
-      "Claus Wilcke"
-    ],
-    [
-      "Enid",
-      "Janina Richter"
-    ],
-    [
-      "Albert",
-      "Wolf Rathjen"
-    ],
-    [
-      "Montgomery",
-      "Hans Sievers"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Caspar Carter",
+      "sprecher" : "Claus Wilcke"
+    },
+    {
+      "rolle" : "Enid",
+      "sprecher" : "Janina Richter"
+    },
+    {
+      "rolle" : "Albert",
+      "sprecher" : "Wolf Rahtjen"
+    },
+    {
+      "rolle" : "Montgomery",
+      "sprecher" : "Hans Sievers"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/108/metadata.json",

--- a/web/data/Serie/109/metadata.json
+++ b/web/data/Serie/109/metadata.json
@@ -47,59 +47,59 @@
       "end" : 4027533
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Nick Nobel",
-      "Ilja Richter"
-    ],
-    [
-      "Sandy",
-      "Micaela Kreissler"
-    ],
-    [
-      "Bill",
-      "Achim Schülke"
-    ],
-    [
-      "Mike Pherson",
-      "Wolf-Dietrich Berg"
-    ],
-    [
-      "Assistent",
-      "Martin Meyer"
-    ],
-    [
-      "Clarissa",
-      "Theresa Underberg"
-    ],
-    [
-      "Veronica",
-      "Saskia Weckler"
-    ],
-    [
-      "Joe",
-      "Jan-David Rönfeldt"
-    ],
-    [
-      "Sekretärin",
-      "Traudel Sperber"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Nick Nobel",
+      "sprecher" : "Ilja Richter"
+    },
+    {
+      "rolle" : "Sandy",
+      "sprecher" : "Micaëla Kreißler"
+    },
+    {
+      "rolle" : "Bill",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Mike Pherson",
+      "sprecher" : "Wolf-Dietrich Berg"
+    },
+    {
+      "rolle" : "Assistent",
+      "sprecher" : "Martin Meyer"
+    },
+    {
+      "rolle" : "Clarissa",
+      "sprecher" : "Theresa Underberg"
+    },
+    {
+      "rolle" : "Veronica",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Joe",
+      "sprecher" : "Jan-David Rönfeldt"
+    },
+    {
+      "rolle" : "Sekretärin",
+      "sprecher" : "Traudel Sperber"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/109/metadata.json",

--- a/web/data/Serie/110/metadata.json
+++ b/web/data/Serie/110/metadata.json
@@ -47,63 +47,63 @@
       "end" : 3310573
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Pablo",
-      "Kai Hendrik Möller"
-    ],
-    [
-      "Dr. Brolin",
-      "Karl-Friedrich Gerster"
-    ],
-    [
-      "Jenkins",
-      "Gustav-Adolph Artz"
-    ],
-    [
-      "Professor Clark",
-      "Thor W. Müller"
-    ],
-    [
-      "Bürgermeister Hoover",
-      "Michael Griem"
-    ],
-    [
-      "Margie",
-      "Susanne Leu"
-    ],
-    [
-      "Mike",
-      "Achim Schülke"
-    ],
-    [
-      "Clark",
-      "Wolf Rathjen"
-    ],
-    [
-      "Wachmann",
-      "Kristian Kretschmer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Pablo",
+      "sprecher" : "Kai Henrik Möller"
+    },
+    {
+      "rolle" : "Dr. Brolin",
+      "sprecher" : "Karl-Friedrich Gerster"
+    },
+    {
+      "rolle" : "Jenkins",
+      "sprecher" : "Gustav-Adolph Artz"
+    },
+    {
+      "rolle" : "Professor Clark",
+      "sprecher" : "Thor W. Müller"
+    },
+    {
+      "rolle" : "Bürgermeister Hoover",
+      "sprecher" : "Michael Griem"
+    },
+    {
+      "rolle" : "Margie",
+      "sprecher" : "Susanna Leu"
+    },
+    {
+      "rolle" : "Mike",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Clark",
+      "sprecher" : "Wolf Rahtjen"
+    },
+    {
+      "rolle" : "Wachmann",
+      "sprecher" : "Kristian Kretschmer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/110/metadata.json",

--- a/web/data/Serie/111/metadata.json
+++ b/web/data/Serie/111/metadata.json
@@ -77,71 +77,71 @@
       "end" : 3906600
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Maggie Jones",
-      "Ulrike Johannson"
-    ],
-    [
-      "Lythia Waterstone",
-      "Barbara Focke"
-    ],
-    [
-      "Elisabeth Waterstone",
-      "Linde Fulde"
-    ],
-    [
-      "John Stanley",
-      "Kai Böger"
-    ],
-    [
-      "Jack Donelly",
-      "Andreas Mattau"
-    ],
-    [
-      "Althena",
-      "Michaela Boland"
-    ],
-    [
-      "Corona",
-      "Stefanie Kirchberger"
-    ],
-    [
-      "Fahrer Ken",
-      "Wolf Frass"
-    ],
-    [
-      "John Fairbanks",
-      "Christian Rudolf"
-    ],
-    [
-      "Hal Fairbanks",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Walt",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Blackeye",
-      "Georg Marquard"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Maggie Jones",
+      "sprecher" : "Ulrike Johannson"
+    },
+    {
+      "rolle" : "Lythia Waterstone",
+      "sprecher" : "Barbara Focke"
+    },
+    {
+      "rolle" : "Elisabeth Waterstone",
+      "sprecher" : "Linde Fulda"
+    },
+    {
+      "rolle" : "John Stanley",
+      "sprecher" : "Kai Böger"
+    },
+    {
+      "rolle" : "Jack Donelly",
+      "sprecher" : "Andreas Mattau"
+    },
+    {
+      "rolle" : "Althena",
+      "sprecher" : "Michaela Boland"
+    },
+    {
+      "rolle" : "Corona",
+      "sprecher" : "Stephanie Damare"
+    },
+    {
+      "rolle" : "Fahrer Ken",
+      "sprecher" : "Wolf Frass"
+    },
+    {
+      "rolle" : "John Fairbanks",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Hal Fairbanks",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Walt",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Blackeye",
+      "sprecher" : "Georg Marquard"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/111/metadata.json",

--- a/web/data/Serie/112/metadata.json
+++ b/web/data/Serie/112/metadata.json
@@ -72,47 +72,47 @@
       "end" : 3529667
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Donovan",
-      "Joachim Richert"
-    ],
-    [
-      "Pit",
-      "Wolfgang Wagner"
-    ],
-    [
-      "Max",
-      "Johannes Rothenstein"
-    ],
-    [
-      "Cowboy",
-      "Christian Niehues"
-    ],
-    [
-      "Creeklong",
-      "Nobi Schatka"
-    ],
-    [
-      "Brad Fleming",
-      "Dennis Jensen"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Donovan",
+      "sprecher" : "Joachim Richert"
+    },
+    {
+      "rolle" : "Pit",
+      "sprecher" : "Wolfgang Wagner"
+    },
+    {
+      "rolle" : "Max",
+      "sprecher" : "Johannes Rothenstein"
+    },
+    {
+      "rolle" : "Cowboy",
+      "sprecher" : "Christian Niehues"
+    },
+    {
+      "rolle" : "Creeklong",
+      "sprecher" : "Nobi Schatka"
+    },
+    {
+      "rolle" : "Brad Fleming",
+      "sprecher" : "Dennis Jensen"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/112/metadata.json",

--- a/web/data/Serie/113/metadata.json
+++ b/web/data/Serie/113/metadata.json
@@ -77,47 +77,47 @@
       "end" : 3607400
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Emily",
-      "Madeleine Weingart"
-    ],
-    [
-      "Mrs Silverstone",
-      "Katrin Wasow"
-    ],
-    [
-      "Dr. Wakefield",
-      "Hans Daniel"
-    ],
-    [
-      "Alruna",
-      "Gisela Trowe"
-    ],
-    [
-      "Marcus Lake",
-      "Thomas Karallus"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Emily",
+      "sprecher" : "Madeleine Weingart"
+    },
+    {
+      "rolle" : "Mrs. Silverstone",
+      "sprecher" : "Katrin Wasow"
+    },
+    {
+      "rolle" : "Dr. Wakefield",
+      "sprecher" : "Hans Daniel"
+    },
+    {
+      "rolle" : "Alruna",
+      "sprecher" : "Gisela Trowe"
+    },
+    {
+      "rolle" : "Marcus Lake",
+      "sprecher" : "Thomas Karallus"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/113/metadata.json",

--- a/web/data/Serie/114/metadata.json
+++ b/web/data/Serie/114/metadata.json
@@ -67,51 +67,51 @@
       "end" : 4150480
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Bernadette O'Donnell",
-      "Eva Maria Bauer"
-    ],
-    [
-      "Cecilia Jones",
-      "Hanni Vanhaiden"
-    ],
-    [
-      "Elouise Adams",
-      "Hannelore Wüst"
-    ],
-    [
-      "Mrs Willow",
-      "Elga Schütz"
-    ],
-    [
-      "Möbelpacker",
-      "Christian Niehues"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Bernadette O'Donnell",
+      "sprecher" : "Eva Maria Bauer"
+    },
+    {
+      "rolle" : "Cecilia Jones",
+      "sprecher" : "Hanni Vanhaiden"
+    },
+    {
+      "rolle" : "Elouise Adams",
+      "sprecher" : "Hannelore Wüst"
+    },
+    {
+      "rolle" : "Mrs. Willow",
+      "sprecher" : "Elga Schütz"
+    },
+    {
+      "rolle" : "Möbelpacker",
+      "sprecher" : "Christian Niehues"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/114/metadata.json",

--- a/web/data/Serie/115/metadata.json
+++ b/web/data/Serie/115/metadata.json
@@ -82,63 +82,64 @@
       "end" : 4200627
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Escovedo",
-      "Ignacio Descalzo"
-    ],
-    [
-      "Anita Caballero",
-      "Isabell Navarro"
-    ],
-    [
-      "Lesley Dimple",
-      "Rica Blunck"
-    ],
-    [
-      "Regina Pearson",
-      "Ingeborg Kallweit"
-    ],
-    [
-      "Mr Horowitz",
-      "Rolf Jülich"
-    ],
-    [
-      "Mr Rothman",
-      "Peter Weis"
-    ],
-    [
-      "Mrs O'Rien",
-      "Victoria von Trautmannsdorff"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Escovedo",
+      "sprecher" : "Ignacio Descalzo"
+    },
+    {
+      "rolle" : "Anita Caballero",
+      "sprecher" : "Isabel Navarro"
+    },
+    {
+      "rolle" : "Lesley Dimple",
+      "sprecher" : "Rica Blunck"
+    },
+    {
+      "rolle" : "Regina Pearson",
+      "sprecher" : "Ingeborg Kallweit"
+    },
+    {
+      "rolle" : "Mr. Horowitz",
+      "sprecher" : "Rolf Jülich"
+    },
+    {
+      "rolle" : "Mr. Rothman",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Mrs. O'Rien",
+      "sprecher" : "Victoria Trauttmansdorff"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/115/metadata.json",

--- a/web/data/Serie/116/metadata.json
+++ b/web/data/Serie/116/metadata.json
@@ -52,51 +52,51 @@
       "end" : 3724893
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mr. Applegate",
-      "Stephan Benson"
-    ],
-    [
-      "Julia Applegate",
-      "Sophie Lechtenbrink"
-    ],
-    [
-      "Teddy Applegate",
-      "Jona Mues"
-    ],
-    [
-      "Rafter",
-      "Volker Bogdan"
-    ],
-    [
-      "Archie",
-      "Bertram Hiese"
-    ],
-    [
-      "Jenny Collins",
-      "Anja Topf"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mr. Applegate",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Julia Applegate",
+      "sprecher" : "Sophie Lechtenbrink"
+    },
+    {
+      "rolle" : "Teddy Applegate",
+      "sprecher" : "Jona Mues"
+    },
+    {
+      "rolle" : "Rafter",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "Archie",
+      "sprecher" : "Bertram Hiese"
+    },
+    {
+      "rolle" : "Jenny Collins",
+      "sprecher" : "Anja Topf"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/116/metadata.json",

--- a/web/data/Serie/117/metadata.json
+++ b/web/data/Serie/117/metadata.json
@@ -62,59 +62,60 @@
       "end" : 3640027
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Godwin",
-      "André Minninger"
-    ],
-    [
-      "Wagner",
-      "Jürgen Thormann"
-    ],
-    [
-      "Beaumont",
-      "Douglas Welbat"
-    ],
-    [
-      "Calhoon",
-      "Bernd Stephan"
-    ],
-    [
-      "Mike",
-      "Arndt Schmöle"
-    ],
-    [
-      "Zia",
-      "Brigitte Böttrich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Wagner",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Beaumont",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Calhoon",
+      "sprecher" : "Bernd Stephan"
+    },
+    {
+      "rolle" : "Mike",
+      "sprecher" : "Arndt Schmöle"
+    },
+    {
+      "rolle" : "Zia",
+      "sprecher" : "Brigitte Böttrich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/117/metadata.json",

--- a/web/data/Serie/118/metadata.json
+++ b/web/data/Serie/118/metadata.json
@@ -72,67 +72,67 @@
       "end" : 3996413
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Ralph",
-      "Jan-David Rönnfeldt"
-    ],
-    [
-      "Robbie",
-      "Manfred Reddemann"
-    ],
-    [
-      "Jack",
-      "Daniel Brühl"
-    ],
-    [
-      "Dennis",
-      "Stefan Brönneke"
-    ],
-    [
-      "Gina",
-      "Chiara Ferraú"
-    ],
-    [
-      "Charly",
-      "Aaron Lee Ullmer"
-    ],
-    [
-      "Sheriff",
-      "Harry Rowohlt"
-    ],
-    [
-      "Turnbull",
-      "Detlef Bierstedt"
-    ],
-    [
-      "Jenny Collins",
-      "Anja Topf"
-    ],
-    [
-      "Dizzy",
-      "Marion Klaus"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Ralph",
+      "sprecher" : "Jan-David Rönfeldt"
+    },
+    {
+      "rolle" : "Robbie",
+      "sprecher" : "Manfred Reddemann"
+    },
+    {
+      "rolle" : "Jack",
+      "sprecher" : "Daniel Brühl"
+    },
+    {
+      "rolle" : "Dennis",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Gina",
+      "sprecher" : "Chiara Ferraú"
+    },
+    {
+      "rolle" : "Charly",
+      "sprecher" : "Aaron Lee Ullmer"
+    },
+    {
+      "rolle" : "Sheriff",
+      "sprecher" : "Harry Rowohlt"
+    },
+    {
+      "rolle" : "Turnbull",
+      "sprecher" : "Detlef Bierstedt"
+    },
+    {
+      "rolle" : "Jenny Collins",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "Dizzy",
+      "sprecher" : "Marion Klaus"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/118/metadata.json",

--- a/web/data/Serie/119/metadata.json
+++ b/web/data/Serie/119/metadata.json
@@ -77,59 +77,60 @@
       "end" : 4063440
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Caitlin Kopperschmidt",
-      "Marion Martienzen"
-    ],
-    [
-      "Jeremy Kopperschmidt",
-      "Lutz Herkenrath"
-    ],
-    [
-      "Graig Kopperschmidt",
-      "Mario Grete"
-    ],
-    [
-      "George",
-      "Hendrik König"
-    ],
-    [
-      "Anthony Quinn",
-      "Franz-Joseph Steffens"
-    ],
-    [
-      "Martha",
-      "Sabine Falkenberg"
-    ],
-    [
-      "Felix Kopperschmidt",
-      "Herrmann Otto"
-    ],
-    [
-      "Mann",
-      "Frank Felicetti"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Caitlin Kopperschmidt",
+      "sprecher" : "Marion Martienzen"
+    },
+    {
+      "rolle" : "Jeremy Kopperschmidt",
+      "sprecher" : "Lutz Herkenrath"
+    },
+    {
+      "rolle" : "Graig Kopperschmidt",
+      "sprecher" : "Mario Grete"
+    },
+    {
+      "rolle" : "George",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Anthony Quinn",
+      "sprecher" : "Franz-Josef Steffens"
+    },
+    {
+      "rolle" : "Martha",
+      "sprecher" : "Sabine Falkenberg"
+    },
+    {
+      "rolle" : "Felix Kopperschmidt",
+      "sprecher" : "Hermann Otto"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Frank Felicetti"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/119/metadata.json",

--- a/web/data/Serie/120/metadata.json
+++ b/web/data/Serie/120/metadata.json
@@ -62,43 +62,43 @@
       "end" : 3528253
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ken Parker, Beachball-Spieler",
-      "Jürgen Holdorf"
-    ],
-    [
-      "Dr. Robinson",
-      "Heinz Lieven"
-    ],
-    [
-      "Mickey McQuire",
-      "Marco Sand"
-    ],
-    [
-      "Mrs Bancroft",
-      "Ilka Kirsch"
-    ],
-    [
-      "Zuschauer",
-      "Alexander Mülle"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ken Parker, Beachball-Spieler",
+      "sprecher" : "Jürgen Holdorf"
+    },
+    {
+      "rolle" : "Dr. Robinson",
+      "sprecher" : "Heinz Lieven"
+    },
+    {
+      "rolle" : "Mickey McQuire",
+      "sprecher" : "Marco Sand"
+    },
+    {
+      "rolle" : "Mrs. Bancroft",
+      "sprecher" : "Ilka Kirsch"
+    },
+    {
+      "rolle" : "Zuschauer",
+      "sprecher" : "Alexander Müller"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/120/metadata.json",

--- a/web/data/Serie/121/metadata.json
+++ b/web/data/Serie/121/metadata.json
@@ -72,55 +72,55 @@
       "end" : 3762347
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Shawn",
-      "Robin Brosch"
-    ],
-    [
-      "Jolene",
-      "Marion Elskis"
-    ],
-    [
-      "Leah",
-      "Susanne Sternberg"
-    ],
-    [
-      "Jelena",
-      "Alexandra Doerk"
-    ],
-    [
-      "Sue",
-      "Kerstin Hilbig"
-    ],
-    [
-      "Kimberly Lloyd",
-      "Ingeborg Christiansen"
-    ],
-    [
-      "William Boyd",
-      "Olaf Kreuzenbeck"
-    ],
-    [
-      "Thorndike",
-      "Michael Lott"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Shawn",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Jolene",
+      "sprecher" : "Marion Elskis"
+    },
+    {
+      "rolle" : "Leah",
+      "sprecher" : "Susanne Sternberg"
+    },
+    {
+      "rolle" : "Jelena Charkova",
+      "sprecher" : "Alexandra Doerk"
+    },
+    {
+      "rolle" : "Sue",
+      "sprecher" : "Kerstin Hilbig"
+    },
+    {
+      "rolle" : "Kimberly Lloyd",
+      "sprecher" : "Ingeborg Christiansen"
+    },
+    {
+      "rolle" : "William Boyd",
+      "sprecher" : "Olaf Kreutzenbeck"
+    },
+    {
+      "rolle" : "Thorndike",
+      "sprecher" : "Michael Lott"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/121/metadata.json",

--- a/web/data/Serie/122/metadata.json
+++ b/web/data/Serie/122/metadata.json
@@ -52,59 +52,59 @@
       "end" : 3494760
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Fred Jenkins",
-      "Nick Seidensticker"
-    ],
-    [
-      "Mr Campbell",
-      "Gerhart Hinze"
-    ],
-    [
-      "Sam Reilly",
-      "Jürgen Strube"
-    ],
-    [
-      "Carl Sheehan",
-      "Michael Weckler"
-    ],
-    [
-      "Collins",
-      "Thorsten Weber"
-    ],
-    [
-      "Mr Kingsley",
-      "Herbert Tennigkeit"
-    ],
-    [
-      "Mrs Kingsley",
-      "Tina Rehfeld-Wildmann"
-    ],
-    [
-      "Devlin Reno",
-      "Jörg Pleva"
-    ],
-    [
-      "Dr. Long",
-      "Lou Wong"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Fred Jenkins",
+      "sprecher" : "Nick Seidensticker"
+    },
+    {
+      "rolle" : "Mr. Campbell",
+      "sprecher" : "Gerhart Hinze"
+    },
+    {
+      "rolle" : "Sam Reilly",
+      "sprecher" : "Jürgen Strube"
+    },
+    {
+      "rolle" : "Carl Sheehan",
+      "sprecher" : "Michael Weckler"
+    },
+    {
+      "rolle" : "Collins",
+      "sprecher" : "Thorsten Weber"
+    },
+    {
+      "rolle" : "Mr. Kingsley",
+      "sprecher" : "Herbert Tennigkeit"
+    },
+    {
+      "rolle" : "Mrs. Kingsley",
+      "sprecher" : "Tina Rehfeld-Wildmann"
+    },
+    {
+      "rolle" : "Devlin Reno",
+      "sprecher" : "Jörg Pleva"
+    },
+    {
+      "rolle" : "Dr. Long",
+      "sprecher" : "Lou Wong"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/122/metadata.json",

--- a/web/data/Serie/123/metadata.json
+++ b/web/data/Serie/123/metadata.json
@@ -62,43 +62,43 @@
       "end" : 3677213
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Emiliano",
-      "Tobias Schmidt"
-    ],
-    [
-      "Pancho",
-      "Ben Hecker"
-    ],
-    [
-      "Esperanza",
-      "Ingeborg Christiansen"
-    ],
-    [
-      "Pedro",
-      "Anton Sprick"
-    ],
-    [
-      "Abelardo",
-      "Peter Brix"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Emiliano",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Pancho",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Esperanza",
+      "sprecher" : "Ingeborg Christiansen"
+    },
+    {
+      "rolle" : "Pedro",
+      "sprecher" : "Anton Sprick"
+    },
+    {
+      "rolle" : "Abelardo",
+      "sprecher" : "Peter Heinrich Brix"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/123/metadata.json",

--- a/web/data/Serie/124/metadata.json
+++ b/web/data/Serie/124/metadata.json
@@ -82,43 +82,43 @@
       "end" : 3990920
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. O'Sullivan",
-      "Eckard Dux"
-    ],
-    [
-      "Butler Paul",
-      "Volker Bogdan"
-    ],
-    [
-      "Dick Perry",
-      "Ernst Hilbich"
-    ],
-    [
-      "Polizist",
-      "Frank Thannhäuser"
-    ],
-    [
-      "Aufsicht",
-      "Patrick Bach"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. O'Sullivan",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Butler Paul",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "Dick Perry",
+      "sprecher" : "Ernst H. Hilbich"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Frank Thannhäuser"
+    },
+    {
+      "rolle" : "Aufsicht",
+      "sprecher" : "Patrick Bach"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/124/metadata.json",

--- a/web/data/Serie/125/1/metadata.json
+++ b/web/data/Serie/125/1/metadata.json
@@ -65,55 +65,56 @@
       "end" : 4488347
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Brittany",
-      "Dorette Hugo"
-    ],
-    [
-      "Hugenay",
-      "Albert Giro"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Jaccard (Off-Stimme)",
-      "Douglas Welbat"
-    ],
-    [
-      "Andy Miller",
-      "Jannik Endemann"
-    ],
-    [
-      "Sharon Lockwood",
-      "Nova Meierhenrich"
-    ],
-    [
-      "Moderator",
-      "Holger Wemhoff"
-    ],
-    [
-      "Rubbish George",
-      "Utz Richter"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Brittany",
+      "sprecher" : "Dorette Hugo"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Albert Giro"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Jaccard (Off-Stimme)",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Andy Miller",
+      "sprecher" : "Jannik Endemann"
+    },
+    {
+      "rolle" : "Sharon Lockwood",
+      "sprecher" : "Nova Meierhenrich"
+    },
+    {
+      "rolle" : "Moderator",
+      "sprecher" : "Holger Wemhoff"
+    },
+    {
+      "rolle" : "Rubbish George",
+      "sprecher" : "Utz Richter"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/125/1/metadata.json",

--- a/web/data/Serie/125/2/metadata.json
+++ b/web/data/Serie/125/2/metadata.json
@@ -75,75 +75,77 @@
       "end" : 4166213
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Brittany",
-      "Dorette Hugo"
-    ],
-    [
-      "Hugenay",
-      "Albert Giro"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Graham, Reporter",
-      "Thomas Bammer"
-    ],
-    [
-      "Julianne Wallace",
-      "Marlen Diekhoff"
-    ],
-    [
-      "Sharon Lockwood",
-      "Nova Meierhenrich"
-    ],
-    [
-      "Moderator",
-      "Holger Wemhoff"
-    ],
-    [
-      "Polizist 1",
-      "Fabian Harloff"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Mrs. Albright",
-      "Lotti Krekel"
-    ],
-    [
-      "Mr. Myers",
-      "Eberhard Haar"
-    ],
-    [
-      "LKW-Fahrer",
-      "Nick Heidfeld"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Brittany",
+      "sprecher" : "Dorette Hugo"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Albert Giro"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Graham, Reporter",
+      "sprecher" : "Thomas Bammer"
+    },
+    {
+      "rolle" : "Julianne Wallace",
+      "sprecher" : "Marlen Diekhoff"
+    },
+    {
+      "rolle" : "Sharon Lockwood",
+      "sprecher" : "Nova Meierhenrich"
+    },
+    {
+      "rolle" : "Moderator",
+      "sprecher" : "Holger Wemhoff"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Fabian Harloff"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Mrs. Albright",
+      "sprecher" : "Lotti Krekel"
+    },
+    {
+      "rolle" : "Mr. Myers",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "LKW-Fahrer",
+      "sprecher" : "Nick Heidfeld"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/125/2/metadata.json",

--- a/web/data/Serie/125/3/metadata.json
+++ b/web/data/Serie/125/3/metadata.json
@@ -85,75 +85,77 @@
       "end" : 4464547
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Brittany",
-      "Dorette Hugo"
-    ],
-    [
-      "Hugenay",
-      "Albert Giro"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Julianne Wallace",
-      "Marlen Diekhoff"
-    ],
-    [
-      "Charles Knox",
-      "Dirk Bach"
-    ],
-    [
-      "Moderator",
-      "Holger Wemhoff"
-    ],
-    [
-      "Polizist 2",
-      "Erik Schäffler"
-    ],
-    [
-      "Ansager",
-      "Bertram Hiese"
-    ],
-    [
-      "Mr. Myers",
-      "Eberhard Haar"
-    ],
-    [
-      "Nachtschatten",
-      "Frank Tannhäuser"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Mr. Baker",
-      "Wolf Pahls"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Brittany",
+      "sprecher" : "Dorette Hugo"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Albert Giro"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Julianne Wallace",
+      "sprecher" : "Marlen Diekhoff"
+    },
+    {
+      "rolle" : "Charles Knox",
+      "sprecher" : "Dirk Bach"
+    },
+    {
+      "rolle" : "Moderator",
+      "sprecher" : "Holger Wemhoff"
+    },
+    {
+      "rolle" : "Polizist 2",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Ansager",
+      "sprecher" : "Bertram Hiese"
+    },
+    {
+      "rolle" : "Mr. Myers",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Nachtschatten",
+      "sprecher" : "Frank Thannhäuser"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Mr. Baker",
+      "sprecher" : "Wolf Pahlke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/125/3/metadata.json",

--- a/web/data/Serie/125/metadata.json
+++ b/web/data/Serie/125/metadata.json
@@ -68,55 +68,56 @@
           "end" : 4488347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brittany",
-          "Dorette Hugo"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Jaccard (Off-Stimme)",
-          "Douglas Welbat"
-        ],
-        [
-          "Andy Miller",
-          "Jannik Endemann"
-        ],
-        [
-          "Sharon Lockwood",
-          "Nova Meierhenrich"
-        ],
-        [
-          "Moderator",
-          "Holger Wemhoff"
-        ],
-        [
-          "Rubbish George",
-          "Utz Richter"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brittany",
+          "sprecher" : "Dorette Hugo"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Jaccard (Off-Stimme)",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Andy Miller",
+          "sprecher" : "Jannik Endemann"
+        },
+        {
+          "rolle" : "Sharon Lockwood",
+          "sprecher" : "Nova Meierhenrich"
+        },
+        {
+          "rolle" : "Moderator",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Rubbish George",
+          "sprecher" : "Utz Richter"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/125/1/metadata.json",
@@ -201,75 +202,77 @@
           "end" : 4166213
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brittany",
-          "Dorette Hugo"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Graham, Reporter",
-          "Thomas Bammer"
-        ],
-        [
-          "Julianne Wallace",
-          "Marlen Diekhoff"
-        ],
-        [
-          "Sharon Lockwood",
-          "Nova Meierhenrich"
-        ],
-        [
-          "Moderator",
-          "Holger Wemhoff"
-        ],
-        [
-          "Polizist 1",
-          "Fabian Harloff"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mrs. Albright",
-          "Lotti Krekel"
-        ],
-        [
-          "Mr. Myers",
-          "Eberhard Haar"
-        ],
-        [
-          "LKW-Fahrer",
-          "Nick Heidfeld"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brittany",
+          "sprecher" : "Dorette Hugo"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Graham, Reporter",
+          "sprecher" : "Thomas Bammer"
+        },
+        {
+          "rolle" : "Julianne Wallace",
+          "sprecher" : "Marlen Diekhoff"
+        },
+        {
+          "rolle" : "Sharon Lockwood",
+          "sprecher" : "Nova Meierhenrich"
+        },
+        {
+          "rolle" : "Moderator",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mrs. Albright",
+          "sprecher" : "Lotti Krekel"
+        },
+        {
+          "rolle" : "Mr. Myers",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "LKW-Fahrer",
+          "sprecher" : "Nick Heidfeld"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/125/2/metadata.json",
@@ -364,75 +367,77 @@
           "end" : 4464547
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Brittany",
-          "Dorette Hugo"
-        ],
-        [
-          "Hugenay",
-          "Albert Giro"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Julianne Wallace",
-          "Marlen Diekhoff"
-        ],
-        [
-          "Charles Knox",
-          "Dirk Bach"
-        ],
-        [
-          "Moderator",
-          "Holger Wemhoff"
-        ],
-        [
-          "Polizist 2",
-          "Erik Schäffler"
-        ],
-        [
-          "Ansager",
-          "Bertram Hiese"
-        ],
-        [
-          "Mr. Myers",
-          "Eberhard Haar"
-        ],
-        [
-          "Nachtschatten",
-          "Frank Tannhäuser"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Mr. Baker",
-          "Wolf Pahls"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Brittany",
+          "sprecher" : "Dorette Hugo"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach",
+          "pseudonym" : "Albert Giro"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Julianne Wallace",
+          "sprecher" : "Marlen Diekhoff"
+        },
+        {
+          "rolle" : "Charles Knox",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "Moderator",
+          "sprecher" : "Holger Wemhoff"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Ansager",
+          "sprecher" : "Bertram Hiese"
+        },
+        {
+          "rolle" : "Mr. Myers",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Nachtschatten",
+          "sprecher" : "Frank Thannhäuser"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Baker",
+          "sprecher" : "Wolf Pahlke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/125/3/metadata.json",
@@ -446,111 +451,113 @@
   "hörspielskriptautor" : "André Minninger",
   "beschreibung" : "Rätselhafte Briefe eines verstorbenen Malers bringen die drei ??? auf die Spur eines verschollenes Gemäldes … Und der Gegenspieler der Detektive aus Rocky Beach ist kein Geringerer als der französische Meisterdieb Victor Hugenay! Wem wird es gelingen, Feuermond zu finden und das in dem Gemälde verborgene große Geheimnis zu lüften?",
   "veröffentlichungsdatum" : "2008-10-10",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Andy Miller",
-      "Jannik Endemann"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Ansager",
-      "Bertram Hiese"
-    ],
-    [
-      "Graham, Reporter",
-      "Thomas Bammer"
-    ],
-    [
-      "Julianne Wallace",
-      "Marlen Diekhoff"
-    ],
-    [
-      "Hugenay",
-      "Albert Giro"
-    ],
-    [
-      "Moderator",
-      "Holger Wemhoff"
-    ],
-    [
-      "Charles Knox",
-      "Dirk Bach"
-    ],
-    [
-      "Mr. Myers",
-      "Eberhard Haar"
-    ],
-    [
-      "Nachtschatten",
-      "Frank Tannhäuser"
-    ],
-    [
-      "Brittany",
-      "Dorette Hugo"
-    ],
-    [
-      "Sharon Lockwood",
-      "Nova Meierhenrich"
-    ],
-    [
-      "Mrs. Albright",
-      "Lotti Krekel"
-    ],
-    [
-      "Jaccard (Off-Stimme)",
-      "Douglas Welbat"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Polizist 1",
-      "Fabian Harloff"
-    ],
-    [
-      "Polizist 2",
-      "Erik Schäffler"
-    ],
-    [
-      "LKW-Fahrer",
-      "Nick Heidfeld"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Rubbish George",
-      "Utz Richter"
-    ],
-    [
-      "Mr. Baker",
-      "Wolf Pahls"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Andy Miller",
+      "sprecher" : "Jannik Endemann"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Ansager",
+      "sprecher" : "Bertram Hiese"
+    },
+    {
+      "rolle" : "Graham, Reporter",
+      "sprecher" : "Thomas Bammer"
+    },
+    {
+      "rolle" : "Julianne Wallace",
+      "sprecher" : "Marlen Diekhoff"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Wolfgang Kubach",
+      "pseudonym" : "Albert Giro"
+    },
+    {
+      "rolle" : "Moderator",
+      "sprecher" : "Holger Wemhoff"
+    },
+    {
+      "rolle" : "Charles Knox",
+      "sprecher" : "Dirk Bach"
+    },
+    {
+      "rolle" : "Mr. Myers",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Nachtschatten",
+      "sprecher" : "Frank Thannhäuser"
+    },
+    {
+      "rolle" : "Brittany",
+      "sprecher" : "Dorette Hugo"
+    },
+    {
+      "rolle" : "Sharon Lockwood",
+      "sprecher" : "Nova Meierhenrich"
+    },
+    {
+      "rolle" : "Mrs. Albright",
+      "sprecher" : "Lotti Krekel"
+    },
+    {
+      "rolle" : "Jaccard (Off-Stimme)",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Fabian Harloff"
+    },
+    {
+      "rolle" : "Polizist 2",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "LKW-Fahrer",
+      "sprecher" : "Nick Heidfeld"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Rubbish George",
+      "sprecher" : "Utz Richter"
+    },
+    {
+      "rolle" : "Mr. Baker",
+      "sprecher" : "Wolf Pahlke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/125/metadata.json",

--- a/web/data/Serie/126/metadata.json
+++ b/web/data/Serie/126/metadata.json
@@ -62,51 +62,51 @@
       "end" : 3992933
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Dr. Chandler",
-      "Wolf Pahlke"
-    ],
-    [
-      "Max",
-      "Sven Dahlem"
-    ],
-    [
-      "Austin",
-      "Patrick Bach"
-    ],
-    [
-      "Dwain",
-      "Tim Knauer"
-    ],
-    [
-      "Mr. Monroe",
-      "Jochen Regelin"
-    ],
-    [
-      "Professor Rosenberg",
-      "Lothar Grützner"
-    ],
-    [
-      "Papagei",
-      "Heikedine Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Dr. Chandler",
+      "sprecher" : "Wolf Pahlke"
+    },
+    {
+      "rolle" : "Max",
+      "sprecher" : "Sven Dahlem"
+    },
+    {
+      "rolle" : "Austin",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Dwain",
+      "sprecher" : "Tim Knauer"
+    },
+    {
+      "rolle" : "Mr. Monroe",
+      "sprecher" : "Joachim Regelien"
+    },
+    {
+      "rolle" : "Professor Rosenberg",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/126/metadata.json",

--- a/web/data/Serie/127/metadata.json
+++ b/web/data/Serie/127/metadata.json
@@ -67,63 +67,63 @@
       "end" : 4390653
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Goodween",
-      "André Minninger"
-    ],
-    [
-      "José",
-      "Patrick Bach"
-    ],
-    [
-      "Steve Bright",
-      "Marek Erhardt"
-    ],
-    [
-      "Brian Smith",
-      "Christian Rode"
-    ],
-    [
-      "Martin",
-      "Jesse Grimm"
-    ],
-    [
-      "Wächter",
-      "Sven Dahlem"
-    ],
-    [
-      "Mrs. Osborne",
-      "Anja Nejarri"
-    ],
-    [
-      "Mr. Pentecost",
-      "Wolf Frass"
-    ],
-    [
-      "Senora Gonzalez",
-      "Susanne von Loessl"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "José",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Steve Bright",
+      "sprecher" : "Marek Erhardt"
+    },
+    {
+      "rolle" : "Brian Smith",
+      "sprecher" : "Christian Rode"
+    },
+    {
+      "rolle" : "Martin",
+      "sprecher" : "Jesse Grimm"
+    },
+    {
+      "rolle" : "Wächter",
+      "sprecher" : "Sven Dahlem"
+    },
+    {
+      "rolle" : "Mrs. Osborne",
+      "sprecher" : "Anja Nejarri"
+    },
+    {
+      "rolle" : "Mr. Pentecost",
+      "sprecher" : "Wolf Frass"
+    },
+    {
+      "rolle" : "Senora Gonzalez",
+      "sprecher" : "Susanne von Loessl"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/127/metadata.json",

--- a/web/data/Serie/128/metadata.json
+++ b/web/data/Serie/128/metadata.json
@@ -67,51 +67,51 @@
       "end" : 4412907
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs Bennett",
-      "Renate Pichler"
-    ],
-    [
-      "Wächter",
-      "Marek Erhardt"
-    ],
-    [
-      "Crowle",
-      "Christian Rudolf"
-    ],
-    [
-      "Casey Wye",
-      "Gisela Trowe"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Oliver Taper",
-      "Gosta Liptow"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Bennett",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Wächter",
+      "sprecher" : "Marek Erhardt"
+    },
+    {
+      "rolle" : "Crowle",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Casey Wye",
+      "sprecher" : "Gisela Trowe"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Oliver Taper",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/128/metadata.json",

--- a/web/data/Serie/129/metadata.json
+++ b/web/data/Serie/129/metadata.json
@@ -92,79 +92,79 @@
       "end" : 4734387
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Layla",
-      "Saskia Weckler"
-    ],
-    [
-      "Alaa Edine",
-      "Robert Missler"
-    ],
-    [
-      "Abazza",
-      "Abdul Kader-Diab"
-    ],
-    [
-      "Kamelhändler",
-      "Wolf Frass"
-    ],
-    [
-      "Kamelführer",
-      "Fathi Farnazmatis"
-    ],
-    [
-      "Wärter",
-      "Gosta Liptow"
-    ],
-    [
-      "Ägypter",
-      "Lothar Grützner"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Rubbish George",
-      "Utz Richter"
-    ],
-    [
-      "Kommissar",
-      "Klaus Dittmann"
-    ],
-    [
-      "Aisha",
-      "Susanne von Loessl"
-    ],
-    [
-      "Verkäufer",
-      "Farhat Al Yhi"
-    ],
-    [
-      "Dick Vincent",
-      "Holger Löwenberg"
-    ],
-    [
-      "Taxifahrer",
-      "Wolf Pahlke"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Layla",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Alaa Edine",
+      "sprecher" : "Abdul Kader-Diab"
+    },
+    {
+      "rolle" : "Abazza",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Kamelhändler",
+      "sprecher" : "Wolf Frass"
+    },
+    {
+      "rolle" : "Kamelführer",
+      "sprecher" : "Fathi Farnazmatis"
+    },
+    {
+      "rolle" : "Wärter",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Ägypter",
+      "sprecher" : "Lothar Grützner"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Rubbish George",
+      "sprecher" : "Utz Richter"
+    },
+    {
+      "rolle" : "Kommissar",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Aisha",
+      "sprecher" : "Susanne von Loessl"
+    },
+    {
+      "rolle" : "Verkäufer",
+      "sprecher" : "Farhat Al Yhi"
+    },
+    {
+      "rolle" : "Dick Vincent",
+      "sprecher" : "Holger Löwenberg"
+    },
+    {
+      "rolle" : "Taxifahrer",
+      "sprecher" : "Wolf Pahlke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/129/metadata.json",

--- a/web/data/Serie/130/metadata.json
+++ b/web/data/Serie/130/metadata.json
@@ -87,63 +87,64 @@
       "end" : 4112560
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Beverly Leung",
-      "Susanne Stangl"
-    ],
-    [
-      "Thomas Johnson",
-      "Lutz Herkenrath"
-    ],
-    [
-      "1. Polizist",
-      "Robert Missler"
-    ],
-    [
-      "2. Polizist",
-      "Edgar Hoppe"
-    ],
-    [
-      "James",
-      "Sönke Städtler"
-    ],
-    [
-      "Daniel Baker",
-      "Sascha Rotermund"
-    ],
-    [
-      "Mr. Grogan",
-      "Günter Flesch"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Beverly Leung",
+      "sprecher" : "Susanne Stangl"
+    },
+    {
+      "rolle" : "Thomas Johnson",
+      "sprecher" : "Lutz Herkenrath"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Polizist 2",
+      "sprecher" : "Edgar Hoppe"
+    },
+    {
+      "rolle" : "James",
+      "sprecher" : "Sönke Städtler"
+    },
+    {
+      "rolle" : "Daniel Baker",
+      "sprecher" : "Sascha Rotermund"
+    },
+    {
+      "rolle" : "Mr. Grogan",
+      "sprecher" : "Günther Flesch"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/130/metadata.json",

--- a/web/data/Serie/131/metadata.json
+++ b/web/data/Serie/131/metadata.json
@@ -52,59 +52,59 @@
       "end" : 4242960
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Lloyd Scavenger",
-      "Stefan Benson"
-    ],
-    [
-      "Jack Lowell",
-      "Siegfried Kernen"
-    ],
-    [
-      "Alexander Nolan",
-      "Wilfried Hochholdinger"
-    ],
-    [
-      "Jaqueline Williams",
-      "Henrike Fehrs"
-    ],
-    [
-      "Ian Parsley",
-      "Jörg Gillner"
-    ],
-    [
-      "Mary Parsley",
-      "Karin Abicht"
-    ],
-    [
-      "Jasper Kittle",
-      "Peter Weis"
-    ],
-    [
-      "Shawne Davison",
-      "Susanne Lothar"
-    ],
-    [
-      "Officer Wood",
-      "Roman Kretschmer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Lloyd Scavenger",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Jack Lowell",
+      "sprecher" : "Siegfried W. Kernen"
+    },
+    {
+      "rolle" : "Alexander Nolan",
+      "sprecher" : "Wilfried Hochholdinger"
+    },
+    {
+      "rolle" : "Jaqueline Williams",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Ian Parsley",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Mary Parsley",
+      "sprecher" : "Carin Abicht"
+    },
+    {
+      "rolle" : "Jasper Kittle",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Shawne Davison",
+      "sprecher" : "Susanne Lothar"
+    },
+    {
+      "rolle" : "Officer Wood",
+      "sprecher" : "Roman Kretschmer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/131/metadata.json",

--- a/web/data/Serie/132/metadata.json
+++ b/web/data/Serie/132/metadata.json
@@ -52,71 +52,71 @@
       "end" : 3799387
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Miss Bennett",
-      "Renate Pichler"
-    ],
-    [
-      "Karen",
-      "Celine Fontange"
-    ],
-    [
-      "Becky",
-      "Katharina v. Keller"
-    ],
-    [
-      "Felicia Sparing",
-      "Rhea Harder"
-    ],
-    [
-      "Mrs. Amelia Sparing",
-      "Karin Buchholz"
-    ],
-    [
-      "Mr. Sparing",
-      "Sky du Mont"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Professor Alkurah",
-      "Ben Hecker"
-    ],
-    [
-      "Eroll",
-      "Bertram Hiese"
-    ],
-    [
-      "Mrs. Featherstone",
-      "Sabine Hahn"
-    ],
-    [
-      "Wärter",
-      "Jürgen Holdorf"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Miss Bennett",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Karen",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Becky",
+      "sprecher" : "Katharina von Keller"
+    },
+    {
+      "rolle" : "Felicia Sparing",
+      "sprecher" : "Rhea Harder-Vennewald"
+    },
+    {
+      "rolle" : "Mrs. Amelia Sparing",
+      "sprecher" : "Karin Buchholz"
+    },
+    {
+      "rolle" : "Mr. Sparing",
+      "sprecher" : "Sky du Mont"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Professor Alkurah",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Eroll",
+      "sprecher" : "Bertram Hiese"
+    },
+    {
+      "rolle" : "Mrs. Featherstone",
+      "sprecher" : "Sabine Hahn"
+    },
+    {
+      "rolle" : "Wärter",
+      "sprecher" : "Jürgen Holdorf"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/132/metadata.json",

--- a/web/data/Serie/133/metadata.json
+++ b/web/data/Serie/133/metadata.json
@@ -52,59 +52,59 @@
       "end" : 3473893
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Sergeant Ludlow",
-      "Dietmar Mues"
-    ],
-    [
-      "Banden-Chef",
-      "Eberhard Haar"
-    ],
-    [
-      "Eddy Reardon",
-      "Lukas Sperber"
-    ],
-    [
-      "Spanier",
-      "Erik Schäffler"
-    ],
-    [
-      "Jack",
-      "Fabian Harloff"
-    ],
-    [
-      "Italiener",
-      "Lutz Harder"
-    ],
-    [
-      "Gauner",
-      "Sven Dahlem"
-    ],
-    [
-      "Gehilfe",
-      "Gerhart Hinze"
-    ],
-    [
-      "Polizist",
-      "Bertram Hiese"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Sergeant Ludlow",
+      "sprecher" : "Dietmar Mues"
+    },
+    {
+      "rolle" : "Banden-Chef",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Eddy Reardon",
+      "sprecher" : "Lukas T. Sperber"
+    },
+    {
+      "rolle" : "Spanier",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Jack",
+      "sprecher" : "Fabian Harloff"
+    },
+    {
+      "rolle" : "Italiener",
+      "sprecher" : "Lutz Harder"
+    },
+    {
+      "rolle" : "Gauner",
+      "sprecher" : "Sven Dahlem"
+    },
+    {
+      "rolle" : "Gehilfe",
+      "sprecher" : "Gerhart Hinze"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Bertram Hiese"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/133/metadata.json",

--- a/web/data/Serie/134/metadata.json
+++ b/web/data/Serie/134/metadata.json
@@ -72,51 +72,51 @@
       "end" : 4029587
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Christine",
-      "Inken Sommer"
-    ],
-    [
-      "Mr. Bambridge",
-      "Gustav-Adolph Artz"
-    ],
-    [
-      "Lo Wang",
-      "Dae Joon Yoo"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Anthony Hearst",
-      "Wolfgang Pampel"
-    ],
-    [
-      "Truck-Fahrer",
-      "Konstantin Graudus"
-    ],
-    [
-      "Avercromby",
-      "Nicolas König"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Christine",
+      "sprecher" : "Inken Sommer"
+    },
+    {
+      "rolle" : "Mr. Bambridge",
+      "sprecher" : "Gustav-Adolph Artz"
+    },
+    {
+      "rolle" : "Lo Wang",
+      "sprecher" : "Dae Joon Yoo"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Anthony Hearst",
+      "sprecher" : "Wolfgang Pampel"
+    },
+    {
+      "rolle" : "Truck-Fahrer",
+      "sprecher" : "Konstantin Graudus"
+    },
+    {
+      "rolle" : "Avercromby",
+      "sprecher" : "Nicolas König"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/134/metadata.json",

--- a/web/data/Serie/135/metadata.json
+++ b/web/data/Serie/135/metadata.json
@@ -92,47 +92,47 @@
       "end" : 4271013
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Pilot",
-      "Gerhart Hinze"
-    ],
-    [
-      "Max",
-      "Traudel Sperber"
-    ],
-    [
-      "Liolotta",
-      "Peter Striebeck"
-    ],
-    [
-      "Althena",
-      "Steffi Kirchberger"
-    ],
-    [
-      "Sarah Livingston",
-      "Rosemarie Wohlbauer"
-    ],
-    [
-      "Elvira Zuckerman",
-      "Konstanze Ullmer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Pilot",
+      "sprecher" : "Gerhart Hinze"
+    },
+    {
+      "rolle" : "Max",
+      "sprecher" : "Traudel Sperber"
+    },
+    {
+      "rolle" : "Liolotta",
+      "sprecher" : "Peter Striebeck"
+    },
+    {
+      "rolle" : "Althena",
+      "sprecher" : "Stephanie Damare"
+    },
+    {
+      "rolle" : "Sarah Livingston",
+      "sprecher" : "Rosemarie Wohlbauer"
+    },
+    {
+      "rolle" : "Elvira Zuckerman",
+      "sprecher" : "Konstanze Ullmer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/135/metadata.json",

--- a/web/data/Serie/136/metadata.json
+++ b/web/data/Serie/136/metadata.json
@@ -72,63 +72,63 @@
       "end" : 4117027
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Darren Duff",
-      "Jesse Grimm"
-    ],
-    [
-      "Taucher Carl",
-      "Oliver Böttcher"
-    ],
-    [
-      "Taucherin Joan",
-      "Christine Pappert"
-    ],
-    [
-      "Paul Brooks",
-      "Heinz Lieven"
-    ],
-    [
-      "Joe Wilcox",
-      "Rolf Becker"
-    ],
-    [
-      "Cassandra Wilcox",
-      "Elke Reissert"
-    ],
-    [
-      "Daniel",
-      "Jochen Baumert"
-    ],
-    [
-      "Henry",
-      "Frank Felicetti"
-    ],
-    [
-      "Doktor Holloway",
-      "Barbara Focke"
-    ],
-    [
-      "Cedric Duff",
-      "Rolf E. Schenker"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Darren Duff",
+      "sprecher" : "Jesse Grimm"
+    },
+    {
+      "rolle" : "Taucher Carl",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Taucherin Joan",
+      "sprecher" : "Christine Pappert"
+    },
+    {
+      "rolle" : "Paul Brooks",
+      "sprecher" : "Heinz Lieven"
+    },
+    {
+      "rolle" : "Joe Wilcox",
+      "sprecher" : "Rolf Becker"
+    },
+    {
+      "rolle" : "Cassandra Wilcox",
+      "sprecher" : "Elke Reissert"
+    },
+    {
+      "rolle" : "Daniel",
+      "sprecher" : "Jochen Baumert"
+    },
+    {
+      "rolle" : "Henry",
+      "sprecher" : "Frank Felicetti"
+    },
+    {
+      "rolle" : "Doktor Holloway",
+      "sprecher" : "Barbara Focke"
+    },
+    {
+      "rolle" : "Cedric Duff",
+      "sprecher" : "Rolf E. Schenker"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/136/metadata.json",

--- a/web/data/Serie/137/metadata.json
+++ b/web/data/Serie/137/metadata.json
@@ -72,47 +72,47 @@
       "end" : 4653507
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Winston Granville",
-      "Christian Rode"
-    ],
-    [
-      "Matthew Granville",
-      "Uwe Friedrichsen"
-    ],
-    [
-      "Smithy",
-      "Konstantin Graudus"
-    ],
-    [
-      "Mr. Jackmore",
-      "Michael Brennicke"
-    ],
-    [
-      "Professor Frazier",
-      "Wilhelm Wieben"
-    ],
-    [
-      "Polizist",
-      "Tetje Mierendorf"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Winston Granville",
+      "sprecher" : "Christian Rode"
+    },
+    {
+      "rolle" : "Matthew Granville",
+      "sprecher" : "Uwe Friedrichsen"
+    },
+    {
+      "rolle" : "Smithy",
+      "sprecher" : "Konstantin Graudus"
+    },
+    {
+      "rolle" : "Mr. Jackmore",
+      "sprecher" : "Michael Brennicke"
+    },
+    {
+      "rolle" : "Professor Frazier",
+      "sprecher" : "Wilhelm Wieben"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Tetje Mierendorf"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/137/metadata.json",

--- a/web/data/Serie/138/metadata.json
+++ b/web/data/Serie/138/metadata.json
@@ -72,39 +72,39 @@
       "end" : 3987133
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Davy Swann",
-      "Thorsten Sense"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Craig Holden",
-      "Gerhard Olschewski"
-    ],
-    [
-      "Löwenritter",
-      "Burghart Klaußner"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Davy Swann",
+      "sprecher" : "Torsten Sense"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Craig Holden",
+      "sprecher" : "Gerhard Olschewski"
+    },
+    {
+      "rolle" : "Löwenritter",
+      "sprecher" : "Burghart Klaußner"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/138/metadata.json",

--- a/web/data/Serie/139/metadata.json
+++ b/web/data/Serie/139/metadata.json
@@ -67,79 +67,80 @@
       "end" : 3860747
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Helena Darraz",
-      "Ingrid Andree"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Pritchard",
-      "Sascha Rotermund"
-    ],
-    [
-      "Sid",
-      "Tilman Madaus"
-    ],
-    [
-      "Caroline",
-      "Celine Fontanges"
-    ],
-    [
-      "Sandy",
-      "Simona Pahl"
-    ],
-    [
-      "Steven",
-      "René Dawn-Claude"
-    ],
-    [
-      "Ernest",
-      "Tim Kreuer"
-    ],
-    [
-      "Radioansagerin",
-      "Susanne Wulkow"
-    ],
-    [
-      "Harvey Griscom",
-      "Christian Rudolf"
-    ],
-    [
-      "John Dellcourt",
-      "Gustav Adolph Artz"
-    ],
-    [
-      "Miss Darraz",
-      "Sabine Hahn"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Helena Darraz",
+      "sprecher" : "Ingrid Andree"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Pritchard",
+      "sprecher" : "Sascha Rotermund"
+    },
+    {
+      "rolle" : "Sid",
+      "sprecher" : "Tilman Madaus"
+    },
+    {
+      "rolle" : "Caroline",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Sandy",
+      "sprecher" : "Simona Pahl"
+    },
+    {
+      "rolle" : "Steven",
+      "sprecher" : "René Dawn-Claude"
+    },
+    {
+      "rolle" : "Ernest",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Radioansagerin",
+      "sprecher" : "Susanne Wulkow"
+    },
+    {
+      "rolle" : "Harvey Griscom",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "John Dellcourt",
+      "sprecher" : "Gustav Adolph Artz"
+    },
+    {
+      "rolle" : "Miss Darraz",
+      "sprecher" : "Sabine Hahn"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/139/metadata.json",

--- a/web/data/Serie/140/metadata.json
+++ b/web/data/Serie/140/metadata.json
@@ -62,59 +62,59 @@
       "end" : 4658533
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Josy McDonaghough",
-      "Lili Draeger"
-    ],
-    [
-      "Homer Diesel",
-      "Christian Senger"
-    ],
-    [
-      "Mary Stamper",
-      "Annabelle Krieg"
-    ],
-    [
-      "Otis Stamper",
-      "Klaus Dittman"
-    ],
-    [
-      "Jonathan Black",
-      "Eckart Dux"
-    ],
-    [
-      "Miles Black",
-      "Sascha Rotermund"
-    ],
-    [
-      "Klara Kowalski",
-      "Steffi Kirchberger"
-    ],
-    [
-      "Silvester Proud",
-      "Gustav A. Artz"
-    ],
-    [
-      "Pfarrer Clark",
-      "Gerd Baltus"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Josy McDonaghough",
+      "sprecher" : "Lili Draeger"
+    },
+    {
+      "rolle" : "Homer Diesel",
+      "sprecher" : "Christian Senger"
+    },
+    {
+      "rolle" : "Mary Stamper",
+      "sprecher" : "Annabelle Krieg"
+    },
+    {
+      "rolle" : "Otis Stamper",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Jonathan Black",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Miles Black",
+      "sprecher" : "Sascha Rotermund"
+    },
+    {
+      "rolle" : "Klara Kowalski",
+      "sprecher" : "Stephanie Damare"
+    },
+    {
+      "rolle" : "Silvester Proud",
+      "sprecher" : "Gustav Adolph Artz"
+    },
+    {
+      "rolle" : "Pfarrer Clark",
+      "sprecher" : "Gerd Baltus"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/140/metadata.json",

--- a/web/data/Serie/141/metadata.json
+++ b/web/data/Serie/141/metadata.json
@@ -72,71 +72,72 @@
       "end" : 3562347
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Jeffrey Seaman",
-      "Daniel Welbat"
-    ],
-    [
-      "Steven",
-      "Oliver Böttcher"
-    ],
-    [
-      "Eric",
-      "Patrick Bach"
-    ],
-    [
-      "Mr. Settler",
-      "Christian Senger"
-    ],
-    [
-      "Auktionator",
-      "Achim Schülke"
-    ],
-    [
-      "Frau",
-      "Hilla Fitzen"
-    ],
-    [
-      "Patrick O'Brian",
-      "Wolfgang Riehm"
-    ],
-    [
-      "William de Haas",
-      "Jörg Gillner"
-    ],
-    [
-      "Theodor Brewster",
-      "Tobias Meister"
-    ],
-    [
-      "Butler",
-      "Olaf Kreuzenbeck"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Jeffrey Seaman",
+      "sprecher" : "Daniel Welbat"
+    },
+    {
+      "rolle" : "Steven",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Eric",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Mr. Settler",
+      "sprecher" : "Christian Senger"
+    },
+    {
+      "rolle" : "Auktionator",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Frau",
+      "sprecher" : "Hilla Fitzen"
+    },
+    {
+      "rolle" : "Patrick O'Brian",
+      "sprecher" : "Wolfgang Riehm"
+    },
+    {
+      "rolle" : "William de Haas",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Theodor Brewster",
+      "sprecher" : "Tobias Meister"
+    },
+    {
+      "rolle" : "Butler",
+      "sprecher" : "Olaf Kreutzenbeck"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/141/metadata.json",

--- a/web/data/Serie/142/metadata.json
+++ b/web/data/Serie/142/metadata.json
@@ -72,79 +72,79 @@
       "end" : 3437227
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Carol Ford",
-      "Claudia Schermutzki"
-    ],
-    [
-      "Francis Studstill",
-      "Elena Wilms"
-    ],
-    [
-      "Baxter Norsworthy",
-      "Udo Schenk"
-    ],
-    [
-      "Gordon Hoke",
-      "Holger Löwenberg"
-    ],
-    [
-      "Jared Fox",
-      "Meik Spallek"
-    ],
-    [
-      "Candace Duskin",
-      "Andrea Linau"
-    ],
-    [
-      "George Bennet",
-      "Urs Affolter"
-    ],
-    [
-      "Greg Harper",
-      "Robert Missler"
-    ],
-    [
-      "Woodland",
-      "Jürgen Thormann"
-    ],
-    [
-      "Reporterin",
-      "Jamie Leaves"
-    ],
-    [
-      "Reporter",
-      "Glenn Goltz"
-    ],
-    [
-      "Wellford",
-      "Oliver Geilhardt"
-    ],
-    [
-      "Pilot",
-      "Achim Schülke"
-    ],
-    [
-      "Lautsprecherstimme",
-      "Sascha Draeger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Carol Ford",
+      "sprecher" : "Claudia Schermutzki"
+    },
+    {
+      "rolle" : "Francis Studstill",
+      "sprecher" : "Elena Wilms"
+    },
+    {
+      "rolle" : "Baxter Norsworthy",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Gordon Hoke",
+      "sprecher" : "Holger Löwenberg"
+    },
+    {
+      "rolle" : "Jared Fox",
+      "sprecher" : "Meik Spallek"
+    },
+    {
+      "rolle" : "Candace Duskin",
+      "sprecher" : "Andrea Lienau"
+    },
+    {
+      "rolle" : "George Bennet",
+      "sprecher" : "Urs Affolter"
+    },
+    {
+      "rolle" : "Greg Harper",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Woodland",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Reporterin",
+      "sprecher" : "Jamie Leaves"
+    },
+    {
+      "rolle" : "Reporter",
+      "sprecher" : "Glenn Goltz"
+    },
+    {
+      "rolle" : "Wellford",
+      "sprecher" : "Oliver Geilhardt"
+    },
+    {
+      "rolle" : "Pilot",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Lautsprecherstimme",
+      "sprecher" : "Sascha Draeger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/142/metadata.json",

--- a/web/data/Serie/143/metadata.json
+++ b/web/data/Serie/143/metadata.json
@@ -62,55 +62,55 @@
       "end" : 3621920
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Richie Hanson",
-      "Dennis Schmidt-Foß"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Goodween",
-      "André Minninger"
-    ],
-    [
-      "Benni",
-      "Ivo Möller"
-    ],
-    [
-      "Jacki Jin",
-      "Robert Missler"
-    ],
-    [
-      "Kellnerin",
-      "Corinna Wodrich"
-    ],
-    [
-      "Croupier",
-      "Dirk Bach"
-    ],
-    [
-      "Mann",
-      "Arndt Schmöle"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Richie Hanson",
+      "sprecher" : "Dennis Schmidt-Foß"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Benni",
+      "sprecher" : "Ivo Möller"
+    },
+    {
+      "rolle" : "Jacki Jin",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Kellnerin",
+      "sprecher" : "Corinna Wodrich"
+    },
+    {
+      "rolle" : "Croupier",
+      "sprecher" : "Dirk Bach"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Arndt Schmöle"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/143/metadata.json",

--- a/web/data/Serie/144/metadata.json
+++ b/web/data/Serie/144/metadata.json
@@ -72,55 +72,56 @@
       "end" : 4256000
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Arthur Sinclair",
-      "Joachim Pukaß"
-    ],
-    [
-      "Mr. Peastone",
-      "Eberhard Haar"
-    ],
-    [
-      "Jeremy Witherspoon",
-      "Martin Semmelrogge"
-    ],
-    [
-      "Barnaby Witherspoon",
-      "Achim Schülke"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Godwin",
-      "André Minninger"
-    ],
-    [
-      "Mann",
-      "Holger Löwenberg"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Arthur Sinclair",
+      "sprecher" : "Joachim Pukaß"
+    },
+    {
+      "rolle" : "Mr. Peastone",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Jeremy Witherspoon",
+      "sprecher" : "Martin Semmelrogge"
+    },
+    {
+      "rolle" : "Barnaby Witherspoon",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Holger Löwenberg"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/144/metadata.json",

--- a/web/data/Serie/145/metadata.json
+++ b/web/data/Serie/145/metadata.json
@@ -67,55 +67,55 @@
       "end" : 3722547
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Takasi Yukawa",
-      "Wilfried Diallaz"
-    ],
-    [
-      "Frank Hektor",
-      "Michael Lott"
-    ],
-    [
-      "Sean Doherty",
-      "Leonhard Mahlich"
-    ],
-    [
-      "Mandy",
-      "Jasmin Wagner"
-    ],
-    [
-      "Zeno Daniels",
-      "Philipp Baltus"
-    ],
-    [
-      "Percy",
-      "Jesse Grimm"
-    ],
-    [
-      "Keko",
-      "Jens Wendland"
-    ],
-    [
-      "Anthony Fender",
-      "Peter Buchholz"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Takasi Yukawa",
+      "sprecher" : "Wilfried Dziallas"
+    },
+    {
+      "rolle" : "Frank Hektor",
+      "sprecher" : "Michael Lott"
+    },
+    {
+      "rolle" : "Sean Doherty",
+      "sprecher" : "Leonhard Mahlich"
+    },
+    {
+      "rolle" : "Mandy",
+      "sprecher" : "Jasmin Wagner"
+    },
+    {
+      "rolle" : "Zeno Daniels",
+      "sprecher" : "Philipp Baltus"
+    },
+    {
+      "rolle" : "Percy",
+      "sprecher" : "Jesse Grimm"
+    },
+    {
+      "rolle" : "Keko",
+      "sprecher" : "Jens Wendland"
+    },
+    {
+      "rolle" : "Anthony Fender",
+      "sprecher" : "Peter Buchholz"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/145/metadata.json",

--- a/web/data/Serie/146/metadata.json
+++ b/web/data/Serie/146/metadata.json
@@ -87,79 +87,80 @@
       "end" : 3430360
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Quentin Wadleigh",
-      "Christian Rudolf"
-    ],
-    [
-      "Dr. Winston Wadleigh",
-      "Mathias Münster"
-    ],
-    [
-      "Dr. John Frears",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Jamie",
-      "Philipp Draeger"
-    ],
-    [
-      "Sammy",
-      "Jacob Mayerhoff"
-    ],
-    [
-      "Mrs. Pitkätossu",
-      "Ingeborg Kallweit"
-    ],
-    [
-      "Jackall Madson",
-      "Ingo Nommsen"
-    ],
-    [
-      "Tiger Madson",
-      "Dieter Dücker"
-    ],
-    [
-      "Vivian",
-      "Saskia Mayerhoff"
-    ],
-    [
-      "Fitzwilliam Waterfield",
-      "Wolfgang Völz"
-    ],
-    [
-      "Sanitäter",
-      "Robin Brosch"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Quentin Wadleigh",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Dr. Winston Wadleigh",
+      "sprecher" : "Mathias Münster"
+    },
+    {
+      "rolle" : "Dr. John Frears",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Jamie",
+      "sprecher" : "Philipp Draeger"
+    },
+    {
+      "rolle" : "Sammy",
+      "sprecher" : "Jacob Mayerhoff"
+    },
+    {
+      "rolle" : "Mrs. Pitkätossu",
+      "sprecher" : "Ingeborg Kallweit"
+    },
+    {
+      "rolle" : "Jackall Madson",
+      "sprecher" : "Ingo Nommsen"
+    },
+    {
+      "rolle" : "Tiger Madson",
+      "sprecher" : "Dieter Dücker"
+    },
+    {
+      "rolle" : "Vivian",
+      "sprecher" : "Saskia Mayerhoff"
+    },
+    {
+      "rolle" : "Fitzwilliam Waterfield",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Sanitäter",
+      "sprecher" : "Robin Brosch"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/146/metadata.json",

--- a/web/data/Serie/147/metadata.json
+++ b/web/data/Serie/147/metadata.json
@@ -52,71 +52,71 @@
       "end" : 3770533
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Adam Campbell",
-      "Santiago Ziesmer"
-    ],
-    [
-      "Henry Campbell",
-      "Christian Rudolf"
-    ],
-    [
-      "John Taylor",
-      "Holger Umbreit"
-    ],
-    [
-      "Edward Crockett",
-      "Ben Hecker"
-    ],
-    [
-      "Mrs. Harkort",
-      "Katja Brügger"
-    ],
-    [
-      "Mr. Prescott",
-      "Stefan Kaminski"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Jack Leech",
-      "Volker Bogdan"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Einbrecher",
-      "Patrick Bach"
-    ],
-    [
-      "Max",
-      "Tommaso Cacciapuoti"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Adam Campbell",
+      "sprecher" : "Santiago Ziesmer"
+    },
+    {
+      "rolle" : "Henry Campbell",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "John Taylor",
+      "sprecher" : "Holger Umbreit"
+    },
+    {
+      "rolle" : "Edward Crockett",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Mrs. Harkort",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Mr. Prescott",
+      "sprecher" : "Stefan Kaminski"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Jack Leech",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Einbrecher",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Max",
+      "sprecher" : "Tommaso Cacciapuoti"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/147/metadata.json",

--- a/web/data/Serie/148/metadata.json
+++ b/web/data/Serie/148/metadata.json
@@ -52,55 +52,55 @@
       "end" : 4011933
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Allie Jamison",
-      "Katrin Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Ursula Burns",
-      "Birke Bruck"
-    ],
-    [
-      "Emerald Pendragon",
-      "Monty Arnold"
-    ],
-    [
-      "Carl Parsley",
-      "Peter Weis"
-    ],
-    [
-      "Sunshine",
-      "Dagmar Dreke"
-    ],
-    [
-      "1. Mann",
-      "Tetje Mierendorf"
-    ],
-    [
-      "2. Mann",
-      "Gosta Liptow"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Allie Jamison",
+      "sprecher" : "Katrin Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Ursula Burns",
+      "sprecher" : "Birke Bruck"
+    },
+    {
+      "rolle" : "Emerald Pendragon",
+      "sprecher" : "Monty Arnold"
+    },
+    {
+      "rolle" : "Carl Parsley",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Sunshine",
+      "sprecher" : "Dagmar Dreke"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Tetje Mierendorf"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Gosta Liptow"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/148/metadata.json",

--- a/web/data/Serie/149/metadata.json
+++ b/web/data/Serie/149/metadata.json
@@ -77,71 +77,71 @@
       "end" : 3717773
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Cynthia McGowan",
-      "Luise Lunow"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Mrs. Andrews",
-      "Konstanze Ullmer"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Mina Parker",
-      "Annabelle Krieg"
-    ],
-    [
-      "Brandon Fraser",
-      "Tim Grobe"
-    ],
-    [
-      "Beatrix Fraser",
-      "Sophie Lechtenbrink"
-    ],
-    [
-      "Roxy",
-      "Julia Fölster"
-    ],
-    [
-      "Josh",
-      "Volker Hanisch"
-    ],
-    [
-      "Paul",
-      "Tim Kreuer"
-    ],
-    [
-      "Davis",
-      "Frank Meyer-Brockmann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Cynthia McGowan",
+      "sprecher" : "Luise Lunow"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Mrs. Andrews",
+      "sprecher" : "Konstanze Ullmer"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Mina Parker",
+      "sprecher" : "Annabelle Krieg"
+    },
+    {
+      "rolle" : "Brandon Fraser",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Beatrix Fraser",
+      "sprecher" : "Sophie Lechtenbrink"
+    },
+    {
+      "rolle" : "Roxy",
+      "sprecher" : "Julia Fölster"
+    },
+    {
+      "rolle" : "Josh",
+      "sprecher" : "Volker Hanisch"
+    },
+    {
+      "rolle" : "Paul",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Davis",
+      "sprecher" : "Frank Meyer-Brockmann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/149/metadata.json",

--- a/web/data/Serie/150/1/metadata.json
+++ b/web/data/Serie/150/1/metadata.json
@@ -75,79 +75,79 @@
       "end" : 4055093
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Frank Mason",
-      "Wolfgang Condrus"
-    ],
-    [
-      "Miles Dempster",
-      "Stephan Benson"
-    ],
-    [
-      "Mr. Sapchevsky",
-      "Andreas Schmidt-Schaller"
-    ],
-    [
-      "Gerry",
-      "Kostja Ullmann"
-    ],
-    [
-      "Ismael",
-      "Stephan Schad"
-    ],
-    [
-      "Carla Fenton",
-      "Natalie O'Hara"
-    ],
-    [
-      "Mrs. Maruthers",
-      "Ulrike Johannson"
-    ],
-    [
-      "Inspektor Havilland",
-      "Oliver Kalkofe"
-    ],
-    [
-      "Taylor",
-      "Bernhard Hoecker"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Angelica",
-      "Anna Thalbach"
-    ],
-    [
-      "Schwester 1",
-      "Manuela Becker"
-    ],
-    [
-      "Schwester 2",
-      "Traudel Sperber"
-    ],
-    [
-      "Pfleger",
-      "Sven Dahlem"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Frank Mason",
+      "sprecher" : "Wolfgang Condrus"
+    },
+    {
+      "rolle" : "Miles Dempster",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Mr. Sapchevsky",
+      "sprecher" : "Andreas Schmidt-Schaller"
+    },
+    {
+      "rolle" : "Gerry",
+      "sprecher" : "Kostja Ullmann"
+    },
+    {
+      "rolle" : "Ismael",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Carla Fenton",
+      "sprecher" : "Natalie O'Hara"
+    },
+    {
+      "rolle" : "Mrs. Maruthers",
+      "sprecher" : "Ulrike Johannson"
+    },
+    {
+      "rolle" : "Inspektor Havilland",
+      "sprecher" : "Oliver Kalkofe"
+    },
+    {
+      "rolle" : "Taylor",
+      "sprecher" : "Bernhard Hoëcker"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Angelica",
+      "sprecher" : "Anna Thalbach"
+    },
+    {
+      "rolle" : "Schwester 1",
+      "sprecher" : "Manuela Becker"
+    },
+    {
+      "rolle" : "Schwester 2",
+      "sprecher" : "Traudel Sperber"
+    },
+    {
+      "rolle" : "Pfleger",
+      "sprecher" : "Sven Dahlem"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/150/1/metadata.json",

--- a/web/data/Serie/150/2/metadata.json
+++ b/web/data/Serie/150/2/metadata.json
@@ -85,83 +85,83 @@
       "end" : 4100240
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Taylor",
-      "Bernhard Hoecker"
-    ],
-    [
-      "Mr. Smith",
-      "Tim Grobe"
-    ],
-    [
-      "Curtis Fisher",
-      "Tobias Schmidt"
-    ],
-    [
-      "Amrita Chakyar",
-      "Angela Stresemann"
-    ],
-    [
-      "Inspektor Havilland",
-      "Oliver Kalkofe"
-    ],
-    [
-      "Ismael",
-      "Stephan Schad"
-    ],
-    [
-      "Angelica",
-      "Anna Thalbach"
-    ],
-    [
-      "Sergeant Madhu",
-      "Olli Dittrich"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Mrs. Andrews",
-      "Konstanze Ullmer"
-    ],
-    [
-      "Frank Mason",
-      "Wolfgang Condrus"
-    ],
-    [
-      "Mr. Raffer",
-      "Harald Dietl"
-    ],
-    [
-      "Feuerwehrmann",
-      "Kai-Hendrik Möller"
-    ],
-    [
-      "Kapitän",
-      "Sky du Mont"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Taylor",
+      "sprecher" : "Bernhard Hoëcker"
+    },
+    {
+      "rolle" : "Mr. Smith",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Curtis Fisher",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Amrita Chakyar",
+      "sprecher" : "Angela Stresemann"
+    },
+    {
+      "rolle" : "Inspektor Havilland",
+      "sprecher" : "Oliver Kalkofe"
+    },
+    {
+      "rolle" : "Ismael",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Angelica",
+      "sprecher" : "Anna Thalbach"
+    },
+    {
+      "rolle" : "Sergeant Madhu",
+      "sprecher" : "Olli Dittrich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Mrs. Andrews",
+      "sprecher" : "Konstanze Ullmer"
+    },
+    {
+      "rolle" : "Frank Mason",
+      "sprecher" : "Wolfgang Condrus"
+    },
+    {
+      "rolle" : "Mr. Raffer",
+      "sprecher" : "Harald Dietl"
+    },
+    {
+      "rolle" : "Feuerwehrmann",
+      "sprecher" : "Kai Henrik Möller"
+    },
+    {
+      "rolle" : "Kapitän",
+      "sprecher" : "Sky du Mont"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/150/2/metadata.json",

--- a/web/data/Serie/150/3/metadata.json
+++ b/web/data/Serie/150/3/metadata.json
@@ -60,83 +60,83 @@
       "end" : 3763400
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Frank Mason",
-      "Wolfgang Condrus"
-    ],
-    [
-      "Taylor",
-      "Bernhard Hoecker"
-    ],
-    [
-      "Curtis Fisher",
-      "Tobias Schmidt"
-    ],
-    [
-      "John Fisher",
-      "Dirk Bach"
-    ],
-    [
-      "Gerry",
-      "Kostja Ullmann"
-    ],
-    [
-      "Ismael",
-      "Stephan Schad"
-    ],
-    [
-      "Mr. Smith",
-      "Tim Grobe"
-    ],
-    [
-      "Mrs. Maruthers",
-      "Ulrike Johannson"
-    ],
-    [
-      "Angelica",
-      "Anna Thalbach"
-    ],
-    [
-      "Sergeant Madhu",
-      "Olli Dittrich"
-    ],
-    [
-      "Mr. Castro",
-      "Jörg Gillner"
-    ],
-    [
-      "Sanitäter",
-      "Robert Kottula"
-    ],
-    [
-      "Anudhara",
-      "Rosakutty Hemsing"
-    ],
-    [
-      "Ruth",
-      "Gabriele Libbach"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Frank Mason",
+      "sprecher" : "Wolfgang Condrus"
+    },
+    {
+      "rolle" : "Taylor",
+      "sprecher" : "Bernhard Hoëcker"
+    },
+    {
+      "rolle" : "Curtis Fisher",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "John Fisher",
+      "sprecher" : "Dirk Bach"
+    },
+    {
+      "rolle" : "Gerry",
+      "sprecher" : "Kostja Ullmann"
+    },
+    {
+      "rolle" : "Ismael",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Mr. Smith",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Mrs. Maruthers",
+      "sprecher" : "Ulrike Johannson"
+    },
+    {
+      "rolle" : "Angelica",
+      "sprecher" : "Anna Thalbach"
+    },
+    {
+      "rolle" : "Sergeant Madhu",
+      "sprecher" : "Olli Dittrich"
+    },
+    {
+      "rolle" : "Mr. Castro",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Sanitäter",
+      "sprecher" : "Robert Kotulla"
+    },
+    {
+      "rolle" : "Anudhara",
+      "sprecher" : "Rosakutty Hemsing"
+    },
+    {
+      "rolle" : "Ruth",
+      "sprecher" : "Gabriele Libbach"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/150/3/metadata.json",

--- a/web/data/Serie/150/metadata.json
+++ b/web/data/Serie/150/metadata.json
@@ -78,79 +78,79 @@
           "end" : 4055093
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Frank Mason",
-          "Wolfgang Condrus"
-        ],
-        [
-          "Miles Dempster",
-          "Stephan Benson"
-        ],
-        [
-          "Mr. Sapchevsky",
-          "Andreas Schmidt-Schaller"
-        ],
-        [
-          "Gerry",
-          "Kostja Ullmann"
-        ],
-        [
-          "Ismael",
-          "Stephan Schad"
-        ],
-        [
-          "Carla Fenton",
-          "Natalie O'Hara"
-        ],
-        [
-          "Mrs. Maruthers",
-          "Ulrike Johannson"
-        ],
-        [
-          "Inspektor Havilland",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Taylor",
-          "Bernhard Hoecker"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Angelica",
-          "Anna Thalbach"
-        ],
-        [
-          "Schwester 1",
-          "Manuela Becker"
-        ],
-        [
-          "Schwester 2",
-          "Traudel Sperber"
-        ],
-        [
-          "Pfleger",
-          "Sven Dahlem"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Frank Mason",
+          "sprecher" : "Wolfgang Condrus"
+        },
+        {
+          "rolle" : "Miles Dempster",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Mr. Sapchevsky",
+          "sprecher" : "Andreas Schmidt-Schaller"
+        },
+        {
+          "rolle" : "Gerry",
+          "sprecher" : "Kostja Ullmann"
+        },
+        {
+          "rolle" : "Ismael",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Carla Fenton",
+          "sprecher" : "Natalie O'Hara"
+        },
+        {
+          "rolle" : "Mrs. Maruthers",
+          "sprecher" : "Ulrike Johannson"
+        },
+        {
+          "rolle" : "Inspektor Havilland",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Taylor",
+          "sprecher" : "Bernhard Hoëcker"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Angelica",
+          "sprecher" : "Anna Thalbach"
+        },
+        {
+          "rolle" : "Schwester 1",
+          "sprecher" : "Manuela Becker"
+        },
+        {
+          "rolle" : "Schwester 2",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Pfleger",
+          "sprecher" : "Sven Dahlem"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/150/1/metadata.json",
@@ -245,83 +245,83 @@
           "end" : 4100240
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Taylor",
-          "Bernhard Hoecker"
-        ],
-        [
-          "Mr. Smith",
-          "Tim Grobe"
-        ],
-        [
-          "Curtis Fisher",
-          "Tobias Schmidt"
-        ],
-        [
-          "Amrita Chakyar",
-          "Angela Stresemann"
-        ],
-        [
-          "Inspektor Havilland",
-          "Oliver Kalkofe"
-        ],
-        [
-          "Ismael",
-          "Stephan Schad"
-        ],
-        [
-          "Angelica",
-          "Anna Thalbach"
-        ],
-        [
-          "Sergeant Madhu",
-          "Olli Dittrich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Mrs. Andrews",
-          "Konstanze Ullmer"
-        ],
-        [
-          "Frank Mason",
-          "Wolfgang Condrus"
-        ],
-        [
-          "Mr. Raffer",
-          "Harald Dietl"
-        ],
-        [
-          "Feuerwehrmann",
-          "Kai-Hendrik Möller"
-        ],
-        [
-          "Kapitän",
-          "Sky du Mont"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Taylor",
+          "sprecher" : "Bernhard Hoëcker"
+        },
+        {
+          "rolle" : "Mr. Smith",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Curtis Fisher",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Amrita Chakyar",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Inspektor Havilland",
+          "sprecher" : "Oliver Kalkofe"
+        },
+        {
+          "rolle" : "Ismael",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Angelica",
+          "sprecher" : "Anna Thalbach"
+        },
+        {
+          "rolle" : "Sergeant Madhu",
+          "sprecher" : "Olli Dittrich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Mrs. Andrews",
+          "sprecher" : "Konstanze Ullmer"
+        },
+        {
+          "rolle" : "Frank Mason",
+          "sprecher" : "Wolfgang Condrus"
+        },
+        {
+          "rolle" : "Mr. Raffer",
+          "sprecher" : "Harald Dietl"
+        },
+        {
+          "rolle" : "Feuerwehrmann",
+          "sprecher" : "Kai Henrik Möller"
+        },
+        {
+          "rolle" : "Kapitän",
+          "sprecher" : "Sky du Mont"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/150/2/metadata.json",
@@ -391,83 +391,83 @@
           "end" : 3763400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Frank Mason",
-          "Wolfgang Condrus"
-        ],
-        [
-          "Taylor",
-          "Bernhard Hoecker"
-        ],
-        [
-          "Curtis Fisher",
-          "Tobias Schmidt"
-        ],
-        [
-          "John Fisher",
-          "Dirk Bach"
-        ],
-        [
-          "Gerry",
-          "Kostja Ullmann"
-        ],
-        [
-          "Ismael",
-          "Stephan Schad"
-        ],
-        [
-          "Mr. Smith",
-          "Tim Grobe"
-        ],
-        [
-          "Mrs. Maruthers",
-          "Ulrike Johannson"
-        ],
-        [
-          "Angelica",
-          "Anna Thalbach"
-        ],
-        [
-          "Sergeant Madhu",
-          "Olli Dittrich"
-        ],
-        [
-          "Mr. Castro",
-          "Jörg Gillner"
-        ],
-        [
-          "Sanitäter",
-          "Robert Kottula"
-        ],
-        [
-          "Anudhara",
-          "Rosakutty Hemsing"
-        ],
-        [
-          "Ruth",
-          "Gabriele Libbach"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Frank Mason",
+          "sprecher" : "Wolfgang Condrus"
+        },
+        {
+          "rolle" : "Taylor",
+          "sprecher" : "Bernhard Hoëcker"
+        },
+        {
+          "rolle" : "Curtis Fisher",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "John Fisher",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "Gerry",
+          "sprecher" : "Kostja Ullmann"
+        },
+        {
+          "rolle" : "Ismael",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Mr. Smith",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Mrs. Maruthers",
+          "sprecher" : "Ulrike Johannson"
+        },
+        {
+          "rolle" : "Angelica",
+          "sprecher" : "Anna Thalbach"
+        },
+        {
+          "rolle" : "Sergeant Madhu",
+          "sprecher" : "Olli Dittrich"
+        },
+        {
+          "rolle" : "Mr. Castro",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Robert Kotulla"
+        },
+        {
+          "rolle" : "Anudhara",
+          "sprecher" : "Rosakutty Hemsing"
+        },
+        {
+          "rolle" : "Ruth",
+          "sprecher" : "Gabriele Libbach"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/150/3/metadata.json",
@@ -481,139 +481,139 @@
   "hörspielskriptautor" : "André Minninger",
   "beschreibung" : "Die drei ??? übernehmen und lösen (hoffentlich!) ihren 150sten Fall! In drei atemberaubenden Folgen sind sie dem Rätsel der Geisterbucht auf der Spur! Welches Geheimnis verbirgt sich hinter dem Testament, dass der exzentrische Harry Shreber kurz vor seinem Tod verfasst hat? Führen die verschlüsselten Verse tatsächlich zu Rashuras Schatz? (Teil A) Den drei Detektiven wird nichts anderes übrig bleiben: Sie müssen in Flammendes Wasser (Teil B) hinab tauchen, denn nur in der Tiefe des Meeres kann geklärt werden, warum Der brennende Kristall (Teil C) so viel Unglück über eine große Anzahl Menschen bringen konnte …",
   "veröffentlichungsdatum" : "2011-11-11",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Frank Mason",
-      "Wolfgang Condrus"
-    ],
-    [
-      "Miles Dempster",
-      "Stephan Benson"
-    ],
-    [
-      "Mr. Sapchevsky",
-      "Andreas Schmidt-Schaller"
-    ],
-    [
-      "Gerry",
-      "Kostja Ullmann"
-    ],
-    [
-      "Ismael",
-      "Stephan Schad"
-    ],
-    [
-      "Carla Fenton",
-      "Natalie O'Hara"
-    ],
-    [
-      "Mrs. Maruthers",
-      "Ulrike Johannson"
-    ],
-    [
-      "Inspektor Havilland",
-      "Oliver Kalkofe"
-    ],
-    [
-      "Taylor",
-      "Bernhard Hoecker"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Angelica",
-      "Anna Thalbach"
-    ],
-    [
-      "Schwester 1",
-      "Manuela Becker"
-    ],
-    [
-      "Schwester 2",
-      "Traudel Sperber"
-    ],
-    [
-      "Pfleger",
-      "Sven Dahlem"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Mr. Smith",
-      "Tim Grobe"
-    ],
-    [
-      "Curtis Fisher",
-      "Tobias Schmidt"
-    ],
-    [
-      "Amrita Chakyar",
-      "Angela Stresemann"
-    ],
-    [
-      "Sergeant Madhu",
-      "Olli Dittrich"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Mrs. Andrews",
-      "Konstanze Ullmer"
-    ],
-    [
-      "Mr. Raffer",
-      "Harald Dietl"
-    ],
-    [
-      "Feuerwehrmann",
-      "Kai-Hendrik Möller"
-    ],
-    [
-      "Kapitän",
-      "Sky du Mont"
-    ],
-    [
-      "John Fisher",
-      "Dirk Bach"
-    ],
-    [
-      "Mr. Castro",
-      "Jörg Gillner"
-    ],
-    [
-      "Sanitäter",
-      "Robert Kottula"
-    ],
-    [
-      "Anudhara",
-      "Rosakutty Hemsing"
-    ],
-    [
-      "Ruth",
-      "Gabriele Libbach"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Frank Mason",
+      "sprecher" : "Wolfgang Condrus"
+    },
+    {
+      "rolle" : "Miles Dempster",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Mr. Sapchevsky",
+      "sprecher" : "Andreas Schmidt-Schaller"
+    },
+    {
+      "rolle" : "Gerry",
+      "sprecher" : "Kostja Ullmann"
+    },
+    {
+      "rolle" : "Ismael",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Carla Fenton",
+      "sprecher" : "Natalie O'Hara"
+    },
+    {
+      "rolle" : "Mrs. Maruthers",
+      "sprecher" : "Ulrike Johannson"
+    },
+    {
+      "rolle" : "Inspektor Havilland",
+      "sprecher" : "Oliver Kalkofe"
+    },
+    {
+      "rolle" : "Taylor",
+      "sprecher" : "Bernhard Hoëcker"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Angelica",
+      "sprecher" : "Anna Thalbach"
+    },
+    {
+      "rolle" : "Schwester 1",
+      "sprecher" : "Manuela Becker"
+    },
+    {
+      "rolle" : "Schwester 2",
+      "sprecher" : "Traudel Sperber"
+    },
+    {
+      "rolle" : "Pfleger",
+      "sprecher" : "Sven Dahlem"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Mr. Smith",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Curtis Fisher",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Amrita Chakyar",
+      "sprecher" : "Angela Stresemann"
+    },
+    {
+      "rolle" : "Sergeant Madhu",
+      "sprecher" : "Olli Dittrich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Mrs. Andrews",
+      "sprecher" : "Konstanze Ullmer"
+    },
+    {
+      "rolle" : "Mr. Raffer",
+      "sprecher" : "Harald Dietl"
+    },
+    {
+      "rolle" : "Feuerwehrmann",
+      "sprecher" : "Kai Henrik Möller"
+    },
+    {
+      "rolle" : "Kapitän",
+      "sprecher" : "Sky du Mont"
+    },
+    {
+      "rolle" : "John Fisher",
+      "sprecher" : "Dirk Bach"
+    },
+    {
+      "rolle" : "Mr. Castro",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Sanitäter",
+      "sprecher" : "Robert Kotulla"
+    },
+    {
+      "rolle" : "Anudhara",
+      "sprecher" : "Rosakutty Hemsing"
+    },
+    {
+      "rolle" : "Ruth",
+      "sprecher" : "Gabriele Libbach"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/150/metadata.json",

--- a/web/data/Serie/151/metadata.json
+++ b/web/data/Serie/151/metadata.json
@@ -87,87 +87,87 @@
       "end" : 3943307
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Laurence Seinfeld",
-      "Wolf Frass"
-    ],
-    [
-      "Denzel Hopkins",
-      "Tilo Schmitz"
-    ],
-    [
-      "Goldie Hopkins",
-      "Madeleine Weingarten"
-    ],
-    [
-      "Neil Rockwell",
-      "Wanja Mues"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Summer Hopkins",
-      "Regina Lemnitz"
-    ],
-    [
-      "Brooks, Galerist",
-      "Martin May"
-    ],
-    [
-      "Mr. Elroy Follister",
-      "Stephan Schwartz"
-    ],
-    [
-      "Martha",
-      "Hanna Reisch"
-    ],
-    [
-      "Dillon",
-      "Gregor Reisch"
-    ],
-    [
-      "Wayne",
-      "Woody Mues"
-    ],
-    [
-      "Gefängniswärter",
-      "Gosta Liptow"
-    ],
-    [
-      "Wirt",
-      "Klaus Dittmann"
-    ],
-    [
-      "Greis",
-      "Jürgen Thormann"
-    ],
-    [
-      "Beamter",
-      "Monty Arnold"
-    ],
-    [
-      "Taxifahrer",
-      "Harald Dietl"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Laurence Seinfeld",
+      "sprecher" : "Wolf Frass"
+    },
+    {
+      "rolle" : "Denzel Hopkins",
+      "sprecher" : "Tilo Schmitz"
+    },
+    {
+      "rolle" : "Goldie Hopkins",
+      "sprecher" : "Madeleine Weingart"
+    },
+    {
+      "rolle" : "Neil Rockwell",
+      "sprecher" : "Wanja Mues"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Summer Hopkins",
+      "sprecher" : "Regina Lemnitz"
+    },
+    {
+      "rolle" : "Brooks, Galerist",
+      "sprecher" : "Martin May"
+    },
+    {
+      "rolle" : "Mr. Elroy Follister",
+      "sprecher" : "Stephan Schwartz"
+    },
+    {
+      "rolle" : "Martha",
+      "sprecher" : "Hanna Reisch"
+    },
+    {
+      "rolle" : "Dillon",
+      "sprecher" : "Gregor Reisch"
+    },
+    {
+      "rolle" : "Wayne",
+      "sprecher" : "Woody Mues"
+    },
+    {
+      "rolle" : "Gefängniswärter",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Wirt",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Greis",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Beamter",
+      "sprecher" : "Monty Arnold"
+    },
+    {
+      "rolle" : "Taxifahrer",
+      "sprecher" : "Harald Dietl"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/151/metadata.json",

--- a/web/data/Serie/152/metadata.json
+++ b/web/data/Serie/152/metadata.json
@@ -67,83 +67,83 @@
       "end" : 3374867
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Bert Young",
-      "Horst Stark"
-    ],
-    [
-      "Mrs. Johnson",
-      "Gabriele Libbach"
-    ],
-    [
-      "Chapman",
-      "Sascha Rotermund"
-    ],
-    [
-      "Tony",
-      "Reent Reins"
-    ],
-    [
-      "Blake",
-      "Wolfgang Rositzka"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Rubbish George",
-      "Utz Richter"
-    ],
-    [
-      "1. Mann",
-      "Rasmus Borowski"
-    ],
-    [
-      "2. Mann",
-      "Jo Kappl"
-    ],
-    [
-      "Verkäufer",
-      "Marcus Schönhoff"
-    ],
-    [
-      "Sunny",
-      "Rainer Schmitt"
-    ],
-    [
-      "Fernsehr-Sprecher",
-      "Jannik Schümann"
-    ],
-    [
-      "Blacky",
-      "Heikedine Körting"
-    ],
-    [
-      "Francesco",
-      "Anton Sprick"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Bert Young",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Mrs. Johnson",
+      "sprecher" : "Gabriele Libbach"
+    },
+    {
+      "rolle" : "Chapman",
+      "sprecher" : "Sascha Rotermund"
+    },
+    {
+      "rolle" : "Tony",
+      "sprecher" : "Reent Reins"
+    },
+    {
+      "rolle" : "Blake",
+      "sprecher" : "Wolfgang Rositzka"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Rubbish George",
+      "sprecher" : "Utz Richter"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Rasmus Borowski"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Joachim Kappl"
+    },
+    {
+      "rolle" : "Verkäufer",
+      "sprecher" : "Marcus Schönhoff"
+    },
+    {
+      "rolle" : "Sunny",
+      "sprecher" : "Rainer Schmitt"
+    },
+    {
+      "rolle" : "Fernsehe-Sprecher",
+      "sprecher" : "Jannik Schümann"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Francesco",
+      "sprecher" : "Anton Sprick"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/152/metadata.json",

--- a/web/data/Serie/153/metadata.json
+++ b/web/data/Serie/153/metadata.json
@@ -62,79 +62,79 @@
       "end" : 3243960
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Sean O'Donnell",
-      "Till Demtrøder"
-    ],
-    [
-      "Alexander Chilton",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Mann im Stadion",
-      "Eric Förster"
-    ],
-    [
-      "Ordner",
-      "Matthias Treder"
-    ],
-    [
-      "Frau im Police Department",
-      "Corinna Wodrich"
-    ],
-    [
-      "Mrs. Gardiner",
-      "Elisa Linnemann"
-    ],
-    [
-      "Sekretärin",
-      "Susan Jarling"
-    ],
-    [
-      "Inspektor Craig",
-      "Gustav-Adolph Artz"
-    ],
-    [
-      "Tom Chilton",
-      "Christopher Arndt"
-    ],
-    [
-      "Junger Mann auf der Pier",
-      "Christian Senger"
-    ],
-    [
-      "Junge im Stadion",
-      "Johann Gutjahr"
-    ],
-    [
-      "Live-Kommentator",
-      "Ulli Potofski"
-    ],
-    [
-      "Ansager",
-      "Frank Wintjen"
-    ],
-    [
-      "Frau auf dem Pier",
-      "Katinka Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Sean O'Donnell",
+      "sprecher" : "Till Demtrøder"
+    },
+    {
+      "rolle" : "Alexander Chilton",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Mann im Stadion",
+      "sprecher" : "Eric Förster"
+    },
+    {
+      "rolle" : "Ordner",
+      "sprecher" : "Matthias Treder"
+    },
+    {
+      "rolle" : "Frau im Police Department",
+      "sprecher" : "Corinna Wodrich"
+    },
+    {
+      "rolle" : "Mrs. Gardiner",
+      "sprecher" : "Elisa Linnemann"
+    },
+    {
+      "rolle" : "Sekretärin",
+      "sprecher" : "Susan Jarling"
+    },
+    {
+      "rolle" : "Inspektor Craig",
+      "sprecher" : "Gustav-Adolph Artz"
+    },
+    {
+      "rolle" : "Tom Chilton",
+      "sprecher" : "Christopher Arndt"
+    },
+    {
+      "rolle" : "Junger Mann auf der Pier",
+      "sprecher" : "Christian Senger"
+    },
+    {
+      "rolle" : "Junge im Stadion",
+      "sprecher" : "Johann Gutjahr"
+    },
+    {
+      "rolle" : "Live-Kommentator",
+      "sprecher" : "Ulrich Potofski"
+    },
+    {
+      "rolle" : "Ansager",
+      "sprecher" : "Frank Wintjen"
+    },
+    {
+      "rolle" : "Frau auf dem Pier",
+      "sprecher" : "Katinka Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/153/metadata.json",

--- a/web/data/Serie/154/metadata.json
+++ b/web/data/Serie/154/metadata.json
@@ -72,95 +72,96 @@
       "end" : 4238587
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Titus Jonas",
-      "Hans Meinhard"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Prof. Jane Heathcliff",
-      "Victoria von Trauttmansdorff"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Mr. Grey",
-      "Urs Affolter"
-    ],
-    [
-      "Lester Price",
-      "Fabian Harloff"
-    ],
-    [
-      "Cinelly",
-      "Bernd Stephan"
-    ],
-    [
-      "Mr. Monroe",
-      "Achim Schülke"
-    ],
-    [
-      "Miss Deborah Cassidy",
-      "Barbara Focke"
-    ],
-    [
-      "Mr. Burke",
-      "Kai-Hendrik Möller"
-    ],
-    [
-      "Miss Trimble",
-      "Christine Pappert"
-    ],
-    [
-      "Mr. Weston",
-      "Joachim Lautenbach"
-    ],
-    [
-      "Nachbarin",
-      "Doris Maria Kaiser"
-    ],
-    [
-      "Butler",
-      "Erik Schäffler"
-    ],
-    [
-      "Goodween",
-      "André Minninger"
-    ],
-    [
-      "Michael Kowalski",
-      "Tobias Schmidt"
-    ],
-    [
-      "Jack",
-      "Leonhard Mahlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Prof. Jane Heathcliff",
+      "sprecher" : "Victoria Trauttmansdorff"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Mr. Grey",
+      "sprecher" : "Urs Affolter"
+    },
+    {
+      "rolle" : "Lester Price",
+      "sprecher" : "Fabian Harloff"
+    },
+    {
+      "rolle" : "Cinelly",
+      "sprecher" : "Bernd Stephan"
+    },
+    {
+      "rolle" : "Mr. Monroe",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Miss Deborah Cassidy",
+      "sprecher" : "Barbara Focke"
+    },
+    {
+      "rolle" : "Mr. Burke",
+      "sprecher" : "Kai Henrik Möller"
+    },
+    {
+      "rolle" : "Miss Trimble",
+      "sprecher" : "Christine Pappert"
+    },
+    {
+      "rolle" : "Mr. Weston",
+      "sprecher" : "Joachim Lautenbach"
+    },
+    {
+      "rolle" : "Nachbarin",
+      "sprecher" : "Doris Maria Kaiser"
+    },
+    {
+      "rolle" : "Butler",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Michael Kowalski",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Jack",
+      "sprecher" : "Leonhard Mahlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/154/metadata.json",

--- a/web/data/Serie/155/metadata.json
+++ b/web/data/Serie/155/metadata.json
@@ -87,63 +87,63 @@
       "end" : 4055280
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Zack Martin",
-      "Christian Stark"
-    ],
-    [
-      "Mary-Ann Leigh",
-      "Manuela Bäcker"
-    ],
-    [
-      "Latona Johnson",
-      "Julia Hummer"
-    ],
-    [
-      "Frank Norman",
-      "Till Huster"
-    ],
-    [
-      "Mrs. Robinson",
-      "Heidi Berndt"
-    ],
-    [
-      "Angela Sciutto",
-      "Gisela Fritsch"
-    ],
-    [
-      "Federico Sciutto",
-      "Rainer Fritzsche"
-    ],
-    [
-      "Mr. Torrance",
-      "Ingo Feder"
-    ],
-    [
-      "Frau",
-      "Konstanze Ullmer"
-    ],
-    [
-      "Kind",
-      "Undine Ullmer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Zack Martin",
+      "sprecher" : "Christian Stark"
+    },
+    {
+      "rolle" : "Mary-Ann Leigh",
+      "sprecher" : "Manuela Eifrig"
+    },
+    {
+      "rolle" : "Latona Johnson",
+      "sprecher" : "Julia Hummer"
+    },
+    {
+      "rolle" : "Frank Norman",
+      "sprecher" : "Till Huster"
+    },
+    {
+      "rolle" : "Mrs. Robinson",
+      "sprecher" : "Heidi Berndt"
+    },
+    {
+      "rolle" : "Angela Sciutto",
+      "sprecher" : "Gisela Fritsch"
+    },
+    {
+      "rolle" : "Federico Sciutto",
+      "sprecher" : "Rainer Fritzsche"
+    },
+    {
+      "rolle" : "Mr. Torrance",
+      "sprecher" : "Ingo Feder"
+    },
+    {
+      "rolle" : "Frau",
+      "sprecher" : "Konstanze Ullmer"
+    },
+    {
+      "rolle" : "Kind",
+      "sprecher" : "Undine Ullmer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/155/metadata.json",

--- a/web/data/Serie/156/metadata.json
+++ b/web/data/Serie/156/metadata.json
@@ -82,63 +82,63 @@
       "end" : 4331240
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ryan Holbrooke",
-      "Manfred Reddemann"
-    ],
-    [
-      "Sheriff Pickett",
-      "Gerhart Hinze"
-    ],
-    [
-      "Stephen Baron",
-      "Patrick Elias"
-    ],
-    [
-      "Zyklon",
-      "Wolfgang Berger"
-    ],
-    [
-      "Al Dahab",
-      "Neil Malik"
-    ],
-    [
-      "Frau",
-      "Regine Lamster"
-    ],
-    [
-      "Matthew",
-      "Mike Olsowski"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Zabriski",
-      "Volker Bogdan"
-    ],
-    [
-      "Fred",
-      "Oliver Mink"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ryan Holbrooke",
+      "sprecher" : "Manfred Reddemann"
+    },
+    {
+      "rolle" : "Sheriff Pickett",
+      "sprecher" : "Gerhart Hinze"
+    },
+    {
+      "rolle" : "Stephen Baron",
+      "sprecher" : "Patrick Elias"
+    },
+    {
+      "rolle" : "Zyklon",
+      "sprecher" : "Wolfgang Berger"
+    },
+    {
+      "rolle" : "Al Dahab",
+      "sprecher" : "Neil Malik Abdullah"
+    },
+    {
+      "rolle" : "Frau",
+      "sprecher" : "Regine Lamster"
+    },
+    {
+      "rolle" : "Matthew",
+      "sprecher" : "Mike Olsowski"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Zabriski",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "Fred",
+      "sprecher" : "Oliver Mink"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/156/metadata.json",

--- a/web/data/Serie/157/metadata.json
+++ b/web/data/Serie/157/metadata.json
@@ -67,63 +67,64 @@
       "end" : 4461093
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Riese",
-      "Tilo Schmitz"
-    ],
-    [
-      "Hunnicutt",
-      "Heinz Lieven"
-    ],
-    [
-      "Sheila",
-      "Melanie Pukaß"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Felicity",
-      "Kari Erlhoff"
-    ],
-    [
-      "Chester",
-      "Mike Olsowski"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Gizmo",
-      "Michael von Rospatt"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Riese",
+      "sprecher" : "Tilo Schmitz"
+    },
+    {
+      "rolle" : "Hunnicutt",
+      "sprecher" : "Heinz Lieven"
+    },
+    {
+      "rolle" : "Sheila",
+      "sprecher" : "Melanie Pukaß"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Felicity",
+      "sprecher" : "Kari Erlhoff"
+    },
+    {
+      "rolle" : "Chester",
+      "sprecher" : "Mike Olsowski"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Gizmo",
+      "sprecher" : "Michael von Rospatt"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/157/metadata.json",

--- a/web/data/Serie/158/metadata.json
+++ b/web/data/Serie/158/metadata.json
@@ -72,75 +72,75 @@
       "end" : 3396520
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Michelle",
-      "Ulrike Stürzbecher"
-    ],
-    [
-      "Ronald Pounder",
-      "Jürgen Kluckert"
-    ],
-    [
-      "Maurice Blight",
-      "Oliver Böttcher"
-    ],
-    [
-      "Betsy",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Isabella",
-      "Isabel Navarro"
-    ],
-    [
-      "Vladas Abakulow",
-      "Eric Schäffler"
-    ],
-    [
-      "Moody Firthway",
-      "Peter Striebeck"
-    ],
-    [
-      "Polizist",
-      "Mike Olsowski"
-    ],
-    [
-      "Jenna",
-      "Konstanze Ullmer"
-    ],
-    [
-      "1. Mann",
-      "Olaf Kreutzenbeck"
-    ],
-    [
-      "2. Mann",
-      "Rainer Fritzsche"
-    ],
-    [
-      "3. Mann",
-      "Claus Fuchs"
-    ],
-    [
-      "4. Mann",
-      "Jannik Endemann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Michelle",
+      "sprecher" : "Ulrike Stürzbecher"
+    },
+    {
+      "rolle" : "Ronald Pounder",
+      "sprecher" : "Jürgen Kluckert"
+    },
+    {
+      "rolle" : "Maurice Blight",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Betsy",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Isabella",
+      "sprecher" : "Isabel Navarro"
+    },
+    {
+      "rolle" : "Vladas Abakulow",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Moody Firthway",
+      "sprecher" : "Peter Striebeck"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Mike Olsowski"
+    },
+    {
+      "rolle" : "Jenna",
+      "sprecher" : "Konstanze Ullmer"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Olaf Kreutzenbeck"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Rainer Fritzsche"
+    },
+    {
+      "rolle" : "Mann 3",
+      "sprecher" : "Claus Fuchs"
+    },
+    {
+      "rolle" : "Mann 4",
+      "sprecher" : "Jannik Endemann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/158/metadata.json",

--- a/web/data/Serie/159/metadata.json
+++ b/web/data/Serie/159/metadata.json
@@ -62,55 +62,56 @@
       "end" : 3931427
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Caroline Cotta",
-      "Michaela Mahlich"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Sergeant Donatelli",
-      "Peter Weis"
-    ],
-    [
-      "1. Mann",
-      "Robin Brosch"
-    ],
-    [
-      "2. Mann",
-      "Gerhart Hinze"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Caroline Cotta",
+      "sprecher" : "Micaëla Kreißler"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Sergeant Donatelli",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Gerhart Hinze"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/159/metadata.json",

--- a/web/data/Serie/160/metadata.json
+++ b/web/data/Serie/160/metadata.json
@@ -52,67 +52,67 @@
       "end" : 3820387
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Barbara",
-      "Tanja Geke"
-    ],
-    [
-      "Professor Mathewson",
-      "Stephan Schwartz"
-    ],
-    [
-      "Arthur",
-      "Stephan Benson"
-    ],
-    [
-      "Alan Jones",
-      "Wolfgang Pampel"
-    ],
-    [
-      "Shu Liin",
-      "Monika Freisfeld-Pampel"
-    ],
-    [
-      "Kellner",
-      "Sven Dahlem"
-    ],
-    [
-      "Frank",
-      "Simon Jäger"
-    ],
-    [
-      "Stadtverwalter",
-      "Achim Schülke"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Feuerschlucker",
-      "Bertram Hiese"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Barbara",
+      "sprecher" : "Tanja Geke"
+    },
+    {
+      "rolle" : "Professor Mathewson",
+      "sprecher" : "Stephan Schwartz"
+    },
+    {
+      "rolle" : "Arthur",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Alan Jones",
+      "sprecher" : "Wolfgang Pampel"
+    },
+    {
+      "rolle" : "Shu Liin",
+      "sprecher" : "Monika Freisfeld-Pampel"
+    },
+    {
+      "rolle" : "Kellner",
+      "sprecher" : "Sven Dahlem"
+    },
+    {
+      "rolle" : "Frank",
+      "sprecher" : "Simon Jäger"
+    },
+    {
+      "rolle" : "Stadtverwalter",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Feuerschlucker",
+      "sprecher" : "Bertram Hiese"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/160/metadata.json",

--- a/web/data/Serie/161/metadata.json
+++ b/web/data/Serie/161/metadata.json
@@ -77,63 +77,63 @@
       "end" : 4238493
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Greenwalt",
-      "Harald Dietl"
-    ],
-    [
-      "Brock",
-      "Guido A. Schick"
-    ],
-    [
-      "Deforge",
-      "Bruno F. Apitz"
-    ],
-    [
-      "Mrs. Kretchmer",
-      "Monika Werner"
-    ],
-    [
-      "Mrs. Espenson",
-      "Karin Eckhold"
-    ],
-    [
-      "Mrs. Wondratschek",
-      "Ela Nitzsche"
-    ],
-    [
-      "Mrs. Field",
-      "Celine Fontanges"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mr. Harris",
-      "Lutz Harder"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Greenwalt",
+      "sprecher" : "Harald Dietl"
+    },
+    {
+      "rolle" : "Brock",
+      "sprecher" : "Guido A. Schick"
+    },
+    {
+      "rolle" : "Deforge",
+      "sprecher" : "Bruno F. Apitz"
+    },
+    {
+      "rolle" : "Mrs. Kretchmer",
+      "sprecher" : "Monika Werner"
+    },
+    {
+      "rolle" : "Mrs. Espenson",
+      "sprecher" : "Karin Eckhold"
+    },
+    {
+      "rolle" : "Mrs. Wondratschek",
+      "sprecher" : "Ela Nitzsche"
+    },
+    {
+      "rolle" : "Mrs. Field",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mr. Harris",
+      "sprecher" : "Lutz Harder"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/161/metadata.json",

--- a/web/data/Serie/162/metadata.json
+++ b/web/data/Serie/162/metadata.json
@@ -62,59 +62,59 @@
       "end" : 4365707
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Prof. Arnold Brewster",
-      "Horst Naumann"
-    ],
-    [
-      "Miss Daggett",
-      "Ingeborg Christiansen"
-    ],
-    [
-      "Hold",
-      "Christian Rode"
-    ],
-    [
-      "Hank Tornby",
-      "Edgar Hoppe"
-    ],
-    [
-      "Mike Cobble",
-      "Gordon Piedesack"
-    ],
-    [
-      "Martin Ishniak",
-      "Erkki Hopf"
-    ],
-    [
-      "Samuel Cobble",
-      "Eckart Dux"
-    ],
-    [
-      "William Prescott",
-      "Eberhard Haar"
-    ],
-    [
-      "Jim Sesto",
-      "Gustav-Adolph Artz"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Prof. Arnold Brewster",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Miss Daggett",
+      "sprecher" : "Ingeborg Christiansen"
+    },
+    {
+      "rolle" : "Hold",
+      "sprecher" : "Christian Rode"
+    },
+    {
+      "rolle" : "Hank Tornby",
+      "sprecher" : "Edgar Hoppe"
+    },
+    {
+      "rolle" : "Mike Cobble",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Martin Ishniak",
+      "sprecher" : "Erkki Hopf"
+    },
+    {
+      "rolle" : "Samuel Cobble",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "William Prescott",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Jim Sesto",
+      "sprecher" : "Gustav-Adolph Artz"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/162/metadata.json",

--- a/web/data/Serie/163/metadata.json
+++ b/web/data/Serie/163/metadata.json
@@ -62,31 +62,31 @@
       "end" : 4468413
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Fynch",
-      "Stefan Benson"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Fynch",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/163/metadata.json",

--- a/web/data/Serie/164/metadata.json
+++ b/web/data/Serie/164/metadata.json
@@ -57,63 +57,65 @@
       "end" : 4125760
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Lenni",
-      "Tim Kreuer"
-    ],
-    [
-      "John Greyfox",
-      "Douglas Welbat"
-    ],
-    [
-      "Clay Carson",
-      "Krystian Martinek"
-    ],
-    [
-      "Walter",
-      "Achim Schülke"
-    ],
-    [
-      "Freddy Hays",
-      "Woody Mues"
-    ],
-    [
-      "Trainer",
-      "Bruno F. Apitz"
-    ],
-    [
-      "Mann",
-      "Wolfram Winfried"
-    ],
-    [
-      "Junge",
-      "Francesco Nieheim"
-    ],
-    [
-      "Spieler",
-      "Carsten Kausse"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Lenni",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "John Greyfox",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Clay Carson",
+      "sprecher" : "Krystian Martinek"
+    },
+    {
+      "rolle" : "Walter",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Freddy Hays",
+      "sprecher" : "Bruno F. Apitz"
+    },
+    {
+      "rolle" : "Trainer",
+      "sprecher" : "Woody Mues"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Wolfram Damerius",
+      "pseudonym" : "Wolfram Winfried"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "Frank Boldewin",
+      "pseudonym" : "Francesco Nieheim"
+    },
+    {
+      "rolle" : "Spieler",
+      "sprecher" : "Carsten Kausse"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/164/metadata.json",

--- a/web/data/Serie/165/metadata.json
+++ b/web/data/Serie/165/metadata.json
@@ -62,67 +62,67 @@
       "end" : 4217360
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Randy",
-      "Marek Harloff"
-    ],
-    [
-      "Jeanne",
-      "Katja Brügger"
-    ],
-    [
-      "Ginette",
-      "Birte Kretschmer"
-    ],
-    [
-      "Tara",
-      "Angela Roy"
-    ],
-    [
-      "Steven",
-      "Robert Steudtner"
-    ],
-    [
-      "Ranger Thornton",
-      "Detlef Bierstedt"
-    ],
-    [
-      "Mr. Louis",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Busfahrer",
-      "Volker Bogdan"
-    ],
-    [
-      "Lindsey",
-      "Susan Jarling"
-    ],
-    [
-      "Reporter",
-      "Daniel Welbat"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Randy",
+      "sprecher" : "Marek Harloff"
+    },
+    {
+      "rolle" : "Jeanne",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Ginette",
+      "sprecher" : "Birte Kretschmer"
+    },
+    {
+      "rolle" : "Tara",
+      "sprecher" : "Angela Roy"
+    },
+    {
+      "rolle" : "Steven",
+      "sprecher" : "Robert Steudtner"
+    },
+    {
+      "rolle" : "Ranger Thornton",
+      "sprecher" : "Detlef Bierstedt"
+    },
+    {
+      "rolle" : "Mr. Louis",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Busfahrer",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "Lindsey",
+      "sprecher" : "Susan Jarling"
+    },
+    {
+      "rolle" : "Reporter",
+      "sprecher" : "Daniel Welbat"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/165/metadata.json",

--- a/web/data/Serie/166/metadata.json
+++ b/web/data/Serie/166/metadata.json
@@ -52,43 +52,43 @@
       "end" : 4063013
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Mr. Bennet",
-      "Sven Dahlem"
-    ],
-    [
-      "Mrs. Dearing",
-      "Saskia Weckler"
-    ],
-    [
-      "Conrad Nash",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Frau",
-      "Elga Schütz"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Mr. Bennet",
+      "sprecher" : "Sven Dahlem"
+    },
+    {
+      "rolle" : "Mrs. Dearing",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Conrad Nash",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Frau",
+      "sprecher" : "Elga Schütz"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/166/metadata.json",

--- a/web/data/Serie/167/metadata.json
+++ b/web/data/Serie/167/metadata.json
@@ -82,79 +82,84 @@
       "end" : 4324213
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Andy Carson",
-      "Stefan Schwade"
-    ],
-    [
-      "Mrs. Hampton",
-      "Celine Fontanges"
-    ],
-    [
-      "Nicky DeLores",
-      "Morgens von Gadow"
-    ],
-    [
-      "Miss Woodrow",
-      "Karin Abicht"
-    ],
-    [
-      "Judy Nigel",
-      "Angela Stresemann"
-    ],
-    [
-      "Direktor Grayston",
-      "Jörg Gillner"
-    ],
-    [
-      "Gregory Katic",
-      "Oliver Böttcher"
-    ],
-    [
-      "Mr. Clark",
-      "Stefan Brentle"
-    ],
-    [
-      "Tarzan",
-      "Sascha Draeger"
-    ],
-    [
-      "Mädchen",
-      "Nicola Melissian"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mr. Callister",
-      "Ingo Feder"
-    ],
-    [
-      "Lionel Pengrim",
-      "Robert Missler"
-    ],
-    [
-      "Ned",
-      "Bruno Ploeger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Andy Carson",
+      "sprecher" : "Stefan Schwade"
+    },
+    {
+      "rolle" : "Mrs. Hampton",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Nicky DeLores",
+      "sprecher" : "Mogens von Gadow"
+    },
+    {
+      "rolle" : "Mrs. Woodrow",
+      "sprecher" : "Carin Abicht"
+    },
+    {
+      "rolle" : "Judy Nigel",
+      "sprecher" : "Angela Stresemann"
+    },
+    {
+      "rolle" : "Direktor Grayston",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Gregory Katic",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Mr. Clark",
+      "sprecher" : "Stefan Brentle"
+    },
+    {
+      "rolle" : "Tarzan",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Mädchen 1",
+      "sprecher" : "Julia Fölster"
+    },
+    {
+      "rolle" : "Mädchen 2",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mr. Callister",
+      "sprecher" : "Ingo Feder"
+    },
+    {
+      "rolle" : "Lionel Pengrim",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Ned",
+      "sprecher" : "Charles Rettinghaus",
+      "pseudonym" : "Bruno Ploeger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/167/metadata.json",

--- a/web/data/Serie/168/metadata.json
+++ b/web/data/Serie/168/metadata.json
@@ -57,83 +57,83 @@
       "end" : 4675973
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Deborah",
-      "Gabi Libbach"
-    ],
-    [
-      "Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Samuel Rodman",
-      "Christian Concillio"
-    ],
-    [
-      "Benjamin Rodman",
-      "Henning Karge"
-    ],
-    [
-      "Vallery Flockheart",
-      "Caroline Kiesewetter"
-    ],
-    [
-      "Nigel Tillerman",
-      "Lutz Mackensy"
-    ],
-    [
-      "Josh Reilly",
-      "Nicholas Müller"
-    ],
-    [
-      "Lexington",
-      "Sascha Eigner"
-    ],
-    [
-      "Reporter",
-      "Rasmus Borowski"
-    ],
-    [
-      "Journalistin",
-      "Nicola Melissian"
-    ],
-    [
-      "Prescott",
-      "Rolf Becker"
-    ],
-    [
-      "Sergeant Morales",
-      "Peter Weis"
-    ],
-    [
-      "Mr. Arvidson",
-      "Gosta Liptow"
-    ],
-    [
-      "Mrs. Arvidson",
-      "Hedy Haase"
-    ],
-    [
-      "Mann",
-      "Andreas Becker"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Deborah",
+      "sprecher" : "Gabriele Libbach"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Samuel Rodman",
+      "sprecher" : "Christian Concilio"
+    },
+    {
+      "rolle" : "Benjamin Rodman",
+      "sprecher" : "Henning Karge"
+    },
+    {
+      "rolle" : "Vallery Flockheart",
+      "sprecher" : "Caroline Kiesewetter"
+    },
+    {
+      "rolle" : "Nigel Tillerman",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Josh Reilly",
+      "sprecher" : "Nicholas Müller"
+    },
+    {
+      "rolle" : "Lexington",
+      "sprecher" : "Sascha Eigner"
+    },
+    {
+      "rolle" : "Reporter",
+      "sprecher" : "Rasmus Borowski"
+    },
+    {
+      "rolle" : "Journalistin",
+      "sprecher" : "Nicolá Melissian"
+    },
+    {
+      "rolle" : "Prescott",
+      "sprecher" : "Rolf Becker"
+    },
+    {
+      "rolle" : "Sergeant Morales",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Mr. Arvidson",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Mrs. Arvidson",
+      "sprecher" : "Hedy Haase"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Andreas Becker"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/168/metadata.json",

--- a/web/data/Serie/169/metadata.json
+++ b/web/data/Serie/169/metadata.json
@@ -57,71 +57,72 @@
       "end" : 4910587
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Bradley",
-      "Nico König"
-    ],
-    [
-      "Bishop Blake",
-      "Wolf Frass"
-    ],
-    [
-      "Junge Frau",
-      "Heikedine Körting"
-    ],
-    [
-      "Derek",
-      "Tim Helssen"
-    ],
-    [
-      "Mrs. Kretschmer",
-      "Monika Werner"
-    ],
-    [
-      "Chastity",
-      "Undine Ullmer"
-    ],
-    [
-      "Charity",
-      "Kassandra Ullmer"
-    ],
-    [
-      "Sam Chiccarelli",
-      "Astrid Kollex"
-    ],
-    [
-      "Griffin Silverman",
-      "Stephan Schad"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Bradley",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Bishop Blake",
+      "sprecher" : "Wolf Frass"
+    },
+    {
+      "rolle" : "Junge Frau",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Derek",
+      "sprecher" : "Tim Helssen"
+    },
+    {
+      "rolle" : "Mrs. Kretschmer",
+      "sprecher" : "Monika Werner"
+    },
+    {
+      "rolle" : "Chastity",
+      "sprecher" : "Undine Ullmer"
+    },
+    {
+      "rolle" : "Charity",
+      "sprecher" : "Kassandra Ullmer"
+    },
+    {
+      "rolle" : "Sam Chiccarelli",
+      "sprecher" : "Astrid Kollex"
+    },
+    {
+      "rolle" : "Griffin Silverman",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/169/metadata.json",

--- a/web/data/Serie/170/metadata.json
+++ b/web/data/Serie/170/metadata.json
@@ -62,87 +62,87 @@
       "end" : 4816533
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Mitch Palmer",
-      "Michael Lott"
-    ],
-    [
-      "Dimitri",
-      "Manou Lubowski"
-    ],
-    [
-      "Roy",
-      "Gosta Liptow"
-    ],
-    [
-      "Boss",
-      "Henry König"
-    ],
-    [
-      "Cindy",
-      "Konstanze Ullmer"
-    ],
-    [
-      "Mike",
-      "Oliver Böttcher"
-    ],
-    [
-      "Wirt",
-      "Peter Lakenmacher"
-    ],
-    [
-      "Rockford",
-      "Christian Senger"
-    ],
-    [
-      "Casino-Besucher",
-      "Robin Bosch"
-    ],
-    [
-      "Casino-Besucherin",
-      "Brigitte Böttrich"
-    ],
-    [
-      "Rezeption 1",
-      "Dorothea Lott"
-    ],
-    [
-      "Rezeption 2",
-      "Marco Spina"
-    ],
-    [
-      "Fernfahrer",
-      "Tilman Madaus"
-    ],
-    [
-      "Putzfrau",
-      "Maria Baptista"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Mitch Palmer",
+      "sprecher" : "Michael Lott"
+    },
+    {
+      "rolle" : "Dimitri",
+      "sprecher" : "Manou Lubowski"
+    },
+    {
+      "rolle" : "Roy",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Boss",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Cindy",
+      "sprecher" : "Konstanze Ullmer"
+    },
+    {
+      "rolle" : "Mike",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Wirt",
+      "sprecher" : "Peter Lakenmacher"
+    },
+    {
+      "rolle" : "Rockford",
+      "sprecher" : "Christian Senger"
+    },
+    {
+      "rolle" : "Casino-Besucher",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Casino-Besucherin",
+      "sprecher" : "Brigitte Böttrich"
+    },
+    {
+      "rolle" : "Rezeption 1",
+      "sprecher" : "Dorothea Lott"
+    },
+    {
+      "rolle" : "Rezeption 2",
+      "sprecher" : "Marco Spina"
+    },
+    {
+      "rolle" : "Fernfahrer",
+      "sprecher" : "Tilman Madaus"
+    },
+    {
+      "rolle" : "Putzfrau",
+      "sprecher" : "Maria Baptista"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/170/metadata.json",

--- a/web/data/Serie/171/metadata.json
+++ b/web/data/Serie/171/metadata.json
@@ -57,91 +57,91 @@
       "end" : 4040853
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Harry Salas",
-      "Pat Murphy"
-    ],
-    [
-      "Vanessa Goodstein",
-      "Simone Ritscher"
-    ],
-    [
-      "Eliah Cristobal",
-      "Stephan Schwartz"
-    ],
-    [
-      "Albert Goodstein",
-      "Manfred Reddemann"
-    ],
-    [
-      "Ben Kramer",
-      "Jan-Christof Kick"
-    ],
-    [
-      "Fiona Kramer",
-      "Lilian Körting"
-    ],
-    [
-      "Wirt",
-      "Harald Halgardt"
-    ],
-    [
-      "Jimmy Blue Eye",
-      "Ulli Potofski"
-    ],
-    [
-      "1. Mann",
-      "Achim Schülke"
-    ],
-    [
-      "2. Mann",
-      "Fabian Harloff"
-    ],
-    [
-      "Frau",
-      "Saskia Weckler"
-    ],
-    [
-      "Rosaria",
-      "Gela del Este"
-    ],
-    [
-      "Silvie",
-      "Katharina von Keller"
-    ],
-    [
-      "Jessy",
-      "Manuela Bäcker"
-    ],
-    [
-      "Sergeant",
-      "Alexander Stamm"
-    ],
-    [
-      "Polizist",
-      "Gordon Piedesack"
-    ],
-    [
-      "Rikuo Yamamoto",
-      "Toru Takahashi"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Harry Salas",
+      "sprecher" : "Pat Murphy"
+    },
+    {
+      "rolle" : "Vanessa Goodstein",
+      "sprecher" : "Simone Ritscher"
+    },
+    {
+      "rolle" : "Eliah Cristobal",
+      "sprecher" : "Stephan Schwartz"
+    },
+    {
+      "rolle" : "Albert Goodstein",
+      "sprecher" : "Manfred Reddemann"
+    },
+    {
+      "rolle" : "Ben Kramer",
+      "sprecher" : "Jan-Christof Kick"
+    },
+    {
+      "rolle" : "Fiona Kramer",
+      "sprecher" : "Lilian Körting"
+    },
+    {
+      "rolle" : "Wirt",
+      "sprecher" : "Harald Halgardt"
+    },
+    {
+      "rolle" : "Jimmy Blue Eye",
+      "sprecher" : "Ulrich Potofski"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Fabian Harloff"
+    },
+    {
+      "rolle" : "Frau",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Rosaria",
+      "sprecher" : "Gela del Este"
+    },
+    {
+      "rolle" : "Silvie",
+      "sprecher" : "Katharina von Keller"
+    },
+    {
+      "rolle" : "Jessy",
+      "sprecher" : "Manuela Eifrig"
+    },
+    {
+      "rolle" : "Sergeant",
+      "sprecher" : "Alexander Stamm"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Rikuo Yamamoto",
+      "sprecher" : "Toru Takahashi"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/171/metadata.json",

--- a/web/data/Serie/172/metadata.json
+++ b/web/data/Serie/172/metadata.json
@@ -62,63 +62,63 @@
       "end" : 4375213
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Drago Martinez",
-      "Konstantin Graudus"
-    ],
-    [
-      "Fred Osborne",
-      "Erik Schäffler"
-    ],
-    [
-      "Cecile Jezero",
-      "Sandra Quadflieg"
-    ],
-    [
-      "Deborah",
-      "Kornelia Lüdorff"
-    ],
-    [
-      "Short",
-      "Manfred Liptow"
-    ],
-    [
-      "Anthony",
-      "Lutz Harder"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Heavy Metal",
-      "Iris Rufner"
-    ],
-    [
-      "Arthur Pepper",
-      "Frank Thannhäuser"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Drago Martinez",
+      "sprecher" : "Konstantin Graudus"
+    },
+    {
+      "rolle" : "Fred Osborne",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Cecile Jezero",
+      "sprecher" : "Sandra Quadflieg"
+    },
+    {
+      "rolle" : "Deborah",
+      "sprecher" : "Kornelia Lüdorff"
+    },
+    {
+      "rolle" : "Short",
+      "sprecher" : "Manfred Liptow"
+    },
+    {
+      "rolle" : "Anthony",
+      "sprecher" : "Lutz Harder"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Heavy Metal",
+      "sprecher" : "Iris Rufner"
+    },
+    {
+      "rolle" : "Arthur Pepper",
+      "sprecher" : "Frank Thannhäuser"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/172/metadata.json",

--- a/web/data/Serie/173/metadata.json
+++ b/web/data/Serie/173/metadata.json
@@ -57,59 +57,59 @@
       "end" : 4225213
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Rupert",
-      "Udo Schenk"
-    ],
-    [
-      "Luke",
-      "Daniel Kirchberger"
-    ],
-    [
-      "Gwendolyn Pembroke",
-      "Aranka Mamero"
-    ],
-    [
-      "Lance Vaughn",
-      "Rainer Schmitt"
-    ],
-    [
-      "'The Destroyer'",
-      "Stephan Schad"
-    ],
-    [
-      "Darby Farnham",
-      "Christine Jensen"
-    ],
-    [
-      "Earl Forrester",
-      "Tobias Schmidt"
-    ],
-    [
-      "Alvin Cray",
-      "Michael Bideller"
-    ],
-    [
-      "Mr. Lloyd",
-      "Lutz Mackensy"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Rupert",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Luke",
+      "sprecher" : "Daniel Kirchberger"
+    },
+    {
+      "rolle" : "Gwendolyn Pembroke",
+      "sprecher" : "Aranka Jaenke-Mamero"
+    },
+    {
+      "rolle" : "Lance Vaughn",
+      "sprecher" : "Rainer Schmitt"
+    },
+    {
+      "rolle" : "'The Destroyer'",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Darby Farnham",
+      "sprecher" : "Christine Jensen"
+    },
+    {
+      "rolle" : "Earl Forrester",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Alvin Cray",
+      "sprecher" : "Michael Bideller"
+    },
+    {
+      "rolle" : "Mr. Lloyd",
+      "sprecher" : "Lutz Mackensy"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/173/metadata.json",

--- a/web/data/Serie/174/metadata.json
+++ b/web/data/Serie/174/metadata.json
@@ -52,55 +52,55 @@
       "end" : 3800827
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Guillermo",
-      "Mario Ramos"
-    ],
-    [
-      "Stanley Morgan",
-      "Romanus Fuhrmann"
-    ],
-    [
-      "Grace Powell",
-      "Luise Lunow"
-    ],
-    [
-      "Angus",
-      "Till Demtrøder"
-    ],
-    [
-      "Inspektor Cottahol",
-      "Holger Mahlich"
-    ],
-    [
-      "Baxter",
-      "Hans Kahlert"
-    ],
-    [
-      "Kranführer",
-      "Klaus Dittmann"
-    ],
-    [
-      "Steve",
-      "Martin Brücker"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Guillermo",
+      "sprecher" : "Mario Ramos"
+    },
+    {
+      "rolle" : "Stanley Morgan",
+      "sprecher" : "Romanus Fuhrmann"
+    },
+    {
+      "rolle" : "Grace Powell",
+      "sprecher" : "Luise Lunow"
+    },
+    {
+      "rolle" : "Angus",
+      "sprecher" : "Till Demtrøder"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Baxter",
+      "sprecher" : "Hans Kahlert"
+    },
+    {
+      "rolle" : "Kranführer",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Steve",
+      "sprecher" : "Martin Brücker"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/174/metadata.json",

--- a/web/data/Serie/175/1/metadata.json
+++ b/web/data/Serie/175/1/metadata.json
@@ -66,99 +66,99 @@
       "end" : 3648933
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Jeremy Bright",
-      "Stephan Schad"
-    ],
-    [
-      "Taylor-Jackson",
-      "Jona Mues"
-    ],
-    [
-      "Francine Breckenridge",
-      "Elga Schütz"
-    ],
-    [
-      "A.C. Berany",
-      "Hanni Vanhaiden"
-    ],
-    [
-      "Samantha",
-      "Henrike Fehrs"
-    ],
-    [
-      "Corvy",
-      "Karen Suender"
-    ],
-    [
-      "Lemuel Garvine",
-      "Tim Grobe"
-    ],
-    [
-      "Prof. Roalstad",
-      "Jürgen Thormann"
-    ],
-    [
-      "Chris",
-      "Soi Anifantis"
-    ],
-    [
-      "Gamma",
-      "Wolfram Grandezka"
-    ],
-    [
-      "Barfrau",
-      "Rhesi Underberg"
-    ],
-    [
-      "John",
-      "Stephan Benson"
-    ],
-    [
-      "Walker",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Lederhose",
-      "Klaus Krückemeyer"
-    ],
-    [
-      "1. Polizist",
-      "Tim Kreuer"
-    ],
-    [
-      "2. Polizist",
-      "Jesse Grimm"
-    ],
-    [
-      "Telefonstimme",
-      "Wolfgang Völz"
-    ],
-    [
-      "Menge",
-      "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Jeremy Bright",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Taylor-Jackson",
+      "sprecher" : "Jona Mues"
+    },
+    {
+      "rolle" : "Francine Breckenridge",
+      "sprecher" : "Elga Schütz"
+    },
+    {
+      "rolle" : "A.C. Berany",
+      "sprecher" : "Hanni Vanhaiden"
+    },
+    {
+      "rolle" : "Samantha",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Corvy",
+      "sprecher" : "Karen Suender"
+    },
+    {
+      "rolle" : "Lemuel Garvine",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Prof. Roalstad",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Chris",
+      "sprecher" : "Soi Anifantis"
+    },
+    {
+      "rolle" : "Gamma",
+      "sprecher" : "Wolfram Grandezka"
+    },
+    {
+      "rolle" : "Barfrau",
+      "sprecher" : "Theresa Underberg"
+    },
+    {
+      "rolle" : "John",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Walker",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Lederhose",
+      "sprecher" : "Klaus Krückemeyer"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Polizist 2",
+      "sprecher" : "Jesse Grimm"
+    },
+    {
+      "rolle" : "Telefonstimme",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Menge",
+      "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/175/1/metadata.json",

--- a/web/data/Serie/175/2/metadata.json
+++ b/web/data/Serie/175/2/metadata.json
@@ -51,75 +51,75 @@
       "end" : 3434200
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Taylor-Jackson",
-      "Jona Mues"
-    ],
-    [
-      "Samantha",
-      "Henrike Fehrs"
-    ],
-    [
-      "Jason",
-      "Woody Mues"
-    ],
-    [
-      "Mrs. Roalstad",
-      "Beate Rysopp"
-    ],
-    [
-      "Prof. Roalstad",
-      "Jürgen Thormann"
-    ],
-    [
-      "Corvy",
-      "Karen Suender"
-    ],
-    [
-      "Mrs. Fernandez",
-      "Anja Topf"
-    ],
-    [
-      "Lemuel Garvine",
-      "Tim Grobe"
-    ],
-    [
-      "Emery",
-      "Peter Weis"
-    ],
-    [
-      "Ginger",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Sanitäter",
-      "Franzisko Löwe"
-    ],
-    [
-      "Schwester",
-      "Maike Nagel"
-    ],
-    [
-      "Menge",
-      "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Taylor-Jackson",
+      "sprecher" : "Jona Mues"
+    },
+    {
+      "rolle" : "Samantha",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Jason",
+      "sprecher" : "Woody Mues"
+    },
+    {
+      "rolle" : "Mrs. Roalstad",
+      "sprecher" : "Beate Rysopp"
+    },
+    {
+      "rolle" : "Prof. Roalstad",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Corvy",
+      "sprecher" : "Karen Suender"
+    },
+    {
+      "rolle" : "Mrs. Fernandez",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "Lemuel Garvine",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Emery",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Ginger",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Sanitäter",
+      "sprecher" : "Franzisko Löwe"
+    },
+    {
+      "rolle" : "Schwester",
+      "sprecher" : "Maike Nagel"
+    },
+    {
+      "rolle" : "Menge",
+      "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/175/2/metadata.json",

--- a/web/data/Serie/175/3/metadata.json
+++ b/web/data/Serie/175/3/metadata.json
@@ -46,67 +46,67 @@
       "end" : 4166493
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Taylor-Jackson",
-      "Jona Mues"
-    ],
-    [
-      "Jason",
-      "Woody Mues"
-    ],
-    [
-      "Ivy",
-      "Leonie Lander"
-    ],
-    [
-      "Prof. Haynthorb",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Mrs. Fernandez",
-      "Anja Topf"
-    ],
-    [
-      "Samantha",
-      "Henrike Fehrs"
-    ],
-    [
-      "Francine Breckenridge",
-      "Elga Schütz"
-    ],
-    [
-      "Dr. Wilcomb",
-      "Heinz Lieven"
-    ],
-    [
-      "3. Polizist",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Menge",
-      "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Taylor-Jackson",
+      "sprecher" : "Jona Mues"
+    },
+    {
+      "rolle" : "Jason",
+      "sprecher" : "Woody Mues"
+    },
+    {
+      "rolle" : "Ivy",
+      "sprecher" : "Leonie Landa"
+    },
+    {
+      "rolle" : "Prof. Haynthorb",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Mrs. Fernandez",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "Samantha",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Francine Breckenridge",
+      "sprecher" : "Elga Schütz"
+    },
+    {
+      "rolle" : "Dr. Wilcomb",
+      "sprecher" : "Heinz Lieven"
+    },
+    {
+      "rolle" : "Polizist 3",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Menge",
+      "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/175/3/metadata.json",

--- a/web/data/Serie/175/metadata.json
+++ b/web/data/Serie/175/metadata.json
@@ -69,99 +69,99 @@
           "end" : 3648933
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Jeremy Bright",
-          "Stephan Schad"
-        ],
-        [
-          "Taylor-Jackson",
-          "Jona Mues"
-        ],
-        [
-          "Francine Breckenridge",
-          "Elga Schütz"
-        ],
-        [
-          "A.C. Berany",
-          "Hanni Vanhaiden"
-        ],
-        [
-          "Samantha",
-          "Henrike Fehrs"
-        ],
-        [
-          "Corvy",
-          "Karen Suender"
-        ],
-        [
-          "Lemuel Garvine",
-          "Tim Grobe"
-        ],
-        [
-          "Prof. Roalstad",
-          "Jürgen Thormann"
-        ],
-        [
-          "Chris",
-          "Soi Anifantis"
-        ],
-        [
-          "Gamma",
-          "Wolfram Grandezka"
-        ],
-        [
-          "Barfrau",
-          "Rhesi Underberg"
-        ],
-        [
-          "John",
-          "Stephan Benson"
-        ],
-        [
-          "Walker",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Lederhose",
-          "Klaus Krückemeyer"
-        ],
-        [
-          "1. Polizist",
-          "Tim Kreuer"
-        ],
-        [
-          "2. Polizist",
-          "Jesse Grimm"
-        ],
-        [
-          "Telefonstimme",
-          "Wolfgang Völz"
-        ],
-        [
-          "Menge",
-          "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Jeremy Bright",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Taylor-Jackson",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Francine Breckenridge",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "A.C. Berany",
+          "sprecher" : "Hanni Vanhaiden"
+        },
+        {
+          "rolle" : "Samantha",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Corvy",
+          "sprecher" : "Karen Suender"
+        },
+        {
+          "rolle" : "Lemuel Garvine",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Prof. Roalstad",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Chris",
+          "sprecher" : "Soi Anifantis"
+        },
+        {
+          "rolle" : "Gamma",
+          "sprecher" : "Wolfram Grandezka"
+        },
+        {
+          "rolle" : "Barfrau",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "John",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Walker",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Lederhose",
+          "sprecher" : "Klaus Krückemeyer"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Jesse Grimm"
+        },
+        {
+          "rolle" : "Telefonstimme",
+          "sprecher" : "Wolfgang Völz"
+        },
+        {
+          "rolle" : "Menge",
+          "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/175/1/metadata.json",
@@ -222,75 +222,75 @@
           "end" : 3434200
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Taylor-Jackson",
-          "Jona Mues"
-        ],
-        [
-          "Samantha",
-          "Henrike Fehrs"
-        ],
-        [
-          "Jason",
-          "Woody Mues"
-        ],
-        [
-          "Mrs. Roalstad",
-          "Beate Rysopp"
-        ],
-        [
-          "Prof. Roalstad",
-          "Jürgen Thormann"
-        ],
-        [
-          "Corvy",
-          "Karen Suender"
-        ],
-        [
-          "Mrs. Fernandez",
-          "Anja Topf"
-        ],
-        [
-          "Lemuel Garvine",
-          "Tim Grobe"
-        ],
-        [
-          "Emery",
-          "Peter Weis"
-        ],
-        [
-          "Ginger",
-          "Heidi Schaffrath"
-        ],
-        [
-          "Sanitäter",
-          "Franzisko Löwe"
-        ],
-        [
-          "Schwester",
-          "Maike Nagel"
-        ],
-        [
-          "Menge",
-          "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Taylor-Jackson",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Samantha",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Jason",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Mrs. Roalstad",
+          "sprecher" : "Beate Rysopp"
+        },
+        {
+          "rolle" : "Prof. Roalstad",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Corvy",
+          "sprecher" : "Karen Suender"
+        },
+        {
+          "rolle" : "Mrs. Fernandez",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Lemuel Garvine",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Emery",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Ginger",
+          "sprecher" : "Heidi Schaffrath"
+        },
+        {
+          "rolle" : "Sanitäter",
+          "sprecher" : "Franzisko Löwe"
+        },
+        {
+          "rolle" : "Schwester",
+          "sprecher" : "Maike Nagel"
+        },
+        {
+          "rolle" : "Menge",
+          "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/175/2/metadata.json",
@@ -346,67 +346,67 @@
           "end" : 4166493
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Taylor-Jackson",
-          "Jona Mues"
-        ],
-        [
-          "Jason",
-          "Woody Mues"
-        ],
-        [
-          "Ivy",
-          "Leonie Lander"
-        ],
-        [
-          "Prof. Haynthorb",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mrs. Fernandez",
-          "Anja Topf"
-        ],
-        [
-          "Samantha",
-          "Henrike Fehrs"
-        ],
-        [
-          "Francine Breckenridge",
-          "Elga Schütz"
-        ],
-        [
-          "Dr. Wilcomb",
-          "Heinz Lieven"
-        ],
-        [
-          "3. Polizist",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Mr. Andrews",
-          "Henry König"
-        ],
-        [
-          "Menge",
-          "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Taylor-Jackson",
+          "sprecher" : "Jona Mues"
+        },
+        {
+          "rolle" : "Jason",
+          "sprecher" : "Woody Mues"
+        },
+        {
+          "rolle" : "Ivy",
+          "sprecher" : "Leonie Landa"
+        },
+        {
+          "rolle" : "Prof. Haynthorb",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Mrs. Fernandez",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Samantha",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Francine Breckenridge",
+          "sprecher" : "Elga Schütz"
+        },
+        {
+          "rolle" : "Dr. Wilcomb",
+          "sprecher" : "Heinz Lieven"
+        },
+        {
+          "rolle" : "Polizist 3",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Menge",
+          "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/175/3/metadata.json",
@@ -419,143 +419,143 @@
   "hörspielskriptautor" : "André Minninger",
   "beschreibung" : "Die drei Detektive bekommen eine einmalige Chance: Sie dürfen an der Universität Ruxton für ein paar Wochen das Studentenleben testen! Doch schnell wird klar, dass hier nicht nur Vorlesungen, Partys und Wohnheimzoff auf sie warten, sondern ein neuer Fall!",
   "veröffentlichungsdatum" : "2015-05-15",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Andrews",
-      "Henry König"
-    ],
-    [
-      "Jeremy Bright",
-      "Stephan Schad"
-    ],
-    [
-      "Taylor-Jackson",
-      "Jona Mues"
-    ],
-    [
-      "Francine Breckenridge",
-      "Elga Schütz"
-    ],
-    [
-      "A.C. Berany",
-      "Hanni Vanhaiden"
-    ],
-    [
-      "Samantha",
-      "Henrike Fehrs"
-    ],
-    [
-      "Corvy",
-      "Karen Suender"
-    ],
-    [
-      "Lemuel Garvine",
-      "Tim Grobe"
-    ],
-    [
-      "Prof. Roalstad",
-      "Jürgen Thormann"
-    ],
-    [
-      "Chris",
-      "Soi Anifantis"
-    ],
-    [
-      "Gamma",
-      "Wolfram Grandezka"
-    ],
-    [
-      "Barfrau",
-      "Rhesi Underberg"
-    ],
-    [
-      "John",
-      "Stephan Benson"
-    ],
-    [
-      "Walker",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Lederhose",
-      "Klaus Krückemeyer"
-    ],
-    [
-      "1. Polizist",
-      "Tim Kreuer"
-    ],
-    [
-      "2. Polizist",
-      "Jesse Grimm"
-    ],
-    [
-      "Telefonstimme",
-      "Wolfgang Völz"
-    ],
-    [
-      "Jason",
-      "Woody Mues"
-    ],
-    [
-      "Mrs. Roalstad",
-      "Beate Rysopp"
-    ],
-    [
-      "Mrs. Fernandez",
-      "Anja Topf"
-    ],
-    [
-      "Emery",
-      "Peter Weis"
-    ],
-    [
-      "Ginger",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Sanitäter",
-      "Franzisko Löwe"
-    ],
-    [
-      "Schwester",
-      "Maike Nagel"
-    ],
-    [
-      "Ivy",
-      "Leonie Lander"
-    ],
-    [
-      "Prof. Haynthorb",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Dr. Wilcomb",
-      "Heinz Lieven"
-    ],
-    [
-      "3. Polizist",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Menge",
-      "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Jeremy Bright",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Taylor-Jackson",
+      "sprecher" : "Jona Mues"
+    },
+    {
+      "rolle" : "Francine Breckenridge",
+      "sprecher" : "Elga Schütz"
+    },
+    {
+      "rolle" : "A.C. Berany",
+      "sprecher" : "Hanni Vanhaiden"
+    },
+    {
+      "rolle" : "Samantha",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Corvy",
+      "sprecher" : "Karen Suender"
+    },
+    {
+      "rolle" : "Lemuel Garvine",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Prof. Roalstad",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Chris",
+      "sprecher" : "Soi Anifantis"
+    },
+    {
+      "rolle" : "Gamma",
+      "sprecher" : "Wolfram Grandezka"
+    },
+    {
+      "rolle" : "Barfrau",
+      "sprecher" : "Theresa Underberg"
+    },
+    {
+      "rolle" : "John",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Walker",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Lederhose",
+      "sprecher" : "Klaus Krückemeyer"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Polizist 2",
+      "sprecher" : "Jesse Grimm"
+    },
+    {
+      "rolle" : "Telefonstimme",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Jason",
+      "sprecher" : "Woody Mues"
+    },
+    {
+      "rolle" : "Mrs. Roalstad",
+      "sprecher" : "Beate Rysopp"
+    },
+    {
+      "rolle" : "Mrs. Fernandez",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "Emery",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Ginger",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Sanitäter",
+      "sprecher" : "Franzisko Löwe"
+    },
+    {
+      "rolle" : "Schwester",
+      "sprecher" : "Maike Nagel"
+    },
+    {
+      "rolle" : "Ivy",
+      "sprecher" : "Leonie Landa"
+    },
+    {
+      "rolle" : "Prof. Haynthorb",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Dr. Wilcomb",
+      "sprecher" : "Heinz Lieven"
+    },
+    {
+      "rolle" : "Polizist 3",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Menge",
+      "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/175/metadata.json",

--- a/web/data/Serie/176/metadata.json
+++ b/web/data/Serie/176/metadata.json
@@ -67,59 +67,59 @@
       "end" : 4064107
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Sidney",
-      "Dorothee Sturz"
-    ],
-    [
-      "Tiffany",
-      "Maureen Havlena"
-    ],
-    [
-      "Salma Hutchinson",
-      "Tina Eschmann"
-    ],
-    [
-      "Trevor Pomery",
-      "Ben Hecker"
-    ],
-    [
-      "Beatrice",
-      "Ursula Sieg"
-    ],
-    [
-      "Claire",
-      "Karin Eckhold"
-    ],
-    [
-      "Pflegerin",
-      "Susanne Wulkow"
-    ],
-    [
-      "Roger Wolf",
-      "Stephan Schad"
-    ],
-    [
-      "Menge Fußballstadion",
-      "Die Gäste der Record-Release-Party am 22.02.2015 in Dortmund. (Wir danken euch für's Mitmachen!)"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Sidney",
+      "sprecher" : "Dorothee Sturz"
+    },
+    {
+      "rolle" : "Tiffany",
+      "sprecher" : "Maureen Havlena"
+    },
+    {
+      "rolle" : "Salma Hutchinson",
+      "sprecher" : "Tina Eschmann"
+    },
+    {
+      "rolle" : "Trevor Pomery",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Beatrice",
+      "sprecher" : "Ursula Sieg"
+    },
+    {
+      "rolle" : "Claire",
+      "sprecher" : "Karin Eckhold"
+    },
+    {
+      "rolle" : "Pflegerin",
+      "sprecher" : "Susanne Wulkow"
+    },
+    {
+      "rolle" : "Roger Wolf",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Menge Fußballstadion",
+      "sprecher" : "Die Gäste der Record-Release-Party am 22.02.2015 in Dortmund. (Wir danken euch für's Mitmachen!)"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/176/metadata.json",

--- a/web/data/Serie/177/metadata.json
+++ b/web/data/Serie/177/metadata.json
@@ -52,59 +52,59 @@
       "end" : 4121080
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Dusty Kirkpatrick",
-      "Hans Kahlert"
-    ],
-    [
-      "Miranda Kramer",
-      "Susanne Sternberg"
-    ],
-    [
-      "Barclay",
-      "Horst Stark"
-    ],
-    [
-      "Brian",
-      "Volker Hanisch"
-    ],
-    [
-      "Raven",
-      "Neda Rahmanian"
-    ],
-    [
-      "Dr. Hardwick",
-      "Till Huster"
-    ],
-    [
-      "Robert",
-      "Tim Kreuer"
-    ],
-    [
-      "Manolo",
-      "Wolfgang Berger"
-    ],
-    [
-      "Polizist",
-      "Kai-Hendrik Möller"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Dusty Kirkpatrick",
+      "sprecher" : "Hans Kahlert"
+    },
+    {
+      "rolle" : "Miranda Kramer",
+      "sprecher" : "Susanne Sternberg"
+    },
+    {
+      "rolle" : "Barclay",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Brian",
+      "sprecher" : "Volker Hanisch"
+    },
+    {
+      "rolle" : "Raven",
+      "sprecher" : "Neda Rahmanian"
+    },
+    {
+      "rolle" : "Dr. Hardwick",
+      "sprecher" : "Till Huster"
+    },
+    {
+      "rolle" : "Robert",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Manolo",
+      "sprecher" : "Wolfgang Berger"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Kai Henrik Möller"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/177/metadata.json",

--- a/web/data/Serie/178/metadata.json
+++ b/web/data/Serie/178/metadata.json
@@ -52,51 +52,51 @@
       "end" : 3955933
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Barbara Mathewson",
-      "Tanja Geke"
-    ],
-    [
-      "Zacharias Faring",
-      "Olaf Reichmann"
-    ],
-    [
-      "Malone",
-      "Tilo Schmitz"
-    ],
-    [
-      "Ben Crane",
-      "Christian Rudolf"
-    ],
-    [
-      "Timothy Jackson",
-      "Nicolas König"
-    ],
-    [
-      "Reginald",
-      "Tobias Schmidt"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Barbara Mathewson",
+      "sprecher" : "Tanja Geke"
+    },
+    {
+      "rolle" : "Zacharias Faring",
+      "sprecher" : "Olaf Reichmann"
+    },
+    {
+      "rolle" : "Malone",
+      "sprecher" : "Tilo Schmitz"
+    },
+    {
+      "rolle" : "Ben Crane",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Timothy Jackson",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Reginald",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/178/metadata.json",

--- a/web/data/Serie/179/metadata.json
+++ b/web/data/Serie/179/metadata.json
@@ -47,71 +47,71 @@
       "end" : 4297960
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Evander Whiteside",
-      "Claus Wilcke"
-    ],
-    [
-      "Wendy Brown",
-      "Catrin Owerfeldt"
-    ],
-    [
-      "Christopher Barclay",
-      "Martin Paas"
-    ],
-    [
-      "Edgar Bristol",
-      "Sascha Gutzeit"
-    ],
-    [
-      "Carter Godfrey",
-      "Nicolas König"
-    ],
-    [
-      "Chuck Foster",
-      "Heiko Wohlgemuth"
-    ],
-    [
-      "Busfahrer Sam",
-      "Achim Schülke"
-    ],
-    [
-      "Officer Ossietzky",
-      "Romanus Fuhrmann"
-    ],
-    [
-      "Matt",
-      "Mike Olsowski"
-    ],
-    [
-      "Stephen",
-      "Alexander Kruuse-Mettin"
-    ],
-    [
-      "Billy",
-      "Tom Pidde"
-    ],
-    [
-      "Polizist Jerry",
-      "Stefan Weißenburger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Evander Whiteside",
+      "sprecher" : "Claus Wilcke"
+    },
+    {
+      "rolle" : "Wendy Brown",
+      "sprecher" : "Catrin Owerfeldt"
+    },
+    {
+      "rolle" : "Christopher Barclay",
+      "sprecher" : "Martin Paas"
+    },
+    {
+      "rolle" : "Edgar Bristol",
+      "sprecher" : "Sascha Gutzeit"
+    },
+    {
+      "rolle" : "Carter Godfrey",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Chuck Foster",
+      "sprecher" : "Heiko Wohlgemuth"
+    },
+    {
+      "rolle" : "Busfahrer Sam",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Officer Ossietzky",
+      "sprecher" : "Romanus Fuhrmann"
+    },
+    {
+      "rolle" : "Matt",
+      "sprecher" : "Mike Olsowski"
+    },
+    {
+      "rolle" : "Stephen",
+      "sprecher" : "Alexander Mettin"
+    },
+    {
+      "rolle" : "Billy",
+      "sprecher" : "Tom Pidde"
+    },
+    {
+      "rolle" : "Polizist Jerry",
+      "sprecher" : "Stefan Weißenburger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/179/metadata.json",

--- a/web/data/Serie/180/metadata.json
+++ b/web/data/Serie/180/metadata.json
@@ -47,59 +47,59 @@
       "end" : 4667840
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Michael Rompa",
-      "Mario Ramos"
-    ],
-    [
-      "Afton",
-      "Julia Fölster"
-    ],
-    [
-      "Skinny Norris",
-      "Michael Harck"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Chef",
-      "Eric Schäffler"
-    ],
-    [
-      "Ron",
-      "Gordon Piedesack"
-    ],
-    [
-      "Ansage",
-      "Joachim Langer"
-    ],
-    [
-      "Oma",
-      "Renate Pichler"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Michael Rompa",
+      "sprecher" : "Mario Ramos"
+    },
+    {
+      "rolle" : "Afton",
+      "sprecher" : "Julia Fölster"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Michael Harck"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Chef",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Ron",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Ansage",
+      "sprecher" : "Joachim Langer"
+    },
+    {
+      "rolle" : "Oma",
+      "sprecher" : "Renate Pichler"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/180/metadata.json",

--- a/web/data/Serie/181/metadata.json
+++ b/web/data/Serie/181/metadata.json
@@ -47,75 +47,75 @@
       "end" : 4413560
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Quinn",
-      "Tobias Diakow"
-    ],
-    [
-      "Nightingale",
-      "Jürgen Thormann"
-    ],
-    [
-      "Pablo",
-      "Till Huster"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Thompson",
-      "Ingeborg Kallweit"
-    ],
-    [
-      "Mrs. Kato",
-      "Dorothea Hagena"
-    ],
-    [
-      "Sullivan",
-      "Jonas Hartmann"
-    ],
-    [
-      "Angelina",
-      "Norma Draeger"
-    ],
-    [
-      "Joshua",
-      "Hugo Richert"
-    ],
-    [
-      "1. Junge",
-      "Louis Körting"
-    ],
-    [
-      "2. Junge",
-      "Henrik Bichels"
-    ],
-    [
-      "Mädchen",
-      "Lilian Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Quinn",
+      "sprecher" : "Tobias Diakow"
+    },
+    {
+      "rolle" : "Nightingale",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Pablo",
+      "sprecher" : "Till Huster"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Thompson",
+      "sprecher" : "Ingeborg Kallweit"
+    },
+    {
+      "rolle" : "Mrs. Kato",
+      "sprecher" : "Dorothea Hagena"
+    },
+    {
+      "rolle" : "Sullivan",
+      "sprecher" : "Jonas Hartmann"
+    },
+    {
+      "rolle" : "Angelina",
+      "sprecher" : "Norma Draeger"
+    },
+    {
+      "rolle" : "Joshua",
+      "sprecher" : "Hugo Richert"
+    },
+    {
+      "rolle" : "Junge 1",
+      "sprecher" : "Louis Körting"
+    },
+    {
+      "rolle" : "Junge 2",
+      "sprecher" : "Henrik Bichels"
+    },
+    {
+      "rolle" : "Mädchen",
+      "sprecher" : "Lilian Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/181/metadata.json",

--- a/web/data/Serie/182/metadata.json
+++ b/web/data/Serie/182/metadata.json
@@ -42,99 +42,99 @@
       "end" : 4546493
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Shaw",
-      "Heikedine Körting"
-    ],
-    [
-      "Randy Carlisle",
-      "Johannes Semm"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Godween",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Polizist",
-      "Christoph Meyer"
-    ],
-    [
-      "Mia",
-      "Elea Richert"
-    ],
-    [
-      "Mrs. Crouch",
-      "Pia Werfel"
-    ],
-    [
-      "Rosemarie Wohlbauer",
-      "Rosemarie Wohlbauer"
-    ],
-    [
-      "Shinefield, Edna",
-      "Edna Shinefield"
-    ],
-    [
-      "George",
-      "Gordon Piedesack"
-    ],
-    [
-      "Ronny",
-      "Anton Pleva"
-    ],
-    [
-      "Loreen",
-      "Barbara Schipper"
-    ],
-    [
-      "TV-Moderatorin",
-      "Dagmar Berghoff"
-    ],
-    [
-      "Daphne",
-      "Enie van de Meiklokjes"
-    ],
-    [
-      "Kiera",
-      "Isabella Grothe"
-    ],
-    [
-      "Luther Litti",
-      "Wolf Frass"
-    ],
-    [
-      "Kyle Caldwell",
-      "Joachim Kretzer"
-    ],
-    [
-      "Hay",
-      "Tobias Diakow"
-    ],
-    [
-      "Junge",
-      "Hugo Richert"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Shaw",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Randy Carlisle",
+      "sprecher" : "Johannes Semm"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Busfahrer",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Christoph Meyer"
+    },
+    {
+      "rolle" : "Mia",
+      "sprecher" : "Elea Richert"
+    },
+    {
+      "rolle" : "Mrs. Crouch",
+      "sprecher" : "Pia Werfel"
+    },
+    {
+      "rolle" : "Edna Shinefield",
+      "sprecher" : "Rosemarie Wohlbauer"
+    },
+    {
+      "rolle" : "George",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Ronny",
+      "sprecher" : "Anton Pleva"
+    },
+    {
+      "rolle" : "Loreen",
+      "sprecher" : "Barbara Schipper"
+    },
+    {
+      "rolle" : "TV-Moderatorin",
+      "sprecher" : "Dagmar Berghoff"
+    },
+    {
+      "rolle" : "Daphne",
+      "sprecher" : "Enie van de Meiklokjes"
+    },
+    {
+      "rolle" : "Kiera",
+      "sprecher" : "Isabella Grothe"
+    },
+    {
+      "rolle" : "Luther Litti",
+      "sprecher" : "Wolf Frass"
+    },
+    {
+      "rolle" : "Kyle Caldwell",
+      "sprecher" : "Joachim Kretzer"
+    },
+    {
+      "rolle" : "Hay",
+      "sprecher" : "Tobias Diakow"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "Hugo Richert"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/182/metadata.json",

--- a/web/data/Serie/183/metadata.json
+++ b/web/data/Serie/183/metadata.json
@@ -47,83 +47,83 @@
       "end" : 4566333
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Lenny The Rock",
-      "Peter Kirchberger"
-    ],
-    [
-      "Sue Tamara",
-      "Maria Hartmann"
-    ],
-    [
-      "Sax Sandler",
-      "Christian Concilio"
-    ],
-    [
-      "Tim Durnell",
-      "Douglas Welbat"
-    ],
-    [
-      "Ron",
-      "Gosta Liptow"
-    ],
-    [
-      "Keith",
-      "Tobias Schmidt"
-    ],
-    [
-      "Debbie Peterson",
-      "Maud Ackermann"
-    ],
-    [
-      "Frank Wheeler",
-      "Timo Wenzel"
-    ],
-    [
-      "Joe",
-      "Stefan Brönneke"
-    ],
-    [
-      "Clayton",
-      "Gordon Piedesack"
-    ],
-    [
-      "Kellnerin",
-      "Simona Pahl"
-    ],
-    [
-      "Partygäste",
-      "Die Gäste der Record-Release-Party am 8. Mai 2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Lenny The Rock",
+      "sprecher" : "Peter Kirchberger"
+    },
+    {
+      "rolle" : "Sue Tamara",
+      "sprecher" : "Maria Hartmann"
+    },
+    {
+      "rolle" : "Sax Sandler",
+      "sprecher" : "Christian Concilio"
+    },
+    {
+      "rolle" : "Tim Durnell",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Ron",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Keith",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Debbie Peterson",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Frank Wheeler",
+      "sprecher" : "Timo Alexander Wenzel"
+    },
+    {
+      "rolle" : "Joe",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Clayton",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Kellnerin",
+      "sprecher" : "Simona Pahl"
+    },
+    {
+      "rolle" : "Partygäste",
+      "sprecher" : "Die Gäste der Record-Release-Party am 08.05.2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/183/metadata.json",

--- a/web/data/Serie/184/metadata.json
+++ b/web/data/Serie/184/metadata.json
@@ -37,79 +37,79 @@
       "end" : 4139387
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jesse",
-      "Jacob Weigert"
-    ],
-    [
-      "Trainer",
-      "Till Huster"
-    ],
-    [
-      "Jaden",
-      "Flemming Draeger"
-    ],
-    [
-      "Joshua",
-      "Louis Körting"
-    ],
-    [
-      "April",
-      "Lilli Körting"
-    ],
-    [
-      "Autumn",
-      "Sabrina Heuer-Diakow"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Charles Morland",
-      "Horst Stark"
-    ],
-    [
-      "Tanika Frost",
-      "Isabella Grothe"
-    ],
-    [
-      "Savannah Frost",
-      "Christiane Leuchtmann"
-    ],
-    [
-      "Dennis Frost",
-      "Sascha Oliver Bauer"
-    ],
-    [
-      "Jane Thompson",
-      "Maud Ackermann"
-    ],
-    [
-      "Tyler",
-      "Christian Rudolf"
-    ],
-    [
-      "Gardener",
-      "Christian Concilio"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jesse",
+      "sprecher" : "Jacob Weigert"
+    },
+    {
+      "rolle" : "Trainer",
+      "sprecher" : "Till Huster"
+    },
+    {
+      "rolle" : "Jaden",
+      "sprecher" : "Flemming Draeger"
+    },
+    {
+      "rolle" : "Joshua",
+      "sprecher" : "Louis Körting"
+    },
+    {
+      "rolle" : "April",
+      "sprecher" : "Lilli Körting"
+    },
+    {
+      "rolle" : "Autumn",
+      "sprecher" : "Sabrina Heuer-Diakow"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Charles Morland",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Tanika Frost",
+      "sprecher" : "Isabella Grothe"
+    },
+    {
+      "rolle" : "Savannah Frost",
+      "sprecher" : "Christiane Leuchtmann"
+    },
+    {
+      "rolle" : "Dennis Frost",
+      "sprecher" : "Sascha Oliver Bauer"
+    },
+    {
+      "rolle" : "Jane Thompson",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Tyler",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Gardener",
+      "sprecher" : "Christian Concilio"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/184/metadata.json",

--- a/web/data/Serie/185/metadata.json
+++ b/web/data/Serie/185/metadata.json
@@ -52,71 +52,71 @@
       "end" : 3685613
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Adam Quinn",
-      "Romanus Fuhrmann"
-    ],
-    [
-      "Mr. Carrington",
-      "Martin May"
-    ],
-    [
-      "Mrs. Carrington",
-      "Manuela Dahm-Mauerhofer"
-    ],
-    [
-      "Liza Hawkins",
-      "Lucia Angela Mahler"
-    ],
-    [
-      "Mr. Hawkins",
-      "Achim Schülke"
-    ],
-    [
-      "Mrs. Hawkins",
-      "Birte Kretschmer"
-    ],
-    [
-      "Leslie Logue-Smith",
-      "Uschi Hugo"
-    ],
-    [
-      "Schauspieler",
-      "Erik Schäffler"
-    ],
-    [
-      "Britney Rogers",
-      "Theresa Berlage"
-    ],
-    [
-      "Sanitäter",
-      "Oliver Böttcher"
-    ],
-    [
-      "Mr. Sisko",
-      "Daniel Welbat"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Adam Quinn",
+      "sprecher" : "Romanus Fuhrmann"
+    },
+    {
+      "rolle" : "Mr. Carrington",
+      "sprecher" : "Martin May"
+    },
+    {
+      "rolle" : "Mrs. Carrington",
+      "sprecher" : "Manuela Dahm"
+    },
+    {
+      "rolle" : "Liza Hawkins",
+      "sprecher" : "Lucia-Angelina Mahler"
+    },
+    {
+      "rolle" : "Mr. Hawkins",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Mrs. Hawkins",
+      "sprecher" : "Birte Kretschmer"
+    },
+    {
+      "rolle" : "Leslie Logue-Smith",
+      "sprecher" : "Uschi Hugo"
+    },
+    {
+      "rolle" : "Schauspieler",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Britney Rogers",
+      "sprecher" : "Theresa Berlage"
+    },
+    {
+      "rolle" : "Sanitäter",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Mr. Sisko",
+      "sprecher" : "Daniel Welbat"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/185/metadata.json",

--- a/web/data/Serie/186/metadata.json
+++ b/web/data/Serie/186/metadata.json
@@ -47,71 +47,71 @@
       "end" : 4356747
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ben Peck",
-      "Wolfgang Völz"
-    ],
-    [
-      "Sandra",
-      "Maureen Havlena"
-    ],
-    [
-      "TV-Nachrichtensprecher",
-      "Holger Wemhoff"
-    ],
-    [
-      "Mr. Castro",
-      "Jürgen Thormann"
-    ],
-    [
-      "Doktor Burke",
-      "Hans Peter Korff"
-    ],
-    [
-      "Mrs. Penny",
-      "Herma Koehn"
-    ],
-    [
-      "Schwester Beatrice",
-      "Roswitha Völz"
-    ],
-    [
-      "Mr. Hooper",
-      "Günther Karl"
-    ],
-    [
-      "Ellyn Djawadi",
-      "Anika Pages"
-    ],
-    [
-      "Mr. Turner",
-      "Klaus Dittmann"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Goodween",
-      "André Minninger"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ben Peck",
+      "sprecher" : "Wolfgang Völz"
+    },
+    {
+      "rolle" : "Sandra",
+      "sprecher" : "Maureen Havlena"
+    },
+    {
+      "rolle" : "TV-Nachrichtensprecher",
+      "sprecher" : "Holger Wemhoff"
+    },
+    {
+      "rolle" : "Mr. Castro",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Doktor Burke",
+      "sprecher" : "Hans Peter Korff"
+    },
+    {
+      "rolle" : "Mrs. Penny",
+      "sprecher" : "Herma Koehn"
+    },
+    {
+      "rolle" : "Schwester Beatrice",
+      "sprecher" : "Roswitha Völz"
+    },
+    {
+      "rolle" : "Mr. Hooper",
+      "sprecher" : "Günther Karl"
+    },
+    {
+      "rolle" : "Ellyn Djawadi",
+      "sprecher" : "Annika Pages"
+    },
+    {
+      "rolle" : "Mr. Turner",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/186/metadata.json",

--- a/web/data/Serie/187/metadata.json
+++ b/web/data/Serie/187/metadata.json
@@ -52,75 +52,75 @@
       "end" : 4036133
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Kramer",
-      "Volker Bogdan"
-    ],
-    [
-      "Emma Bailey",
-      "Hansi Jochmann"
-    ],
-    [
-      "Hank",
-      "Ben Hecker"
-    ],
-    [
-      "Lewis Geriwell",
-      "Frank Gustavus"
-    ],
-    [
-      "Henry Appleton",
-      "Peter Heeckt"
-    ],
-    [
-      "Amber",
-      "Sarah Madeleine Tusk"
-    ],
-    [
-      "Laura",
-      "Maud Ackermann"
-    ],
-    [
-      "Gerald",
-      "Michael von Rospatt"
-    ],
-    [
-      "Nat",
-      "Tobias Schmidt"
-    ],
-    [
-      "Collins",
-      "Gosta Liptow"
-    ],
-    [
-      "Nader Rope",
-      "Michael Bideller"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Kramer",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "Emma Bailey",
+      "sprecher" : "Hansi Jochmann"
+    },
+    {
+      "rolle" : "Hank",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Lewis Geriwell",
+      "sprecher" : "Frank Gustavus"
+    },
+    {
+      "rolle" : "Henry Appleton",
+      "sprecher" : "Peter Heeckt"
+    },
+    {
+      "rolle" : "Amber",
+      "sprecher" : "Sarah Madeleine Tusk"
+    },
+    {
+      "rolle" : "Laura",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Gerald",
+      "sprecher" : "Michael von Rospatt"
+    },
+    {
+      "rolle" : "Nat",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Collins",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Nader Rope",
+      "sprecher" : "Michael Bideller"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/187/metadata.json",

--- a/web/data/Serie/188/metadata.json
+++ b/web/data/Serie/188/metadata.json
@@ -57,71 +57,71 @@
       "end" : 4807547
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Clarissa Franklin",
-      "Judy Winter"
-    ],
-    [
-      "Laura Stryker",
-      "Regina Lemnitz"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Anruferin",
-      "Topsy Küppers"
-    ],
-    [
-      "Anrufer",
-      "Oliver Kalkofe"
-    ],
-    [
-      "Regisseur",
-      "Nikolas Tantsoukes"
-    ],
-    [
-      "Stephen",
-      "Timo Hempel"
-    ],
-    [
-      "Redakteurin",
-      "Reinhilt Schneider"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Sax Sandler",
-      "Christian Concilio"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Clarissa Franklin",
+      "sprecher" : "Judy Winter"
+    },
+    {
+      "rolle" : "Laura Stryker",
+      "sprecher" : "Regina Lemnitz"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Anruferin",
+      "sprecher" : "Topsy Küppers"
+    },
+    {
+      "rolle" : "Anrufer",
+      "sprecher" : "Oliver Kalkofe"
+    },
+    {
+      "rolle" : "Regisseur",
+      "sprecher" : "Nikolas Tantsoukes"
+    },
+    {
+      "rolle" : "Stephen",
+      "sprecher" : "Timo Hempel"
+    },
+    {
+      "rolle" : "Redakteurin",
+      "sprecher" : "Reinhilt Schneider"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Sax Sandler",
+      "sprecher" : "Christian Concilio"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/188/metadata.json",

--- a/web/data/Serie/189/metadata.json
+++ b/web/data/Serie/189/metadata.json
@@ -47,67 +47,67 @@
       "end" : 3917560
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Whitty",
-      "Claus Wilcke"
-    ],
-    [
-      "Hank",
-      "Robert Missler"
-    ],
-    [
-      "Cowboy Dick",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Mr. Arbuthnott",
-      "Eckart Dux"
-    ],
-    [
-      "Mrs. Lockwood",
-      "Ingeborg Kallweit"
-    ],
-    [
-      "Linda",
-      "Svenja Pages"
-    ],
-    [
-      "Roger",
-      "Christian Stark"
-    ],
-    [
-      "Mann",
-      "Gernot Endemann"
-    ],
-    [
-      "Einsatzleiter",
-      "Achim Schülke"
-    ],
-    [
-      "Polizist",
-      "Alexander Mettin"
-    ],
-    [
-      "Mechaniker",
-      "Joachim Kretzer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Whitty",
+      "sprecher" : "Claus Wilcke"
+    },
+    {
+      "rolle" : "Hank",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Cowboy Dick",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Mr. Arbuthnott",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Mrs. Lockwood",
+      "sprecher" : "Ingeborg Kallweit"
+    },
+    {
+      "rolle" : "Linda",
+      "sprecher" : "Svenja Pages"
+    },
+    {
+      "rolle" : "Roger",
+      "sprecher" : "Christian Stark"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Gernot Endemann"
+    },
+    {
+      "rolle" : "Einsatzleiter",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Alexander Mettin"
+    },
+    {
+      "rolle" : "Mechaniker",
+      "sprecher" : "Joachim Kretzer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/189/metadata.json",

--- a/web/data/Serie/190/metadata.json
+++ b/web/data/Serie/190/metadata.json
@@ -37,55 +37,55 @@
       "end" : 3834400
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Jeff Ranaldo",
-      "Till Huster"
-    ],
-    [
-      "Mr. McBrandon",
-      "Rainer Brandt"
-    ],
-    [
-      "Sandy",
-      "Anna Carlsson"
-    ],
-    [
-      "Roboter",
-      "Joachim Kretzer"
-    ],
-    [
-      "Computerstimme",
-      "Hansi Jochmann"
-    ],
-    [
-      "Bruce Torino",
-      "Michael Lott"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Jeff Ranaldo",
+      "sprecher" : "Till Huster"
+    },
+    {
+      "rolle" : "Mr. McBrandon",
+      "sprecher" : "Rainer Brandt"
+    },
+    {
+      "rolle" : "Sandy",
+      "sprecher" : "Anna Carlsson"
+    },
+    {
+      "rolle" : "Roboter",
+      "sprecher" : "Joachim Kretzer"
+    },
+    {
+      "rolle" : "Computerstimme",
+      "sprecher" : "Hansi Jochmann"
+    },
+    {
+      "rolle" : "Bruce Torino",
+      "sprecher" : "Michael Lott"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/190/metadata.json",

--- a/web/data/Serie/191/metadata.json
+++ b/web/data/Serie/191/metadata.json
@@ -47,51 +47,51 @@
       "end" : 4266120
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Priscilla Sicktree",
-      "Marianne Bernhardt"
-    ],
-    [
-      "Hank",
-      "Henry König"
-    ],
-    [
-      "Brian",
-      "Patrick Mölleken"
-    ],
-    [
-      "Ashlyn",
-      "Julia Fölster"
-    ],
-    [
-      "Rosie Wrenwick",
-      "Gerlinde Dillge"
-    ],
-    [
-      "Sheriff Stone",
-      "Horst Stark"
-    ],
-    [
-      "Hilfssheriff Jonathan",
-      "Christian Rudolf"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Priscilla Sicktree",
+      "sprecher" : "Marianne Bernhardt"
+    },
+    {
+      "rolle" : "Hank",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Brian",
+      "sprecher" : "Patrick Mölleken"
+    },
+    {
+      "rolle" : "Ashlyn",
+      "sprecher" : "Julia Fölster"
+    },
+    {
+      "rolle" : "Rosie Wrenwick",
+      "sprecher" : "Gerlinde Dillge"
+    },
+    {
+      "rolle" : "Sheriff Stone",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Hilfssheriff Jonathan",
+      "sprecher" : "Christian Rudolf"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/191/metadata.json",

--- a/web/data/Serie/192/metadata.json
+++ b/web/data/Serie/192/metadata.json
@@ -47,63 +47,63 @@
       "end" : 4081427
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Zuko",
-      "Kostja Ullmann"
-    ],
-    [
-      "Katara",
-      "Mitsue Kono"
-    ],
-    [
-      "Xiang Than",
-      "Horst Naumann"
-    ],
-    [
-      "Fan Quoc",
-      "Christine Wilhelmi"
-    ],
-    [
-      "Fan Yuen",
-      "Frank Gustavus"
-    ],
-    [
-      "Dealerin",
-      "Barbara Schipper"
-    ],
-    [
-      "1. Chinese",
-      "Frank Richartz"
-    ],
-    [
-      "2. Chinese",
-      "Erik Schäffler"
-    ],
-    [
-      "Fan Hao",
-      "Gerd Baltus"
-    ],
-    [
-      "Einlass",
-      "Matti Schmidt-Schaller"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Zuko",
+      "sprecher" : "Kostja Ullmann"
+    },
+    {
+      "rolle" : "Katara",
+      "sprecher" : "Mitsue Kono"
+    },
+    {
+      "rolle" : "Xiang Than",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Fan Quoc",
+      "sprecher" : "Christine Wilhelmi"
+    },
+    {
+      "rolle" : "Fan Yuen",
+      "sprecher" : "Frank Gustavus"
+    },
+    {
+      "rolle" : "Dealerin",
+      "sprecher" : "Barbara Schipper"
+    },
+    {
+      "rolle" : "Chinese 1",
+      "sprecher" : "Frank Richartz"
+    },
+    {
+      "rolle" : "Chinese 2",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Fan Hao",
+      "sprecher" : "Gerd Baltus"
+    },
+    {
+      "rolle" : "Einlass",
+      "sprecher" : "Matti Schmidt-Schaller"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/192/metadata.json",

--- a/web/data/Serie/193/metadata.json
+++ b/web/data/Serie/193/metadata.json
@@ -47,83 +47,83 @@
       "end" : 4183227
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Angler",
-      "Stephan Chrzescinski"
-    ],
-    [
-      "Mac Anderson",
-      "Achim Buch"
-    ],
-    [
-      "Reporterin",
-      "Marion Gretchen Schmitz"
-    ],
-    [
-      "Mann",
-      "Sven Dahlem"
-    ],
-    [
-      "Grady",
-      "Werner Wilkening"
-    ],
-    [
-      "Pettengill",
-      "Peter Kirchberger"
-    ],
-    [
-      "Sheriff Rolins",
-      "Tommi Piper"
-    ],
-    [
-      "Farragut",
-      "Hanns Jörg Krumpholz"
-    ],
-    [
-      "Leah",
-      "Antje Birnbaum"
-    ],
-    [
-      "Cynthia Wetmore",
-      "Dorothea Hagena"
-    ],
-    [
-      "Hotelier",
-      "Gordon Piedesack"
-    ],
-    [
-      "Frau",
-      "Maud Ackermann"
-    ],
-    [
-      "Junge",
-      "Tim Heuer"
-    ],
-    [
-      "Daniel",
-      "Jannik Schümann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Angler",
+      "sprecher" : "Stephan Chrzescinski"
+    },
+    {
+      "rolle" : "Mac Anderson",
+      "sprecher" : "Achim Buch"
+    },
+    {
+      "rolle" : "Reporterin",
+      "sprecher" : "Marion Gretchen Schmitz"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Sven Dahlem"
+    },
+    {
+      "rolle" : "Grady",
+      "sprecher" : "Werner Wilkening"
+    },
+    {
+      "rolle" : "Pettengill",
+      "sprecher" : "Peter Kirchberger"
+    },
+    {
+      "rolle" : "Sheriff Rolins",
+      "sprecher" : "Tommi Piper"
+    },
+    {
+      "rolle" : "Farragut",
+      "sprecher" : "Hanns Jörg Krumpholz"
+    },
+    {
+      "rolle" : "Leah",
+      "sprecher" : "Antje Birnbaum"
+    },
+    {
+      "rolle" : "Cynthia Wetmore",
+      "sprecher" : "Dorothea Hagena"
+    },
+    {
+      "rolle" : "Hotelier",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Frau",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "Tim Heuer"
+    },
+    {
+      "rolle" : "Daniel",
+      "sprecher" : "Jannik Schümann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/193/metadata.json",

--- a/web/data/Serie/194/metadata.json
+++ b/web/data/Serie/194/metadata.json
@@ -47,79 +47,79 @@
       "end" : 4616840
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Gladys Pixie",
-      "Rosemarie Wohlbauer"
-    ],
-    [
-      "Frank Firhouse",
-      "Lutz Mackensy"
-    ],
-    [
-      "Maggie Smith",
-      "Susanne Wulkow"
-    ],
-    [
-      "Aurora",
-      "Andreja Schneider"
-    ],
-    [
-      "Angela",
-      "Lucia Mahler"
-    ],
-    [
-      "Conchita Dominguez",
-      "Katja Brügger"
-    ],
-    [
-      "Reporter",
-      "Jörgpeter von Clarenau"
-    ],
-    [
-      "Putzfrau",
-      "Clarissa Börner"
-    ],
-    [
-      "Heather",
-      "Enie van de Meiklokjes"
-    ],
-    [
-      "Folder",
-      "Harald Weiler"
-    ],
-    [
-      "Hopper",
-      "Achim Schülke"
-    ],
-    [
-      "Rezeptionist",
-      "Christopher Hoseit"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Gladys Pixie",
+      "sprecher" : "Rosemarie Wohlbauer"
+    },
+    {
+      "rolle" : "Frank Firhouse",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Maggie Smith",
+      "sprecher" : "Susanne Wulkow"
+    },
+    {
+      "rolle" : "Aurora",
+      "sprecher" : "Andreja Schneider"
+    },
+    {
+      "rolle" : "Angela",
+      "sprecher" : "Lucia-Angelina Mahler"
+    },
+    {
+      "rolle" : "Conchita Dominguez",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Reporter",
+      "sprecher" : "Jörgpeter Ahlers"
+    },
+    {
+      "rolle" : "Putzfrau",
+      "sprecher" : "Clarissa Börner"
+    },
+    {
+      "rolle" : "Heather",
+      "sprecher" : "Enie van de Meiklokjes"
+    },
+    {
+      "rolle" : "Folder",
+      "sprecher" : "Harald Weiler"
+    },
+    {
+      "rolle" : "Hopper",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Rezeptionist",
+      "sprecher" : "Christopher Hoseit"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/194/metadata.json",

--- a/web/data/Serie/195/metadata.json
+++ b/web/data/Serie/195/metadata.json
@@ -42,55 +42,55 @@
       "end" : 4503053
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Wally Robertson",
-      "Michael Prelle"
-    ],
-    [
-      "Charmayne Robertson",
-      "Daniela Hoffmann"
-    ],
-    [
-      "Dwaight Hayward",
-      "Gordon Piedesack"
-    ],
-    [
-      "Mrs. Flagstaff",
-      "Sabine Hahn"
-    ],
-    [
-      "Polizist",
-      "Erik Schäffler"
-    ],
-    [
-      "1. Mann",
-      "Ingo Menowski"
-    ],
-    [
-      "2. Mann",
-      "Riko Tauber"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Wally Robertson",
+      "sprecher" : "Michael Prelle"
+    },
+    {
+      "rolle" : "Charmayne Robertson",
+      "sprecher" : "Daniela Hoffmann"
+    },
+    {
+      "rolle" : "Dwaight Hayward",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Mrs. Flagstaff",
+      "sprecher" : "Sabine Hahn"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Mann 1",
+      "sprecher" : "Ingo Menowski"
+    },
+    {
+      "rolle" : "Mann 2",
+      "sprecher" : "Riko Tauber"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/195/metadata.json",

--- a/web/data/Serie/196/metadata.json
+++ b/web/data/Serie/196/metadata.json
@@ -47,59 +47,59 @@
       "end" : 4728400
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Patricia Osborne",
-      "Barbara Focke"
-    ],
-    [
-      "Osiris",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Sunshine",
-      "Dagmar Dreke"
-    ],
-    [
-      "Vandaan",
-      "Andreas Birnbaum"
-    ],
-    [
-      "Frank Corman /Mr Giggles",
-      "Lutz Mackensy"
-    ],
-    [
-      "Trixie Stiles",
-      "Anne Moll"
-    ],
-    [
-      "Bryan Bonfanti",
-      "Frank Roder"
-    ],
-    [
-      "Miller",
-      "Birte Kretschmer"
-    ],
-    [
-      "Henson",
-      "Constantin Stahlberg"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Patricia Osborne",
+      "sprecher" : "Barbara Focke"
+    },
+    {
+      "rolle" : "Osiris",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Sunshine",
+      "sprecher" : "Dagmar Dreke"
+    },
+    {
+      "rolle" : "Vandaan",
+      "sprecher" : "Andreas Birnbaum"
+    },
+    {
+      "rolle" : "Frank Corman / Mr Giggles",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Trixie Stiles",
+      "sprecher" : "Anne Moll"
+    },
+    {
+      "rolle" : "Bryan Bonfanti",
+      "sprecher" : "Frank Roder"
+    },
+    {
+      "rolle" : "Miller",
+      "sprecher" : "Birte Kretschmer"
+    },
+    {
+      "rolle" : "Henson",
+      "sprecher" : "Constantin Stahlberg"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/196/metadata.json",

--- a/web/data/Serie/197/metadata.json
+++ b/web/data/Serie/197/metadata.json
@@ -52,83 +52,84 @@
       "end" : 4190827
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Matthew Kooning",
-      "Tim Kreuer"
-    ],
-    [
-      "Doktor Kooning",
-      "Dietrich Adam"
-    ],
-    [
-      "Mrs. Kooning",
-      "Christiane Leuchtmann"
-    ],
-    [
-      "Finnley Stenseth",
-      "Julian Greis"
-    ],
-    [
-      "Farryn Stenseth",
-      "Clarissa Börner"
-    ],
-    [
-      "Mrs. Stenseth",
-      "Herma Koehn"
-    ],
-    [
-      "Stacey Warren",
-      "Katja Brügger"
-    ],
-    [
-      "Brandon",
-      "Stefan Exner"
-    ],
-    [
-      "Surferin",
-      "Simona Pahl"
-    ],
-    [
-      "Surfer",
-      "Tim Knauer"
-    ],
-    [
-      "Dylan",
-      "Sascha Rotermund"
-    ],
-    [
-      "Steven",
-      "Johannes Korff"
-    ],
-    [
-      "M. Keen",
-      "Detlef Tams"
-    ],
-    [
-      "George",
-      "Mars Saibert"
-    ],
-    [
-      "Mann",
-      "Gunnar Bergmann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Matthew Kooning",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Doktor Kooning",
+      "sprecher" : "Dietrich Adam"
+    },
+    {
+      "rolle" : "Mrs. Kooning",
+      "sprecher" : "Christiane Leuchtmann"
+    },
+    {
+      "rolle" : "Finnley Stenseth",
+      "sprecher" : "Julian Greis"
+    },
+    {
+      "rolle" : "Farryn Stenseth",
+      "sprecher" : "Clarissa Börner"
+    },
+    {
+      "rolle" : "Mrs. Stenseth",
+      "sprecher" : "Herma Koehn"
+    },
+    {
+      "rolle" : "Stacey Warren",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Brandon",
+      "sprecher" : "Stefan Exner"
+    },
+    {
+      "rolle" : "Surferin",
+      "sprecher" : "Simona Pahl"
+    },
+    {
+      "rolle" : "Surfer",
+      "sprecher" : "Tim Knauer"
+    },
+    {
+      "rolle" : "Dylan",
+      "sprecher" : "Sascha Rotermund"
+    },
+    {
+      "rolle" : "Steven",
+      "sprecher" : "Johannes Korff"
+    },
+    {
+      "rolle" : "M. Keen",
+      "sprecher" : "Detlef Tams"
+    },
+    {
+      "rolle" : "George",
+      "sprecher" : "Marcel Saibert"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Peter Flechtner",
+      "pseudonym" : "Gunnar Bergmann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/197/metadata.json",

--- a/web/data/Serie/198/metadata.json
+++ b/web/data/Serie/198/metadata.json
@@ -47,83 +47,83 @@
       "end" : 4166400
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Elliot Littlehorn",
-      "Santiago Ziesmer"
-    ],
-    [
-      "Tobin Muller",
-      "Niko Minninger"
-    ],
-    [
-      "Amalia",
-      "Malin Steffen"
-    ],
-    [
-      "Zauberer Miller",
-      "Julian Horeyseck"
-    ],
-    [
-      "Kelvin Mitchell",
-      "Kai Mertens"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Leigh",
-      "Vivian Brünner"
-    ],
-    [
-      "Mutter",
-      "Tina Eschmann"
-    ],
-    [
-      "Zoey",
-      "Manuela Eifrig"
-    ],
-    [
-      "Mabel",
-      "Nicola Schäffler"
-    ],
-    [
-      "Glatzkopf",
-      "Achim Schülke"
-    ],
-    [
-      "Dustin Cooper",
-      "Claus Fuchs"
-    ],
-    [
-      "Wahrsagerin Susannah",
-      "Mia Diekow"
-    ],
-    [
-      "Dr. Benchfield",
-      "Harald Dietl"
-    ],
-    [
-      "Emily",
-      "Birte Kretschmer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Elliot Littlehorn",
+      "sprecher" : "Santiago Ziesmer"
+    },
+    {
+      "rolle" : "Tobin Muller",
+      "sprecher" : "Niko Minninger"
+    },
+    {
+      "rolle" : "Amalia",
+      "sprecher" : "Malin Steffen"
+    },
+    {
+      "rolle" : "Zauberer Miller",
+      "sprecher" : "Julian Horeyseck"
+    },
+    {
+      "rolle" : "Kelvin Mitchell",
+      "sprecher" : "Kai Mertens"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Leigh",
+      "sprecher" : "Vivian Brünner"
+    },
+    {
+      "rolle" : "Mutter",
+      "sprecher" : "Tina Eschmann"
+    },
+    {
+      "rolle" : "Zoey",
+      "sprecher" : "Manuela Eifrig"
+    },
+    {
+      "rolle" : "Mabel",
+      "sprecher" : "Nicola Schäffler"
+    },
+    {
+      "rolle" : "Glatzkopf",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Dustin Cooper",
+      "sprecher" : "Claus Fuchs"
+    },
+    {
+      "rolle" : "Wahrsagerin Susannah",
+      "sprecher" : "Mia Diekow"
+    },
+    {
+      "rolle" : "Dr. Benchfield",
+      "sprecher" : "Harald Dietl"
+    },
+    {
+      "rolle" : "Emily",
+      "sprecher" : "Birte Kretschmer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/198/metadata.json",

--- a/web/data/Serie/199/metadata.json
+++ b/web/data/Serie/199/metadata.json
@@ -47,59 +47,59 @@
       "end" : 4506587
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Mr. Aaron Grover",
-      "Gernot Endemann"
-    ],
-    [
-      "Msr. Patricia Grover",
-      "Heidi Berndt"
-    ],
-    [
-      "Elodie Grover",
-      "Henrike Fehrs"
-    ],
-    [
-      "Desmond Cathpole",
-      "Martin Brücker"
-    ],
-    [
-      "Hausmeister Spencer",
-      "Werner Cartano"
-    ],
-    [
-      "Mr. Rubberwood",
-      "Udo Schenk"
-    ],
-    [
-      "Mr. Parker Mayfield",
-      "Holger Umbreit"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Mr. Aaron Grover",
+      "sprecher" : "Gernot Endemann"
+    },
+    {
+      "rolle" : "Msr. Patricia Grover",
+      "sprecher" : "Heidi Berndt"
+    },
+    {
+      "rolle" : "Elodie Grover",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Desmond Cathpole",
+      "sprecher" : "Martin Brücker"
+    },
+    {
+      "rolle" : "Hausmeister Spencer",
+      "sprecher" : "Werner Cartano"
+    },
+    {
+      "rolle" : "Mr. Rubberwood",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Mr. Parker Mayfield",
+      "sprecher" : "Holger Umbreit"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/199/metadata.json",

--- a/web/data/Serie/200/metadata.json
+++ b/web/data/Serie/200/metadata.json
@@ -293,127 +293,127 @@
       "end" : 17712107
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Off-Sprecher",
-      "Udo Schenk"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Timothy",
-      "Peter Buchholz"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Inspector Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Goodween",
-      "André Minninger"
-    ],
-    [
-      "Rubbish George",
-      "Hans Peter Korff"
-    ],
-    [
-      "Vikram",
-      "Michael Deffert"
-    ],
-    [
-      "Bonnie Newman",
-      "Carla Becker"
-    ],
-    [
-      "Mr. August",
-      "Carlo von Tiedemann"
-    ],
-    [
-      "Gus August",
-      "Stephan Chrzescinski"
-    ],
-    [
-      "Helena",
-      "Neda Rahmanian"
-    ],
-    [
-      "Mr. Anderson",
-      "Hubertus Meyer-Burckhardt"
-    ],
-    [
-      "Gabriel White",
-      "Till Hagen"
-    ],
-    [
-      "Solomon Charles",
-      "Jürgen Thormann"
-    ],
-    [
-      "Mr. Dwiggins",
-      "Hanns Jörg Krumpholz"
-    ],
-    [
-      "Mr. Randur",
-      "Eckart Dux"
-    ],
-    [
-      "Beaver",
-      "Peter Franke"
-    ],
-    [
-      "Jariwala",
-      "Till Demtrøder"
-    ],
-    [
-      "Shakrabati",
-      "Sonny Pathak"
-    ],
-    [
-      "Shekinah",
-      "Madeleine Weingart"
-    ],
-    [
-      "Nachtwächter",
-      "Wolfgang Häntsch"
-    ],
-    [
-      "Maria",
-      "Caroline Kiesewetter"
-    ],
-    [
-      "Bruce",
-      "Michael Lott"
-    ],
-    [
-      "Polizist",
-      "Mars Saibert"
-    ],
-    [
-      "Officer",
-      "Helge Halvé"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Off-Sprecher",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Timothy",
+      "sprecher" : "Peter Buchholz"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Rubbish George",
+      "sprecher" : "Hans Peter Korff"
+    },
+    {
+      "rolle" : "Vikram",
+      "sprecher" : "Michael Deffert"
+    },
+    {
+      "rolle" : "Bonnie Newman",
+      "sprecher" : "Carla Becker"
+    },
+    {
+      "rolle" : "Mr. August",
+      "sprecher" : "Carlo von Tiedemann"
+    },
+    {
+      "rolle" : "Gus August",
+      "sprecher" : "Stephan Chrzescinski"
+    },
+    {
+      "rolle" : "Helena",
+      "sprecher" : "Neda Rahmanian"
+    },
+    {
+      "rolle" : "Mr. Anderson",
+      "sprecher" : "Hubertus Meyer-Burckhardt"
+    },
+    {
+      "rolle" : "Gabriel White",
+      "sprecher" : "Till Hagen"
+    },
+    {
+      "rolle" : "Solomon Charles",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Mr. Dwiggins",
+      "sprecher" : "Hanns Jörg Krumpholz"
+    },
+    {
+      "rolle" : "Mr. Randur",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Beaver",
+      "sprecher" : "Peter Franke"
+    },
+    {
+      "rolle" : "Jariwala",
+      "sprecher" : "Till Demtrøder"
+    },
+    {
+      "rolle" : "Shakrabati",
+      "sprecher" : "Sonny Pathak"
+    },
+    {
+      "rolle" : "Shekinah",
+      "sprecher" : "Madeleine Weingart"
+    },
+    {
+      "rolle" : "Nachtwächter",
+      "sprecher" : "Wolfgang Häntsch"
+    },
+    {
+      "rolle" : "Maria",
+      "sprecher" : "Caroline Kiesewetter"
+    },
+    {
+      "rolle" : "Bruce",
+      "sprecher" : "Michael Lott"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Marcel Saibert"
+    },
+    {
+      "rolle" : "Officer",
+      "sprecher" : "Helge Halvé"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/200/metadata.json",

--- a/web/data/Serie/201/metadata.json
+++ b/web/data/Serie/201/metadata.json
@@ -52,59 +52,59 @@
       "end" : 4703027
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ben Hustler",
-      "Christian Brückner"
-    ],
-    [
-      "Loomy",
-      "Achim Schülke"
-    ],
-    [
-      "Angie",
-      "Angelika Bartsch"
-    ],
-    [
-      "Lesley",
-      "Ann Montenbruck"
-    ],
-    [
-      "Buchhändlerin",
-      "Victoria Fleer"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Andrews",
-      "Heidrun von Goessel"
-    ],
-    [
-      "Kathy",
-      "Celine Fontanges"
-    ],
-    [
-      "Harry",
-      "Woody Mues"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ben Hustler",
+      "sprecher" : "Christian Brückner"
+    },
+    {
+      "rolle" : "Loomy",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Angie",
+      "sprecher" : "Angelika Bartsch"
+    },
+    {
+      "rolle" : "Lesley",
+      "sprecher" : "Ann Montenbruck"
+    },
+    {
+      "rolle" : "Buchhändlerin",
+      "sprecher" : "Victoria Fleer"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Andrews",
+      "sprecher" : "Heidrun von Goessel"
+    },
+    {
+      "rolle" : "Kathy",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Harry",
+      "sprecher" : "Woody Mues"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/201/metadata.json",

--- a/web/data/Serie/202/metadata.json
+++ b/web/data/Serie/202/metadata.json
@@ -42,47 +42,47 @@
       "end" : 4568253
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Laurenne Duffy",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Joe Patwin",
-      "Jürgen Uter"
-    ],
-    [
-      "Trevor Tompson",
-      "Marek Erhardt"
-    ],
-    [
-      "Bruce Osborne",
-      "Martin Paas"
-    ],
-    [
-      "Kelly",
-      "Henrike Fehrs"
-    ],
-    [
-      "Walt Duffy",
-      "Stephan Benson"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Laurenne Duffy",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Joe Patwin",
+      "sprecher" : "Jürgen Uter"
+    },
+    {
+      "rolle" : "Trevor Tompson",
+      "sprecher" : "Marek Erhardt"
+    },
+    {
+      "rolle" : "Bruce Osborne",
+      "sprecher" : "Martin Paas"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Walt Duffy",
+      "sprecher" : "Stephan Benson"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/202/metadata.json",

--- a/web/data/Serie/203/metadata.json
+++ b/web/data/Serie/203/metadata.json
@@ -47,47 +47,47 @@
       "end" : 4610333
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jorunn",
-      "Lilith Gebauer"
-    ],
-    [
-      "Mrs. Planter",
-      "Angela Quast"
-    ],
-    [
-      "Deidre",
-      "Gabriele Libbach"
-    ],
-    [
-      "Special Agent Ross",
-      "Udo Schenk"
-    ],
-    [
-      "Special Agent Wright",
-      "Astrid Kollex"
-    ],
-    [
-      "Fischer",
-      "Peter Franke"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jorunn",
+      "sprecher" : "Lilith Gebauer"
+    },
+    {
+      "rolle" : "Mrs. Planter",
+      "sprecher" : "Angela Quast"
+    },
+    {
+      "rolle" : "Deidre",
+      "sprecher" : "Gabriele Libbach"
+    },
+    {
+      "rolle" : "Special Agent Ross",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Special Agent Wright",
+      "sprecher" : "Astrid Kollex"
+    },
+    {
+      "rolle" : "Fischer",
+      "sprecher" : "Peter Franke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/203/metadata.json",

--- a/web/data/Serie/204/metadata.json
+++ b/web/data/Serie/204/metadata.json
@@ -37,51 +37,51 @@
       "end" : 4144067
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mary",
-      "Marion Gretchen-Schmitz"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Potato-Fred",
-      "Peter Weis"
-    ],
-    [
-      "Mr. Pinches",
-      "Jürgen Uter"
-    ],
-    [
-      "Carter Bridou",
-      "Peter G. Dirmeier"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mary",
+      "sprecher" : "Marion Gretchen Schmitz"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Potato-Fred",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Mr. Pinches",
+      "sprecher" : "Jürgen Uter"
+    },
+    {
+      "rolle" : "Carter Bridou",
+      "sprecher" : "Peter G. Dirmeier"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/204/metadata.json",

--- a/web/data/Serie/205/metadata.json
+++ b/web/data/Serie/205/metadata.json
@@ -37,75 +37,75 @@
       "end" : 4255120
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Trish",
-      "Katrin Decker"
-    ],
-    [
-      "Giovanni",
-      "Stephan Schad"
-    ],
-    [
-      "Rosaly",
-      "Gertie Honeck"
-    ],
-    [
-      "Matteo",
-      "Roman Rossa"
-    ],
-    [
-      "Caroline",
-      "Marianne Bernhardt"
-    ],
-    [
-      "Butler",
-      "Ivo Möller"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Charles Stapleton",
-      "Romanus Fuhrmann"
-    ],
-    [
-      "Direktor Greenwalt",
-      "Jürgen Uter"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Angestellter",
-      "Oliver Böttcher"
-    ],
-    [
-      "Polizist",
-      "Carlo von Tiedemann"
-    ],
-    [
-      "Papagei",
-      "Merete Brettschneider"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Trish",
+      "sprecher" : "Katrin Decker"
+    },
+    {
+      "rolle" : "Giovanni",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Rosaly",
+      "sprecher" : "Gertie Honeck"
+    },
+    {
+      "rolle" : "Matteo",
+      "sprecher" : "Roman Rossa"
+    },
+    {
+      "rolle" : "Caroline",
+      "sprecher" : "Marianne Bernhardt"
+    },
+    {
+      "rolle" : "Butler",
+      "sprecher" : "Ivo Möller"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Charles Stapleton",
+      "sprecher" : "Romanus Fuhrmann"
+    },
+    {
+      "rolle" : "Direktor Greenwalt",
+      "sprecher" : "Jürgen Uter"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Angestellter",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Carlo von Tiedemann"
+    },
+    {
+      "rolle" : "Papagei",
+      "sprecher" : "Merete Brettschneider"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/205/metadata.json",

--- a/web/data/Serie/206/metadata.json
+++ b/web/data/Serie/206/metadata.json
@@ -37,51 +37,51 @@
       "end" : 3762867
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mr. Mason Huntington",
-      "Wolfgang Häntsch"
-    ],
-    [
-      "Mrs. Brankle",
-      "Mignon Remé"
-    ],
-    [
-      "Xeni",
-      "Lina Maria Millat"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Seymore-Wrightson",
-      "Rosemarie Wohlbauer"
-    ],
-    [
-      "Franklyn Seymore",
-      "Achim Schülke"
-    ],
-    [
-      "Liane Shore",
-      "Sadra Keck"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mr. Mason Huntington",
+      "sprecher" : "Wolfgang Häntsch"
+    },
+    {
+      "rolle" : "Mrs. Brankle",
+      "sprecher" : "Mignon Remé"
+    },
+    {
+      "rolle" : "Xeni",
+      "sprecher" : "Lina Maria Millat"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Seymore-Wrightson",
+      "sprecher" : "Rosemarie Wohlbauer"
+    },
+    {
+      "rolle" : "Franklyn Seymore",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Liane Shore",
+      "sprecher" : "Sandra Keck"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/206/metadata.json",

--- a/web/data/Serie/207/metadata.json
+++ b/web/data/Serie/207/metadata.json
@@ -37,63 +37,63 @@
       "end" : 3725680
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Minh",
-      "Jona Mues"
-    ],
-    [
-      "Luke",
-      "Alexander Merbeth"
-    ],
-    [
-      "Mark",
-      "Woody Mues"
-    ],
-    [
-      "Stéphane Mertens",
-      "Peter Kaempfe"
-    ],
-    [
-      "Kassiererin",
-      "Birte Kretschmer"
-    ],
-    [
-      "Ron Baxter",
-      "Robin Brosch"
-    ],
-    [
-      "Oma",
-      "Apollonia Jepsen"
-    ],
-    [
-      "Mrs. Willard",
-      "Daniela Ziegler"
-    ],
-    [
-      "Li",
-      "Traudel Sperber"
-    ],
-    [
-      "Tilan",
-      "Caroline Kiesewetter"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Minh",
+      "sprecher" : "Jona Mues"
+    },
+    {
+      "rolle" : "Luke",
+      "sprecher" : "Alexander Merbeth"
+    },
+    {
+      "rolle" : "Mark",
+      "sprecher" : "Woody Mues"
+    },
+    {
+      "rolle" : "Stéphane Mertens",
+      "sprecher" : "Peter Kaempfe"
+    },
+    {
+      "rolle" : "Kassiererin",
+      "sprecher" : "Birte Kretschmer"
+    },
+    {
+      "rolle" : "Ron Baxter",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Oma",
+      "sprecher" : "Apollonia Jepsen"
+    },
+    {
+      "rolle" : "Mrs. Willard",
+      "sprecher" : "Daniela Ziegler"
+    },
+    {
+      "rolle" : "Li",
+      "sprecher" : "Traudel Sperber"
+    },
+    {
+      "rolle" : "Tilan",
+      "sprecher" : "Caroline Kiesewetter"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/207/metadata.json",

--- a/web/data/Serie/208/metadata.json
+++ b/web/data/Serie/208/metadata.json
@@ -37,79 +37,79 @@
       "end" : 4250387
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Bootsie Washington",
-      "Andreas Birnbaum"
-    ],
-    [
-      "Majorie Dever",
-      "Victoria Trauttmansdorff"
-    ],
-    [
-      "Schwester",
-      "Gabriele Libbach"
-    ],
-    [
-      "Leland Hanson",
-      "Matthias Keller"
-    ],
-    [
-      "Jolene",
-      "Sarah Madeleine Tusk"
-    ],
-    [
-      "Perceval",
-      "André Beyer"
-    ],
-    [
-      "Mercury",
-      "Kerstin Draeger"
-    ],
-    [
-      "Coldfield",
-      "Wolf-Dietrich Sprenger"
-    ],
-    [
-      "Urs",
-      "Hanns Jörg Krumpholz"
-    ],
-    [
-      "Nicolas",
-      "Uwe Lauschke"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Carver",
-      "Andreas Zaron"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Bootsie Washington",
+      "sprecher" : "Andreas Birnbaum"
+    },
+    {
+      "rolle" : "Majorie Dever",
+      "sprecher" : "Victoria Trauttmansdorff"
+    },
+    {
+      "rolle" : "Schwester",
+      "sprecher" : "Gabriele Libbach"
+    },
+    {
+      "rolle" : "Leland Hanson",
+      "sprecher" : "Matthias Keller"
+    },
+    {
+      "rolle" : "Jolene",
+      "sprecher" : "Sarah Madeleine Tusk"
+    },
+    {
+      "rolle" : "Perceval",
+      "sprecher" : "André Beyer"
+    },
+    {
+      "rolle" : "Mercury",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "Coldfield",
+      "sprecher" : "Wolf-Dietrich Sprenger"
+    },
+    {
+      "rolle" : "Urs",
+      "sprecher" : "Hanns Jörg Krumpholz"
+    },
+    {
+      "rolle" : "Nicolas",
+      "sprecher" : "Uwe Lauschke"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Carver",
+      "sprecher" : "Andreas Zaron"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/208/metadata.json",

--- a/web/data/Serie/209/metadata.json
+++ b/web/data/Serie/209/metadata.json
@@ -42,59 +42,59 @@
       "end" : 3596773
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Oisin Murphy",
-      "Douglas Welbat"
-    ],
-    [
-      "Lelia Murphy",
-      "Katja Brügger"
-    ],
-    [
-      "Virgil",
-      "Steffen Groth"
-    ],
-    [
-      "Wanda Waffle",
-      "Anja Topf"
-    ],
-    [
-      "Smiddie",
-      "Ivo Möller"
-    ],
-    [
-      "Clown",
-      "Andreas Birnbaum"
-    ],
-    [
-      "Zamora",
-      "Rainer Schmitt"
-    ],
-    [
-      "Easly",
-      "Paul Michaeli"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Oisin Murphy",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Lelia Murphy",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Virgil",
+      "sprecher" : "Steffen Groth"
+    },
+    {
+      "rolle" : "Wanda Waffle",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "Smiddie",
+      "sprecher" : "Ivo Möller"
+    },
+    {
+      "rolle" : "Clown",
+      "sprecher" : "Andreas Birnbaum"
+    },
+    {
+      "rolle" : "Zamora",
+      "sprecher" : "Rainer Schmitt"
+    },
+    {
+      "rolle" : "Easly",
+      "sprecher" : "Paul Michaeli"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/209/metadata.json",

--- a/web/data/Serie/210/metadata.json
+++ b/web/data/Serie/210/metadata.json
@@ -37,51 +37,51 @@
       "end" : 3627267
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Zach Cannings",
-      "Martin May"
-    ],
-    [
-      "Nicole",
-      "Saskia Weckler"
-    ],
-    [
-      "Mitarbeiter",
-      "Achim Funk"
-    ],
-    [
-      "Sara Roskin",
-      "Elke Reissert"
-    ],
-    [
-      "Caden Devlin",
-      "Werner Wilkening"
-    ],
-    [
-      "Offizier der Küstenwache (1)",
-      "Thorsten Laussch"
-    ],
-    [
-      "Offizier der Küstenwache (2)",
-      "Andreas Birnbaum"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Zach Cannings",
+      "sprecher" : "Martin May"
+    },
+    {
+      "rolle" : "Nicole",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Mitarbeiter",
+      "sprecher" : "Achim Funk"
+    },
+    {
+      "rolle" : "Sara Roskin",
+      "sprecher" : "Elke Reissert"
+    },
+    {
+      "rolle" : "Caden Devlin",
+      "sprecher" : "Werner Wilkening"
+    },
+    {
+      "rolle" : "Offizier der Küstenwache 1",
+      "sprecher" : "Thorsten Laussch"
+    },
+    {
+      "rolle" : "Offizier der Küstenwache 2",
+      "sprecher" : "Andreas Birnbaum"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/210/metadata.json",

--- a/web/data/Serie/211/metadata.json
+++ b/web/data/Serie/211/metadata.json
@@ -37,59 +37,59 @@
       "end" : 4321973
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Jock",
-      "Christian Stark"
-    ],
-    [
-      "Gavin Sterling",
-      "Stephan Benson"
-    ],
-    [
-      "Judith Sterling",
-      "Hedi Kriegeskotte"
-    ],
-    [
-      "Leopold Nelson",
-      "Oliver Kalkofe"
-    ],
-    [
-      "Marlow",
-      "Janis Zaurins"
-    ],
-    [
-      "Rick",
-      "Daniel Welbat"
-    ],
-    [
-      "Mrs. Torres",
-      "Heidi Berndt"
-    ],
-    [
-      "Dark Blue D",
-      "Ivo Möller"
-    ],
-    [
-      "Busfahrerin",
-      "Rosemarie Wohlbauer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Jock",
+      "sprecher" : "Christian Stark"
+    },
+    {
+      "rolle" : "Gavin Sterling",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Judith Sterling",
+      "sprecher" : "Hedi Kriegeskotte"
+    },
+    {
+      "rolle" : "Leopold Nelson",
+      "sprecher" : "Oliver Kalkofe"
+    },
+    {
+      "rolle" : "Marlow",
+      "sprecher" : "Janis Zaurins"
+    },
+    {
+      "rolle" : "Rick",
+      "sprecher" : "Daniel Welbat"
+    },
+    {
+      "rolle" : "Mrs. Torres",
+      "sprecher" : "Heidi Berndt"
+    },
+    {
+      "rolle" : "Dark Blue D",
+      "sprecher" : "Ivo Möller"
+    },
+    {
+      "rolle" : "Busfahrerin",
+      "sprecher" : "Rosemarie Wohlbauer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/211/metadata.json",

--- a/web/data/Serie/212/metadata.json
+++ b/web/data/Serie/212/metadata.json
@@ -42,59 +42,59 @@
       "end" : 4395213
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Larry Conklin",
-      "Helmut Zierl"
-    ],
-    [
-      "Fairfax",
-      "Wolfgang Pampel"
-    ],
-    [
-      "Zachary",
-      "Nicolas König"
-    ],
-    [
-      "Butler Francis",
-      "Bruno F. Apitz"
-    ],
-    [
-      "Mrs. Dutton",
-      "Monika Werner"
-    ],
-    [
-      "Noreen",
-      "Simona Pahl"
-    ],
-    [
-      "Mrs. Mobray",
-      "Eva Weissmann"
-    ],
-    [
-      "Polizist",
-      "Holger Wemhoff"
-    ],
-    [
-      "Miyazawa",
-      "Achim Schülke"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Larry Conklin",
+      "sprecher" : "Helmut Zierl"
+    },
+    {
+      "rolle" : "Fairfax",
+      "sprecher" : "Wolfgang Pampel"
+    },
+    {
+      "rolle" : "Zachary",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Butler Francis",
+      "sprecher" : "Bruno F. Apitz"
+    },
+    {
+      "rolle" : "Mrs. Dutton",
+      "sprecher" : "Monika Werner"
+    },
+    {
+      "rolle" : "Noreen",
+      "sprecher" : "Simona Pahl"
+    },
+    {
+      "rolle" : "Mrs. Mobray",
+      "sprecher" : "Eva Weissmann"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Holger Wemhoff"
+    },
+    {
+      "rolle" : "Miyazawa",
+      "sprecher" : "Achim Schülke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/212/metadata.json",

--- a/web/data/Serie/213/metadata.json
+++ b/web/data/Serie/213/metadata.json
@@ -42,75 +42,75 @@
       "end" : 4378267
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Jojo",
-      "Lovis Harloff"
-    ],
-    [
-      "Mrs Carmichael",
-      "Anne Moll"
-    ],
-    [
-      "Mr Jeremiah Carmichael",
-      "Peter Bieringer"
-    ],
-    [
-      "Gravedigger",
-      "Lutz Mackensy"
-    ],
-    [
-      "Kruger",
-      "Gordon Piedesack"
-    ],
-    [
-      "Annabelle Delaney",
-      "Sabine Kaack"
-    ],
-    [
-      "Claire Delaney",
-      "Theresa Underberg"
-    ],
-    [
-      "Ace Hall",
-      "Patrick Berg"
-    ],
-    [
-      "Vince Buchanan",
-      "Joachim Kretzer"
-    ],
-    [
-      "Neal Buchanan",
-      "Marek Harloff"
-    ],
-    [
-      "Moderator",
-      "Holger Wemhoff"
-    ],
-    [
-      "Pearson",
-      "Till Huster"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Jojo",
+      "sprecher" : "Lovis Harloff"
+    },
+    {
+      "rolle" : "Mrs. Carmichael",
+      "sprecher" : "Anne Moll"
+    },
+    {
+      "rolle" : "Mr. Jeremiah Carmichael",
+      "sprecher" : "Peter Bieringer"
+    },
+    {
+      "rolle" : "Gravedigger",
+      "sprecher" : "Lutz Mackensy"
+    },
+    {
+      "rolle" : "Kruger",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Annabelle Delaney",
+      "sprecher" : "Sabine Kaack"
+    },
+    {
+      "rolle" : "Claire Delaney",
+      "sprecher" : "Theresa Underberg"
+    },
+    {
+      "rolle" : "Ace Hall",
+      "sprecher" : "Patrick Berg"
+    },
+    {
+      "rolle" : "Vince Buchanan",
+      "sprecher" : "Joachim Kretzer"
+    },
+    {
+      "rolle" : "Neal Buchanan",
+      "sprecher" : "Marek Harloff"
+    },
+    {
+      "rolle" : "Moderator",
+      "sprecher" : "Holger Wemhoff"
+    },
+    {
+      "rolle" : "Pearson",
+      "sprecher" : "Till Huster"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/213/metadata.json",

--- a/web/data/Serie/214/metadata.json
+++ b/web/data/Serie/214/metadata.json
@@ -37,67 +37,67 @@
       "end" : 3938600
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Kommissarin Lisa Merryweather",
-      "Caroline Peters"
-    ],
-    [
-      "Elena Fleckenstein",
-      "Christiane Leuchtmann"
-    ],
-    [
-      "Roderick Sanders",
-      "Albrecht Ganskopf"
-    ],
-    [
-      "Fahrerin",
-      "Elga Schütz"
-    ],
-    [
-      "Rubbish George",
-      "Hans Peter Korff"
-    ],
-    [
-      "Officer Brown",
-      "André Beyer"
-    ],
-    [
-      "Bote",
-      "Achim Schülke"
-    ],
-    [
-      "Polizist",
-      "Alexander Mettin"
-    ],
-    [
-      "Angestellte im Altenheim",
-      "Barbara Schipper"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Kommissarin Lisa Merryweather",
+      "sprecher" : "Caroline Peters"
+    },
+    {
+      "rolle" : "Elena Fleckenstein",
+      "sprecher" : "Christiane Leuchtmann"
+    },
+    {
+      "rolle" : "Roderick Sanders",
+      "sprecher" : "Albrecht Ganskopf"
+    },
+    {
+      "rolle" : "Fahrerin",
+      "sprecher" : "Elga Schütz"
+    },
+    {
+      "rolle" : "Rubbish George",
+      "sprecher" : "Hans Peter Korff"
+    },
+    {
+      "rolle" : "Officer Brown",
+      "sprecher" : "André Beyer"
+    },
+    {
+      "rolle" : "Bote",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Alexander Mettin"
+    },
+    {
+      "rolle" : "Angestellte im Altenheim",
+      "sprecher" : "Barbara Schipper"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/214/metadata.json",

--- a/web/data/Serie/215/metadata.json
+++ b/web/data/Serie/215/metadata.json
@@ -47,63 +47,63 @@
       "end" : 3954893
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Arnold Grasso",
-      "Patrick Berg"
-    ],
-    [
-      "Amalia",
-      "Verena Frost"
-    ],
-    [
-      "Sarah",
-      "Jana Schmidt"
-    ],
-    [
-      "Eric",
-      "Rasmus Borowski"
-    ],
-    [
-      "Nicolas",
-      "Lukas T. Sperber"
-    ],
-    [
-      "Dennis",
-      "Detlef Tams"
-    ],
-    [
-      "Dale Congden",
-      "Peter Kaempfe"
-    ],
-    [
-      "Professor Hogan",
-      "Hannes Hellmann"
-    ],
-    [
-      "Officer",
-      "Torsten Münchow"
-    ],
-    [
-      "Ansage",
-      "Anne Moll"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Arnold Grasso",
+      "sprecher" : "Patrick Berg"
+    },
+    {
+      "rolle" : "Amalia",
+      "sprecher" : "Verena Frost"
+    },
+    {
+      "rolle" : "Sarah",
+      "sprecher" : "Jana Catharina Schmidt"
+    },
+    {
+      "rolle" : "Eric",
+      "sprecher" : "Rasmus Borowski"
+    },
+    {
+      "rolle" : "Nicolas",
+      "sprecher" : "Lukas T. Sperber"
+    },
+    {
+      "rolle" : "Dennis",
+      "sprecher" : "Detlef Tams"
+    },
+    {
+      "rolle" : "Dale Congden",
+      "sprecher" : "Peter Kaempfe"
+    },
+    {
+      "rolle" : "Professor Hogan",
+      "sprecher" : "Hannes Hellmann"
+    },
+    {
+      "rolle" : "Officer",
+      "sprecher" : "Torsten Münchow"
+    },
+    {
+      "rolle" : "Ansage",
+      "sprecher" : "Anne Moll"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/215/metadata.json",

--- a/web/data/Serie/216/metadata.json
+++ b/web/data/Serie/216/metadata.json
@@ -52,55 +52,55 @@
       "end" : 3884267
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Kendra Bowman",
-      "Sandra Schwittau"
-    ],
-    [
-      "Huxley, Sittich",
-      "Achim Buch"
-    ],
-    [
-      "Matt",
-      "Manfred Liptow"
-    ],
-    [
-      "Carol",
-      "Gerlinde Dillge"
-    ],
-    [
-      "Trevor",
-      "Peter Kaempfe"
-    ],
-    [
-      "Officer",
-      "Torsten Münchow"
-    ],
-    [
-      "Reginald",
-      "Malte Janßen"
-    ],
-    [
-      "Blacky",
-      "Heikedine Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Kendra Bowman",
+      "sprecher" : "Sandra Schwittau"
+    },
+    {
+      "rolle" : "Huxley, Sittich",
+      "sprecher" : "Achim Buch"
+    },
+    {
+      "rolle" : "Matt",
+      "sprecher" : "Manfred Liptow"
+    },
+    {
+      "rolle" : "Carol",
+      "sprecher" : "Gerlinde Dillge"
+    },
+    {
+      "rolle" : "Trevor",
+      "sprecher" : "Peter Kaempfe"
+    },
+    {
+      "rolle" : "Officer",
+      "sprecher" : "Torsten Münchow"
+    },
+    {
+      "rolle" : "Reginald",
+      "sprecher" : "Malte Janßen"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/216/metadata.json",

--- a/web/data/Serie/217/metadata.json
+++ b/web/data/Serie/217/metadata.json
@@ -47,67 +47,67 @@
       "end" : 4520653
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Julia Scott",
-      "Stephanie Kirchberger"
-    ],
-    [
-      "Onkel Titus",
-      "Erik Schäffler"
-    ],
-    [
-      "Gwendolyn",
-      "Maud Ackermann"
-    ],
-    [
-      "Nicholas",
-      "Max König"
-    ],
-    [
-      "Raphael Luca",
-      "Achim Buch"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Bronkowitz",
-      "Angela Stresemann"
-    ],
-    [
-      "Lady",
-      "Eva Monar"
-    ],
-    [
-      "Dame",
-      "Carolyn Walsh"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Hunter Scott",
-      "Hans-Jürgen Mende"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Julia Scott",
+      "sprecher" : "Stephanie Damare"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Gwendolyn",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Nicholas",
+      "sprecher" : "Max König"
+    },
+    {
+      "rolle" : "Raphael Luca",
+      "sprecher" : "Achim Buch"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Bronkowitz",
+      "sprecher" : "Angela Stresemann"
+    },
+    {
+      "rolle" : "Lady",
+      "sprecher" : "Eva Monar"
+    },
+    {
+      "rolle" : "Dame",
+      "sprecher" : "Carolyn Walsh"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Hunter Scott",
+      "sprecher" : "Hans-Jürgen Mende"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/217/metadata.json",

--- a/web/data/Serie/218/metadata.json
+++ b/web/data/Serie/218/metadata.json
@@ -47,67 +47,67 @@
       "end" : 4372133
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Olivia",
-      "Uschi Hugo"
-    ],
-    [
-      "Pamela Parker, Olivias Mutter",
-      "Katrin Decker"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Eudora Kretschmer",
-      "Monika Werner"
-    ],
-    [
-      "Barbara",
-      "Carolyn Walsh"
-    ],
-    [
-      "Canyon Brookside",
-      "Marek Erhardt"
-    ],
-    [
-      "Owens",
-      "Jan Langer"
-    ],
-    [
-      "Bernie Walters",
-      "Vadim Goldfeld"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Edgar Mulligan",
-      "Karsten Haase"
-    ],
-    [
-      "Swift",
-      "Tim Grobe"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Olivia",
+      "sprecher" : "Uschi Hugo"
+    },
+    {
+      "rolle" : "Pamela Parker, Olivias Mutter",
+      "sprecher" : "Katrin Decker"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Eudora Kretschmer",
+      "sprecher" : "Monika Werner"
+    },
+    {
+      "rolle" : "Barbara",
+      "sprecher" : "Carolyn Walsh"
+    },
+    {
+      "rolle" : "Canyon Brookside",
+      "sprecher" : "Marek Erhardt"
+    },
+    {
+      "rolle" : "Owens",
+      "sprecher" : "Jan Langer"
+    },
+    {
+      "rolle" : "Bernie Walters",
+      "sprecher" : "Vadim Goldfeld"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Edgar Mulligan",
+      "sprecher" : "Karsten Haase"
+    },
+    {
+      "rolle" : "Swift",
+      "sprecher" : "Tim Grobe"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/218/metadata.json",

--- a/web/data/Serie/219/metadata.json
+++ b/web/data/Serie/219/metadata.json
@@ -47,67 +47,67 @@
       "end" : 4189547
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Detective Ella",
-      "Neda Rahmanian"
-    ],
-    [
-      "Officer James",
-      "Sascha Gutzeit"
-    ],
-    [
-      "Mr. Shaw",
-      "Michael Grimm"
-    ],
-    [
-      "Paul Forsters",
-      "Achim Buch"
-    ],
-    [
-      "Esprit",
-      "Matthias Keller"
-    ],
-    [
-      "Anthony Spring",
-      "Douglas Welbat"
-    ],
-    [
-      "Butch",
-      "Tom Pidde"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Blacky",
-      "Heikedine Körting"
-    ],
-    [
-      "Godween",
-      "André Minninger"
-    ],
-    [
-      "Polizist",
-      "Frank Meyer-Brockmann"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Detective Ella",
+      "sprecher" : "Neda Rahmanian"
+    },
+    {
+      "rolle" : "Officer James",
+      "sprecher" : "Sascha Gutzeit"
+    },
+    {
+      "rolle" : "Mr. Shaw",
+      "sprecher" : "Michael Grimm"
+    },
+    {
+      "rolle" : "Paul Forsters",
+      "sprecher" : "Achim Buch"
+    },
+    {
+      "rolle" : "Esprit",
+      "sprecher" : "Matthias Keller"
+    },
+    {
+      "rolle" : "Anthony Spring",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Butch",
+      "sprecher" : "Tom Pidde"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Goodween",
+      "sprecher" : "André Minninger"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Frank Meyer-Brockmann"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/219/metadata.json",

--- a/web/data/Serie/220/metadata.json
+++ b/web/data/Serie/220/metadata.json
@@ -57,59 +57,59 @@
       "end" : 4446747
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Bill Greyfield",
-      "Gordon Piedesack"
-    ],
-    [
-      "Karen Greyfield",
-      "Beate Rysopp"
-    ],
-    [
-      "Ralph Sanders",
-      "Jens Böttcher"
-    ],
-    [
-      "Dylan Reid",
-      "Matthias Keller"
-    ],
-    [
-      "Zoe",
-      "Marion Martienzen"
-    ],
-    [
-      "Simon Cobby",
-      "Pat Murphy"
-    ],
-    [
-      "Angela van Limbeek",
-      "Malin Steffen"
-    ],
-    [
-      "John Addington",
-      "Andreas Birnbaum"
-    ],
-    [
-      "Doktor Williams",
-      "Holger Wemhoff"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Bill Greyfield",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Karen Greyfield",
+      "sprecher" : "Beate Rysopp"
+    },
+    {
+      "rolle" : "Ralph Sanders",
+      "sprecher" : "Jens Böttcher"
+    },
+    {
+      "rolle" : "Dylan Reid",
+      "sprecher" : "Matthias Keller"
+    },
+    {
+      "rolle" : "Zoe",
+      "sprecher" : "Marion Martienzen"
+    },
+    {
+      "rolle" : "Simon Cobby",
+      "sprecher" : "Pat Murphy"
+    },
+    {
+      "rolle" : "Angela van Limbeek",
+      "sprecher" : "Malin Steffen"
+    },
+    {
+      "rolle" : "John Addington",
+      "sprecher" : "Andreas Birnbaum"
+    },
+    {
+      "rolle" : "Doktor Williams",
+      "sprecher" : "Holger Wemhoff"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/220/metadata.json",

--- a/web/data/Serie/221/metadata.json
+++ b/web/data/Serie/221/metadata.json
@@ -52,47 +52,47 @@
       "end" : 3932520
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Professor Douglas Bancroft",
-      "Jürgen Thormann"
-    ],
-    [
-      "Butler Vernom",
-      "Jürgen Holdorf"
-    ],
-    [
-      "Miss Mortimer",
-      "Heidi Schaffrath"
-    ],
-    [
-      "Elwood Shoreland",
-      "Martin May"
-    ],
-    [
-      "Darian",
-      "Marc Zabinski"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Professor Douglas Bancroft",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Butler Vernom",
+      "sprecher" : "Jürgen Holdorf"
+    },
+    {
+      "rolle" : "Miss Mortimer",
+      "sprecher" : "Heidi Schaffrath"
+    },
+    {
+      "rolle" : "Elwood Shoreland",
+      "sprecher" : "Martin May"
+    },
+    {
+      "rolle" : "Darian",
+      "sprecher" : "Marc Zabinski"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/221/metadata.json",

--- a/web/data/Serie/222/metadata.json
+++ b/web/data/Serie/222/metadata.json
@@ -47,67 +47,67 @@
       "end" : 4615480
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Amanda Blunt",
-      "Katy Karrenbauer"
-    ],
-    [
-      "Quinn",
-      "Till Hagen"
-    ],
-    [
-      "Lyn",
-      "Henrike Fehrs"
-    ],
-    [
-      "Opossum",
-      "Reinhold Kammerer"
-    ],
-    [
-      "Nancy",
-      "Britta Steffenhagen"
-    ],
-    [
-      "Odo",
-      "Sebastian König"
-    ],
-    [
-      "Dimwitt",
-      "Achim Schülke"
-    ],
-    [
-      "Telefonstimme",
-      "Nico König"
-    ],
-    [
-      "Colstone",
-      "Peter G. Dirmeier"
-    ],
-    [
-      "Moderatorin",
-      "Petra Kleinert"
-    ],
-    [
-      "Sheriff",
-      "Konstantin Graudus"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Amanda Blunt",
+      "sprecher" : "Katy Karrenbauer"
+    },
+    {
+      "rolle" : "Quinn",
+      "sprecher" : "Till Hagen"
+    },
+    {
+      "rolle" : "Lyn",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Opossum",
+      "sprecher" : "Reinhold Kammerer"
+    },
+    {
+      "rolle" : "Nancy",
+      "sprecher" : "Britta Steffenhagen"
+    },
+    {
+      "rolle" : "Odo",
+      "sprecher" : "Sebastian König"
+    },
+    {
+      "rolle" : "Dimwitt",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Telefonstimme",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "Colstone",
+      "sprecher" : "Peter G. Dirmeier"
+    },
+    {
+      "rolle" : "Moderatorin",
+      "sprecher" : "Petra Kleinert"
+    },
+    {
+      "rolle" : "Sheriff",
+      "sprecher" : "Konstantin Graudus"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/222/metadata.json",

--- a/web/data/Serie/223/metadata.json
+++ b/web/data/Serie/223/metadata.json
@@ -47,71 +47,72 @@
       "end" : 4799880
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Erik Schäffler"
-    ],
-    [
-      "Trenton",
-      "Marco Steeger"
-    ],
-    [
-      "Buzzy",
-      "Merete Brettschneider"
-    ],
-    [
-      "Harold",
-      "Leonhard Mahlich"
-    ],
-    [
-      "George",
-      "Robin Brosch"
-    ],
-    [
-      "Roberta",
-      "Pamela Punti"
-    ],
-    [
-      "Evander Prettyman",
-      "Nicolas Böll"
-    ],
-    [
-      "Liam",
-      "Stefan Brönneke"
-    ],
-    [
-      "Lincoln",
-      "Hans Peter Korff"
-    ],
-    [
-      "Maya",
-      "Manuela Eifrig"
-    ],
-    [
-      "Haylie",
-      "Barbara Schipper"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Trenton",
+      "sprecher" : "Marco Steeger"
+    },
+    {
+      "rolle" : "Buzzy",
+      "sprecher" : "Merete Brettschneider"
+    },
+    {
+      "rolle" : "Harold",
+      "sprecher" : "Leonhard Mahlich"
+    },
+    {
+      "rolle" : "George",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Roberta",
+      "sprecher" : "Heikedine Körting",
+      "pseudonym" : "Pamela Punti"
+    },
+    {
+      "rolle" : "Evander Prettyman",
+      "sprecher" : "Nicolas Böll"
+    },
+    {
+      "rolle" : "Liam",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Lincoln",
+      "sprecher" : "Hans Peter Korff"
+    },
+    {
+      "rolle" : "Maya",
+      "sprecher" : "Manuela Eifrig"
+    },
+    {
+      "rolle" : "Haylie",
+      "sprecher" : "Barbara Schipper"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/223/metadata.json",

--- a/web/data/Serie/224/metadata.json
+++ b/web/data/Serie/224/metadata.json
@@ -47,55 +47,55 @@
       "end" : 4363613
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ian Carew",
-      "Sascha Draeger"
-    ],
-    [
-      "Mambo Mawu",
-      "Regina Lemnitz"
-    ],
-    [
-      "Kommissarin Martinez",
-      "Caroline Kiesewetter"
-    ],
-    [
-      "Larry",
-      "Stephan Schad"
-    ],
-    [
-      "Morton",
-      "Michael Prelle"
-    ],
-    [
-      "Thabani Mathoho",
-      "Tim Grobe"
-    ],
-    [
-      "Clayton Badu",
-      "Frank Roder"
-    ],
-    [
-      "Cumba Balewa",
-      "Heidi Berndt"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ian Carew",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Mambo Mawu",
+      "sprecher" : "Regina Lemnitz"
+    },
+    {
+      "rolle" : "Kommissarin Martinez",
+      "sprecher" : "Caroline Kiesewetter"
+    },
+    {
+      "rolle" : "Larry",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Michael Prelle"
+    },
+    {
+      "rolle" : "Thabani Mathoho",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Clayton Badu",
+      "sprecher" : "Frank Roder"
+    },
+    {
+      "rolle" : "Cumba Balewa",
+      "sprecher" : "Heidi Berndt"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/224/metadata.json",

--- a/web/data/Serie/225/metadata.json
+++ b/web/data/Serie/225/metadata.json
@@ -216,83 +216,83 @@
       "end" : 10696453
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Erik Schäffler"
-    ],
-    [
-      "Kenneth",
-      "Till Huster"
-    ],
-    [
-      "Chief Householder",
-      "Gordon Piedesack"
-    ],
-    [
-      "Tricia Cooper",
-      "Anna Carlsson"
-    ],
-    [
-      "Mr. Rice",
-      "Stephan Schad"
-    ],
-    [
-      "Katee",
-      "Anne Moll"
-    ],
-    [
-      "Sergeant Murray",
-      "Achim Buch"
-    ],
-    [
-      "Mary",
-      "Svantje Wascher"
-    ],
-    [
-      "Scott",
-      "John Wesley Zielmann"
-    ],
-    [
-      "Johnson",
-      "Wanja Mues"
-    ],
-    [
-      "Nigel",
-      "Tim Mälzer"
-    ],
-    [
-      "Patrick",
-      "Christian Rudolf"
-    ],
-    [
-      "Dolly Craig",
-      "Rosemarie Wohlbauer"
-    ],
-    [
-      "Mrs. Cooper",
-      "Angelika Berg"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Kenneth",
+      "sprecher" : "Till Huster"
+    },
+    {
+      "rolle" : "Chief Householder",
+      "sprecher" : "Gordon Piedesack"
+    },
+    {
+      "rolle" : "Tricia Cooper",
+      "sprecher" : "Anna Carlsson"
+    },
+    {
+      "rolle" : "Mr. Rice",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Katee",
+      "sprecher" : "Anne Moll"
+    },
+    {
+      "rolle" : "Sergeant Murray",
+      "sprecher" : "Achim Buch"
+    },
+    {
+      "rolle" : "Mary",
+      "sprecher" : "Svantje Wascher"
+    },
+    {
+      "rolle" : "Scott",
+      "sprecher" : "John Wesley Zielmann"
+    },
+    {
+      "rolle" : "Johnson",
+      "sprecher" : "Wanja Mues"
+    },
+    {
+      "rolle" : "Nigel",
+      "sprecher" : "Tim Mälzer"
+    },
+    {
+      "rolle" : "Patrick",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Dolly Craig",
+      "sprecher" : "Rosemarie Wohlbauer"
+    },
+    {
+      "rolle" : "Mrs. Cooper",
+      "sprecher" : "Angelika Berg"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/225/metadata.json",

--- a/web/data/Serie/226/metadata.json
+++ b/web/data/Serie/226/metadata.json
@@ -37,59 +37,59 @@
       "end" : 4953600
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Clarissa Franklin",
-      "Judy Winter"
-    ],
-    [
-      "Jack Cliffwater",
-      "Oliver Kalkofe"
-    ],
-    [
-      "Mr. Bumblebee",
-      "Tim Grobe"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Evans",
-      "Merete Brettschneider"
-    ],
-    [
-      "Mr. Powers",
-      "Achim Buch"
-    ],
-    [
-      "Meyer",
-      "Tim Helssen"
-    ],
-    [
-      "Polizist",
-      "John Wesley Zielmann"
-    ],
-    [
-      "Polizistin",
-      "Merle Tucholka"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Clarissa Franklin",
+      "sprecher" : "Judy Winter"
+    },
+    {
+      "rolle" : "Jack Cliffwater",
+      "sprecher" : "Oliver Kalkofe"
+    },
+    {
+      "rolle" : "Mr. Bumblebee",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Evans",
+      "sprecher" : "Merete Brettschneider"
+    },
+    {
+      "rolle" : "Mr. Powers",
+      "sprecher" : "Achim Buch"
+    },
+    {
+      "rolle" : "Meyer",
+      "sprecher" : "Tim Helssen"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "John Wesley Zielmann"
+    },
+    {
+      "rolle" : "Polizistin",
+      "sprecher" : "Merle Tucholka"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Serie/226/metadata.json",

--- a/web/data/Spezial.json
+++ b/web/data/Spezial.json
@@ -168,67 +168,68 @@
           "end" : 5400124
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mr. Claudius",
-          "Gerlach Fiedler"
-        ],
-        [
-          "Mrs. Claudius",
-          "Brigitte Böttrich"
-        ],
-        [
-          "Mr. Fentriss",
-          "Detlef Bierstedt"
-        ],
-        [
-          "Hugenay",
-          "Wolfgang Kubach"
-        ],
-        [
-          "Carlos",
-          "Stefan Brönneke"
-        ],
-        [
-          "Ramos",
-          "Dario Bertoli"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Opa",
-          "Harry Rowohlt"
-        ],
-        [
-          "Miss Waggoner",
-          "Ursula Vogel"
-        ],
-        [
-          "Senora",
-          "Barbara Benuel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mr. Claudius, Kunsthändler",
+          "sprecher" : "Gerlach Fiedler"
+        },
+        {
+          "rolle" : "Mrs. Claudius",
+          "sprecher" : "Brigitte Böttrich"
+        },
+        {
+          "rolle" : "Mr. Fentriss, Schriftsteller",
+          "sprecher" : "Detlef Bierstedt"
+        },
+        {
+          "rolle" : "Hugenay",
+          "sprecher" : "Wolfgang Kubach"
+        },
+        {
+          "rolle" : "Carlos",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Onkel Ramos",
+          "sprecher" : "Detlef Bierstedt",
+          "pseudonym" : "Dario Bertoli"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Opa",
+          "sprecher" : "Harry Rowohlt"
+        },
+        {
+          "rolle" : "Miss Waggoner",
+          "sprecher" : "Ursula Vogel"
+        },
+        {
+          "rolle" : "Senora",
+          "sprecher" : "Barbara Benuel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/metadata.json",
@@ -311,99 +312,100 @@
               "end" : 4757160
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Onkel Titus Jonas",
-              "Hans Meinhardt"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Officer Flann Doyle",
-              "Douglas Welbat"
-            ],
-            [
-              "Tanya Sullivan",
-              "Marion Elskis"
-            ],
-            [
-              "Sebastian Dawson",
-              "Bastian Pastewka"
-            ],
-            [
-              "Miss Tomkins",
-              "Steffi Kirchberger"
-            ],
-            [
-              "Mr. Foley",
-              "Dirk Bach"
-            ],
-            [
-              "John Gabbin",
-              "Tobias Schmidt"
-            ],
-            [
-              "Matthew Gabbin",
-              "Jürgen Thormann"
-            ],
-            [
-              "Georgina",
-              "Maud Ackermann"
-            ],
-            [
-              "Gil Renard",
-              "Udo Schenk"
-            ],
-            [
-              "Hedy Carlson",
-              "Luise Helm"
-            ],
-            [
-              "Steve",
-              "Sascha Draeger"
-            ],
-            [
-              "Jack",
-              "Hendrik Buchna"
-            ],
-            [
-              "Laury",
-              "Rhea Harder-Vennewald"
-            ],
-            [
-              "Gast 1",
-              "Christian Senger"
-            ],
-            [
-              "Fahrerin",
-              "Corinna Wodrich"
-            ],
-            [
-              "Radiosprecher",
-              "Tobias Meister"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Officer Flann Doyle",
+              "sprecher" : "Douglas Welbat"
+            },
+            {
+              "rolle" : "Tanya Sullivan",
+              "sprecher" : "Marion Elskis"
+            },
+            {
+              "rolle" : "Sebastian Dawson",
+              "sprecher" : "Bastian Pastewka"
+            },
+            {
+              "rolle" : "Miss Tomkins",
+              "sprecher" : "Stephanie Damare"
+            },
+            {
+              "rolle" : "Mr. Foley",
+              "sprecher" : "Dirk Bach"
+            },
+            {
+              "rolle" : "John Gabbin",
+              "sprecher" : "Tobias Schmidt"
+            },
+            {
+              "rolle" : "Matthew Gabbin",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Georgina",
+              "sprecher" : "Maud Ackermann"
+            },
+            {
+              "rolle" : "Gil Renard",
+              "sprecher" : "Udo Schenk"
+            },
+            {
+              "rolle" : "Hedy Carlson",
+              "sprecher" : "Luise Helm"
+            },
+            {
+              "rolle" : "Steve",
+              "sprecher" : "Sascha Draeger"
+            },
+            {
+              "rolle" : "Jack",
+              "sprecher" : "Hendrik Buchna"
+            },
+            {
+              "rolle" : "Laury",
+              "sprecher" : "Rhea Harder-Vennewald"
+            },
+            {
+              "rolle" : "Gast 1",
+              "sprecher" : "Christian Senger"
+            },
+            {
+              "rolle" : "Fahrerin",
+              "sprecher" : "Corinna Wodrich"
+            },
+            {
+              "rolle" : "Radiosprecher",
+              "sprecher" : "Tobias Meister"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/1/metadata.json",
@@ -479,95 +481,95 @@
               "end" : 3904933
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Officer Flann Doyle",
-              "Douglas Welbat"
-            ],
-            [
-              "Gil Renard",
-              "Udo Schenk"
-            ],
-            [
-              "Hedy Carlson",
-              "Luise Helm"
-            ],
-            [
-              "Peter Foster",
-              "Gerrit Schmidt-Foss"
-            ],
-            [
-              "Mrs. Shaw",
-              "Isabella Grote"
-            ],
-            [
-              "Sebastian Dawson",
-              "Bastian Pastewka"
-            ],
-            [
-              "Annie Wilkes",
-              "Regina Lemnitz"
-            ],
-            [
-              "Mädchen 1",
-              "Katinka Körting"
-            ],
-            [
-              "Mädchen 2",
-              "Jacqueline Meybauer"
-            ],
-            [
-              "Georgina",
-              "Maud Ackermann"
-            ],
-            [
-              "Alter Mann",
-              "Jörg Gillner"
-            ],
-            [
-              "Junger Mann",
-              "Patrick Bach"
-            ],
-            [
-              "Dick Perry",
-              "Ernst H. Hilbich"
-            ],
-            [
-              "Matthew Gabbin",
-              "Jürgen Thormann"
-            ],
-            [
-              "Steve",
-              "Sascha Draeger"
-            ],
-            [
-              "Radiosprecher",
-              "Tobias Meister"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Officer Flann Doyle",
+              "sprecher" : "Douglas Welbat"
+            },
+            {
+              "rolle" : "Gil Renard",
+              "sprecher" : "Udo Schenk"
+            },
+            {
+              "rolle" : "Hedy Carlson",
+              "sprecher" : "Luise Helm"
+            },
+            {
+              "rolle" : "Peter Foster",
+              "sprecher" : "Gerrit Schmidt-Foß"
+            },
+            {
+              "rolle" : "Mrs. Shaw",
+              "sprecher" : "Isabella Grothe"
+            },
+            {
+              "rolle" : "Sebastian Dawson",
+              "sprecher" : "Bastian Pastewka"
+            },
+            {
+              "rolle" : "Annie Wilkes",
+              "sprecher" : "Regina Lemnitz"
+            },
+            {
+              "rolle" : "Mädchen 1",
+              "sprecher" : "Katinka Körting"
+            },
+            {
+              "rolle" : "Mädchen 2",
+              "sprecher" : "Jacqueline Meybauer"
+            },
+            {
+              "rolle" : "Georgina",
+              "sprecher" : "Maud Ackermann"
+            },
+            {
+              "rolle" : "Alter Mann",
+              "sprecher" : "Jörg Gillner"
+            },
+            {
+              "rolle" : "Junger Mann",
+              "sprecher" : "Patrick Bach"
+            },
+            {
+              "rolle" : "Dick Perry",
+              "sprecher" : "Ernst H. Hilbich"
+            },
+            {
+              "rolle" : "Matthew Gabbin",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Steve",
+              "sprecher" : "Sascha Draeger"
+            },
+            {
+              "rolle" : "Radiosprecher",
+              "sprecher" : "Tobias Meister"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/2/metadata.json",
@@ -658,131 +660,131 @@
               "end" : 4416000
             }
           ],
-          "sprecher" : [
-            [
-              "Erzähler",
-              "Thomas Fritsch"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tante Mathilda Jonas",
-              "Karin Lieneweg"
-            ],
-            [
-              "Bill Andrews",
-              "Henry König"
-            ],
-            [
-              "Inspektor Cotta",
-              "Holger Mahlich"
-            ],
-            [
-              "Miss Bennett",
-              "Renate Pilcher"
-            ],
-            [
-              "Dick Perry",
-              "Ernst H. Hilbich"
-            ],
-            [
-              "Walter Bush",
-              "Rolf E. Schenker"
-            ],
-            [
-              "Officer Flann Doyle",
-              "Douglas Welbat"
-            ],
-            [
-              "Ian Bush",
-              "Sky du Mont / Lucas Sperber"
-            ],
-            [
-              "Jimmy Sinclair",
-              "Siegfried Kernen / Nils Noller"
-            ],
-            [
-              "Charlie Parker",
-              "Jörg Gillner / Laurence Kalaidjan"
-            ],
-            [
-              "Brianna Jackson",
-              "Hansi Jochmann / Natalie Demtröder"
-            ],
-            [
-              "Chloe Smathers",
-              "Valerie Demtröder"
-            ],
-            [
-              "Joseph Quick",
-              "Harry Rowohlt"
-            ],
-            [
-              "Mr. Raynes",
-              "Olaf Kreuzenbeck"
-            ],
-            [
-              "Jeff White",
-              "Horst Naumann"
-            ],
-            [
-              "Hedy Carlson",
-              "Luise Helm"
-            ],
-            [
-              "Gil Renard",
-              "Udo Schenk"
-            ],
-            [
-              "Peter Foster",
-              "Gerrit Schmidt-Foss"
-            ],
-            [
-              "Matthew Gabbin",
-              "Jürgen Thormann"
-            ],
-            [
-              "Steve",
-              "Sascha Draeger"
-            ],
-            [
-              "Laury",
-              "Rhea Harder-Vennewald"
-            ],
-            [
-              "Georgina",
-              "Maud Ackermann"
-            ],
-            [
-              "Bedienung",
-              "Tim Wenderoth"
-            ],
-            [
-              "Gast",
-              "Andreas Otto"
-            ],
-            [
-              "Sekretärin",
-              "Corinna Wodrich"
-            ],
-            [
-              "Sebastian Dawson",
-              "Bastian Pastewka"
-            ],
-            [
-              "Radiosprecher",
-              "Tobias Meister"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Miss Bennett",
+              "sprecher" : "Renate Pichler"
+            },
+            {
+              "rolle" : "Dick Perry",
+              "sprecher" : "Ernst H. Hilbich"
+            },
+            {
+              "rolle" : "Walter Bush",
+              "sprecher" : "Rolf E. Schenker"
+            },
+            {
+              "rolle" : "Officer Flann Doyle",
+              "sprecher" : "Douglas Welbat"
+            },
+            {
+              "rolle" : "Ian Bush",
+              "sprecher" : "Sky du Mont / Lukas T. Sperber"
+            },
+            {
+              "rolle" : "Jimmy Sinclair",
+              "sprecher" : "Siegfried W. Kernen / Nils Noller"
+            },
+            {
+              "rolle" : "Charlie Parker",
+              "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+            },
+            {
+              "rolle" : "Brianna Jackson",
+              "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+            },
+            {
+              "rolle" : "Chloe Smathers",
+              "sprecher" : "Valerie Demtrøder"
+            },
+            {
+              "rolle" : "Joseph Quick",
+              "sprecher" : "Harry Rowohlt"
+            },
+            {
+              "rolle" : "Mr. Raynes",
+              "sprecher" : "Olaf Kreutzenbeck"
+            },
+            {
+              "rolle" : "Jeff White",
+              "sprecher" : "Horst Naumann"
+            },
+            {
+              "rolle" : "Hedy Carlson",
+              "sprecher" : "Luise Helm"
+            },
+            {
+              "rolle" : "Gil Renard",
+              "sprecher" : "Udo Schenk"
+            },
+            {
+              "rolle" : "Peter Foster",
+              "sprecher" : "Gerrit Schmidt-Foß"
+            },
+            {
+              "rolle" : "Matthew Gabbin",
+              "sprecher" : "Jürgen Thormann"
+            },
+            {
+              "rolle" : "Steve",
+              "sprecher" : "Sascha Draeger"
+            },
+            {
+              "rolle" : "Laury",
+              "sprecher" : "Rhea Harder-Vennewald"
+            },
+            {
+              "rolle" : "Georgina",
+              "sprecher" : "Maud Ackermann"
+            },
+            {
+              "rolle" : "Bedienung",
+              "sprecher" : "Tim Wenderoth"
+            },
+            {
+              "rolle" : "Gast",
+              "sprecher" : "Andreas Otto"
+            },
+            {
+              "rolle" : "Sekretärin",
+              "sprecher" : "Corinna Wodrich"
+            },
+            {
+              "rolle" : "Sebastian Dawson",
+              "sprecher" : "Bastian Pastewka"
+            },
+            {
+              "rolle" : "Radiosprecher",
+              "sprecher" : "Tobias Meister"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/3/metadata.json",
@@ -795,187 +797,188 @@
       "hörspielskriptautor" : "André Minninger",
       "beschreibung" : "Kann ein und derselbe Tag dreimal völlig unterschiedlich verlaufen? Kann ein unscheinbares Detail wie ein Colaglas darüber entscheiden, wie sich alle weiteren Geschehnisse entwickeln? Erlebe, wie Justus, Peter und Bob auf den unheimlichen Fluch der Sheldon Street, die mysteriösen Zeichen der Ritter stoßen und den bedrohlichen Fremden Freund stoßen – und zwar zeitgleich am selben Tag!\nDrei Geschichten von drei Autoren führen dich dreimal durch einen Tag, wie er unterschiedlicher nicht verlaufen könnte.",
       "veröffentlichungsdatum" : "2010-10-01",
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Officer Flann Doyle",
-          "Douglas Welbat"
-        ],
-        [
-          "Tanya Sullivan",
-          "Marion Elskis"
-        ],
-        [
-          "Sebastian Dawson",
-          "Bastian Pastewka"
-        ],
-        [
-          "Miss Tomkins",
-          "Steffi Kirchberger"
-        ],
-        [
-          "Mr. Foley",
-          "Dirk Bach"
-        ],
-        [
-          "John Gabbin",
-          "Tobias Schmidt"
-        ],
-        [
-          "Matthew Gabbin",
-          "Jürgen Thormann"
-        ],
-        [
-          "Georgina",
-          "Maud Ackermann"
-        ],
-        [
-          "Gil Renard",
-          "Udo Schenk"
-        ],
-        [
-          "Hedy Carlson",
-          "Luise Helm"
-        ],
-        [
-          "Steve",
-          "Sascha Draeger"
-        ],
-        [
-          "Jack",
-          "Hendrik Buchna"
-        ],
-        [
-          "Laury",
-          "Rhea Harder-Vennewald"
-        ],
-        [
-          "Gast 1",
-          "Christian Senger"
-        ],
-        [
-          "Fahrerin",
-          "Corinna Wodrich"
-        ],
-        [
-          "Radiosprecher",
-          "Tobias Meister"
-        ],
-        [
-          "Peter Foster",
-          "Gerrit Schmidt-Foss"
-        ],
-        [
-          "Mrs. Shaw",
-          "Isabella Grote"
-        ],
-        [
-          "Annie Wilkes",
-          "Regina Lemnitz"
-        ],
-        [
-          "Mädchen 1",
-          "Katinka Körting"
-        ],
-        [
-          "Mädchen 2",
-          "Jacqueline Meybauer"
-        ],
-        [
-          "Alter Mann",
-          "Jörg Gillner"
-        ],
-        [
-          "Junger Mann",
-          "Patrick Bach"
-        ],
-        [
-          "Dick Perry",
-          "Ernst H. Hilbich"
-        ],
-        [
-          "Bill Andrews",
-          "Henry König"
-        ],
-        [
-          "Miss Bennett",
-          "Renate Pilcher"
-        ],
-        [
-          "Walter Bush",
-          "Rolf E. Schenker"
-        ],
-        [
-          "Ian Bush",
-          "Sky du Mont / Lucas Sperber"
-        ],
-        [
-          "Jimmy Sinclair",
-          "Siegfried Kernen / Nils Noller"
-        ],
-        [
-          "Charlie Parker",
-          "Jörg Gillner / Laurence Kalaidjan"
-        ],
-        [
-          "Brianna Jackson",
-          "Hansi Jochmann / Natalie Demtröder"
-        ],
-        [
-          "Chloe Smathers",
-          "Valerie Demtröder"
-        ],
-        [
-          "Joseph Quick",
-          "Harry Rowohlt"
-        ],
-        [
-          "Mr. Raynes",
-          "Olaf Kreuzenbeck"
-        ],
-        [
-          "Jeff White",
-          "Horst Naumann"
-        ],
-        [
-          "Bedienung",
-          "Tim Wenderoth"
-        ],
-        [
-          "Gast 2",
-          "Andreas Otto"
-        ],
-        [
-          "Sekretärin",
-          "Corinna Wodrich"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Officer Flann Doyle",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Tanya Sullivan",
+          "sprecher" : "Marion Elskis"
+        },
+        {
+          "rolle" : "Sebastian Dawson",
+          "sprecher" : "Bastian Pastewka"
+        },
+        {
+          "rolle" : "Miss Tomkins",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Mr. Foley",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "John Gabbin",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Matthew Gabbin",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Georgina",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Gil Renard",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Hedy Carlson",
+          "sprecher" : "Luise Helm"
+        },
+        {
+          "rolle" : "Steve",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Hendrik Buchna"
+        },
+        {
+          "rolle" : "Laury",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Gast 1",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Fahrerin",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Radiosprecher",
+          "sprecher" : "Tobias Meister"
+        },
+        {
+          "rolle" : "Peter Foster",
+          "sprecher" : "Gerrit Schmidt-Foß"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Isabella Grothe"
+        },
+        {
+          "rolle" : "Annie Wilkes",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Mädchen 1",
+          "sprecher" : "Katinka Körting"
+        },
+        {
+          "rolle" : "Mädchen 2",
+          "sprecher" : "Jacqueline Meybauer"
+        },
+        {
+          "rolle" : "Alter Mann",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Junger Mann",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Dick Perry",
+          "sprecher" : "Ernst H. Hilbich"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Miss Bennett",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Walter Bush",
+          "sprecher" : "Rolf E. Schenker"
+        },
+        {
+          "rolle" : "Ian Bush",
+          "sprecher" : "Sky du Mont / Lukas T. Sperber"
+        },
+        {
+          "rolle" : "Jimmy Sinclair",
+          "sprecher" : "Siegfried W. Kernen / Nils Noller"
+        },
+        {
+          "rolle" : "Charlie Parker",
+          "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+        },
+        {
+          "rolle" : "Brianna Jackson",
+          "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+        },
+        {
+          "rolle" : "Chloe Smathers",
+          "sprecher" : "Valerie Demtrøder"
+        },
+        {
+          "rolle" : "Joseph Quick",
+          "sprecher" : "Harry Rowohlt"
+        },
+        {
+          "rolle" : "Mr. Raynes",
+          "sprecher" : "Olaf Kreutzenbeck"
+        },
+        {
+          "rolle" : "Jeff White",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Bedienung",
+          "sprecher" : "Tim Wenderoth"
+        },
+        {
+          "rolle" : "Gast 2",
+          "sprecher" : "Andreas Otto"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Corinna Wodrich"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/metadata.json",
@@ -1051,99 +1054,101 @@
           "end" : 3675453
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Ben",
-          "Fabian Harloff"
-        ],
-        [
-          "Silvia",
-          "Marion von Stengel"
-        ],
-        [
-          "Ralph",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Spud",
-          "Rasmus Borowski"
-        ],
-        [
-          "O-Ian",
-          "Celine Fontanges"
-        ],
-        [
-          "Setch",
-          "Stefan Brönneke"
-        ],
-        [
-          "Hi-Top",
-          "Robin Brosch"
-        ],
-        [
-          "Car",
-          "Volker Hanisch"
-        ],
-        [
-          "Chip-Shape",
-          "Jens Wendland"
-        ],
-        [
-          "Carol",
-          "Alexandra Garcia"
-        ],
-        [
-          "Slide Terranova",
-          "Nico König"
-        ],
-        [
-          "P. \"Pejo\" Joseph McGaskill",
-          "Peter Kirchberger"
-        ],
-        [
-          "Sax Sendler",
-          "Christian Concillio"
-        ],
-        [
-          "Hausmeister",
-          "Edgar Bessen"
-        ],
-        [
-          "Bau-Kollege",
-          "Holger Umbreit"
-        ],
-        [
-          "Junge",
-          "Michael Lampe"
-        ],
-        [
-          "Mädchen",
-          "Pamela Punti"
-        ],
-        [
-          "Weibl. Offstimme",
-          "Susanne Wulkow"
-        ],
-        [
-          "Werbestimme",
-          "Enie van de Meiklokjes"
-        ],
-        [
-          "Menge",
-          "www.dreifragezeichen.de/www/menge-brainwash"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Ben",
+          "sprecher" : "Fabian Harloff"
+        },
+        {
+          "rolle" : "Silvia",
+          "sprecher" : "Marion von Stengel"
+        },
+        {
+          "rolle" : "Ralph",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Spud",
+          "sprecher" : "Rasmus Borowski"
+        },
+        {
+          "rolle" : "O-Ian",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Setch",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Hi-Top",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Car",
+          "sprecher" : "Volker Hanisch"
+        },
+        {
+          "rolle" : "Chip-Shape",
+          "sprecher" : "Jens Wendland"
+        },
+        {
+          "rolle" : "Carol",
+          "sprecher" : "Alexandra Garcia"
+        },
+        {
+          "rolle" : "Slide Terranova",
+          "sprecher" : "Nicolas König"
+        },
+        {
+          "rolle" : "P. \"Pejo\" Joseph McGaskill",
+          "sprecher" : "Peter Kirchberger"
+        },
+        {
+          "rolle" : "Sax Sandler",
+          "sprecher" : "Christian Concilio"
+        },
+        {
+          "rolle" : "Hausmeister",
+          "sprecher" : "Edgar Bessen"
+        },
+        {
+          "rolle" : "Bau-Kollege",
+          "sprecher" : "Holger Umbreit"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "André Minninger",
+          "pseudonym" : "Michael Lampe"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Weibl. Offstimme",
+          "sprecher" : "Susanne Wulkow"
+        },
+        {
+          "rolle" : "Werbestimme",
+          "sprecher" : "Enie van de Meiklokjes"
+        },
+        {
+          "rolle" : "Menge",
+          "sprecher" : "Lauscherlounge-Zuschauer (www.dreifragezeichen.de/www/menge-brainwash)"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json",
@@ -1294,91 +1299,91 @@
               "end" : 3498480
             }
           ],
-          "sprecher" : [
-            [
-              "Off-Stimme",
-              "Claudia Stocksieker"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tony",
-              "Stefan Kaminski"
-            ],
-            [
-              "Joey",
-              "Tommaso Cacciapuoti"
-            ],
-            [
-              "Ansager in der Schlammringkampfarena",
-              "Christian Rudolf"
-            ],
-            [
-              "Margarine",
-              "Alma Clausen"
-            ],
-            [
-              "Lincolnfahrer",
-              "Mike Olsowski"
-            ],
-            [
-              "Freakshow-Jack",
-              "Peter Bänker"
-            ],
-            [
-              "Der unergründliche Mickey",
-              "Krystian Martinek"
-            ],
-            [
-              "Die bärtige Marilyn",
-              "Santiago Ziesmer"
-            ],
-            [
-              "Miss Luzzy",
-              "Katja Brügger"
-            ],
-            [
-              "Bubba Detroit",
-              "Klaus Dittmann"
-            ],
-            [
-              "Junge",
-              "Patrick Bach"
-            ],
-            [
-              "Burger-Verkäufer Arnie",
-              "Manou Lubowski"
-            ],
-            [
-              "Reporterin",
-              "Mara Bergmann"
-            ],
-            [
-              "Anna Millar",
-              "Christine Pappert"
-            ],
-            [
-              "Bombenattentäter Daniel",
-              "Tim Grobe"
-            ],
-            [
-              "Polizist",
-              "Wolfgang Kaven"
-            ],
-            [
-              "Papagei",
-              "Heikedine Körting"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Off-Stimme",
+              "sprecher" : "Claudia Stocksieker"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tony",
+              "sprecher" : "Stefan Kaminski"
+            },
+            {
+              "rolle" : "Joey",
+              "sprecher" : "Tommaso Cacciapuoti"
+            },
+            {
+              "rolle" : "Ansager in der Schlammringkampfarena",
+              "sprecher" : "Christian Rudolf"
+            },
+            {
+              "rolle" : "Margarine",
+              "sprecher" : "Alma Clausen"
+            },
+            {
+              "rolle" : "Lincolnfahrer",
+              "sprecher" : "Mike Olsowski"
+            },
+            {
+              "rolle" : "Freakshow-Jack",
+              "sprecher" : "Peter Bänker"
+            },
+            {
+              "rolle" : "Der unergründliche Mickey",
+              "sprecher" : "Krystian Martinek"
+            },
+            {
+              "rolle" : "Die bärtige Marilyn",
+              "sprecher" : "Santiago Ziesmer"
+            },
+            {
+              "rolle" : "Miss Luzzy",
+              "sprecher" : "Katja Brügger"
+            },
+            {
+              "rolle" : "Bubba Detroit",
+              "sprecher" : "Klaus Dittmann"
+            },
+            {
+              "rolle" : "Junge",
+              "sprecher" : "Patrick Bach"
+            },
+            {
+              "rolle" : "Burger-Verkäufer Arnie",
+              "sprecher" : "Manou Lubowski"
+            },
+            {
+              "rolle" : "Reporterin",
+              "sprecher" : "Mara Bergmann"
+            },
+            {
+              "rolle" : "Anna Millar",
+              "sprecher" : "Christine Pappert"
+            },
+            {
+              "rolle" : "Bombenattentäter Daniel",
+              "sprecher" : "Tim Grobe"
+            },
+            {
+              "rolle" : "Polizist",
+              "sprecher" : "Wolfgang Kaven"
+            },
+            {
+              "rolle" : "Blacky",
+              "sprecher" : "Heikedine Körting"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/1/metadata.json",
@@ -1679,79 +1684,79 @@
               "end" : 4497427
             }
           ],
-          "sprecher" : [
-            [
-              "Off-Stimme",
-              "Claudia Stocksieker"
-            ],
-            [
-              "Justus Jonas",
-              "Oliver Rohrbeck"
-            ],
-            [
-              "Peter Shaw",
-              "Jens Wawrczeck"
-            ],
-            [
-              "Bob Andrews",
-              "Andreas Fröhlich"
-            ],
-            [
-              "Tony",
-              "Stefan Kaminski"
-            ],
-            [
-              "Joey",
-              "Tommaso Cacciapuoti"
-            ],
-            [
-              "Anna Millar",
-              "Christine Pappert"
-            ],
-            [
-              "Lily",
-              "Verena Wolfien"
-            ],
-            [
-              "Max",
-              "Holger Umbreit"
-            ],
-            [
-              "Milli",
-              "Ulrike Knief"
-            ],
-            [
-              "Celeste Hummer",
-              "Maria Willer"
-            ],
-            [
-              "Anthem Hummer",
-              "Martin May"
-            ],
-            [
-              "Morton",
-              "Andreas von der Meden"
-            ],
-            [
-              "Papagei",
-              "Heikedine Körting"
-            ],
-            [
-              "Bruce Millar",
-              "Ben Hecker"
-            ],
-            [
-              "Kommissar Reynolds",
-              "Wolfgang Draeger"
-            ],
-            [
-              "Mr. Albert Hitfield",
-              "Volker Bogdan"
-            ],
-            [
-              "TV-Sprecher",
-              "Friedel Bott"
-            ]
+          "sprechrollen" : [
+            {
+              "rolle" : "Off-Stimme",
+              "sprecher" : "Claudia Stocksieker"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tony",
+              "sprecher" : "Stefan Kaminski"
+            },
+            {
+              "rolle" : "Joey",
+              "sprecher" : "Tommaso Cacciapuoti"
+            },
+            {
+              "rolle" : "Anna Millar",
+              "sprecher" : "Christine Pappert"
+            },
+            {
+              "rolle" : "Lily",
+              "sprecher" : "Verena Wolfien"
+            },
+            {
+              "rolle" : "Max",
+              "sprecher" : "Holger Umbreit"
+            },
+            {
+              "rolle" : "Milli",
+              "sprecher" : "Ulrike Knief"
+            },
+            {
+              "rolle" : "Celeste Hummer",
+              "sprecher" : "Maria Willer"
+            },
+            {
+              "rolle" : "Anthem Hummer",
+              "sprecher" : "Martin May"
+            },
+            {
+              "rolle" : "Morton",
+              "sprecher" : "Andreas von der Meden"
+            },
+            {
+              "rolle" : "Blacky",
+              "sprecher" : "Heikedine Körting"
+            },
+            {
+              "rolle" : "Bruce Millar",
+              "sprecher" : "Ben Hecker"
+            },
+            {
+              "rolle" : "Kommissar Reynolds",
+              "sprecher" : "Wolfgang Draeger"
+            },
+            {
+              "rolle" : "Albert Hitfield",
+              "sprecher" : "Volker Bogdan"
+            },
+            {
+              "rolle" : "TV-Sprecher",
+              "sprecher" : "Friedel Bott"
+            }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/2/metadata.json",
@@ -2056,131 +2061,131 @@
           "end" : 7594170
         }
       ],
-      "sprecher" : [
-        [
-          "Off-Stimme",
-          "Claudia Stocksieker"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tony",
-          "Stefan Kaminski"
-        ],
-        [
-          "Joey",
-          "Tommaso Cacciapuoti"
-        ],
-        [
-          "Ansager in der Schlammringkampfarena",
-          "Christian Rudolf"
-        ],
-        [
-          "Margarine",
-          "Alma Clausen"
-        ],
-        [
-          "Lincolnfahrer",
-          "Mike Olsowski"
-        ],
-        [
-          "Freakshow-Jack",
-          "Peter Bänker"
-        ],
-        [
-          "Der unergründliche Mickey",
-          "Krystian Martinek"
-        ],
-        [
-          "Die bärtige Marilyn",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Miss Luzzy",
-          "Katja Brügger"
-        ],
-        [
-          "Bubba Detroit",
-          "Klaus Dittmann"
-        ],
-        [
-          "Junge",
-          "Patrick Bach"
-        ],
-        [
-          "Burger-Verkäufer Arnie",
-          "Manou Lubowski"
-        ],
-        [
-          "Reporterin",
-          "Mara Bergmann"
-        ],
-        [
-          "Anna Millar",
-          "Christine Pappert"
-        ],
-        [
-          "Bombenattentäter Daniel",
-          "Tim Grobe"
-        ],
-        [
-          "Polizist",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Lily",
-          "Verena Wolfien"
-        ],
-        [
-          "Max",
-          "Holger Umbreit"
-        ],
-        [
-          "Milli",
-          "Ulrike Knief"
-        ],
-        [
-          "Celeste Hummer",
-          "Maria Willer"
-        ],
-        [
-          "Anthem Hummer",
-          "Martin May"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Bruce Millar",
-          "Ben Hecker"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mr. Albert Hitfield",
-          "Volker Bogdan"
-        ],
-        [
-          "TV-Sprecher",
-          "Friedel Bott"
-        ],
-        [
-          "Papagei",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Off-Stimme",
+          "sprecher" : "Claudia Stocksieker"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Stefan Kaminski"
+        },
+        {
+          "rolle" : "Joey",
+          "sprecher" : "Tommaso Cacciapuoti"
+        },
+        {
+          "rolle" : "Ansager in der Schlammringkampfarena",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Margarine",
+          "sprecher" : "Alma Clausen"
+        },
+        {
+          "rolle" : "Lincolnfahrer",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Freakshow-Jack",
+          "sprecher" : "Peter Bänker"
+        },
+        {
+          "rolle" : "Der unergründliche Mickey",
+          "sprecher" : "Krystian Martinek"
+        },
+        {
+          "rolle" : "Die bärtige Marilyn",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Miss Luzzy",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Bubba Detroit",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Burger-Verkäufer Arnie",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Reporterin",
+          "sprecher" : "Mara Bergmann"
+        },
+        {
+          "rolle" : "Anna Millar",
+          "sprecher" : "Christine Pappert"
+        },
+        {
+          "rolle" : "Bombenattentäter Daniel",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Lily",
+          "sprecher" : "Verena Wolfien"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Holger Umbreit"
+        },
+        {
+          "rolle" : "Milli",
+          "sprecher" : "Ulrike Knief"
+        },
+        {
+          "rolle" : "Celeste Hummer",
+          "sprecher" : "Maria Willer"
+        },
+        {
+          "rolle" : "Anthem Hummer",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Bruce Millar",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Albert Hitfield",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "TV-Sprecher",
+          "sprecher" : "Friedel Bott"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json",
@@ -2242,59 +2247,59 @@
           "end" : 3170453
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Doktor Ax Me",
-          "Krystian Martinek"
-        ],
-        [
-          "Stinky Rossiter",
-          "Dustin Sattler-Semmelrogge"
-        ],
-        [
-          "Fear Crowther",
-          "Ingo Mommsen"
-        ],
-        [
-          "Mouth Crosby",
-          "Stefan Gabriel"
-        ],
-        [
-          "Mack Dolland",
-          "Mike Olsowski"
-        ],
-        [
-          "Eric Mukogawa",
-          "Marek Harloff"
-        ],
-        [
-          "Marilla",
-          "Saskia Mayerhoff"
-        ],
-        [
-          "Kelly",
-          "Juliane Szalay"
-        ],
-        [
-          "Rosie",
-          "Reinhilt Schneider"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Doktor Ax Me",
+          "sprecher" : "Krystian Martinek"
+        },
+        {
+          "rolle" : "Stinky Rossiter",
+          "sprecher" : "Dustin Semmelrogge"
+        },
+        {
+          "rolle" : "Fear Crowther",
+          "sprecher" : "Ingo Nommsen"
+        },
+        {
+          "rolle" : "Mouth Crosby",
+          "sprecher" : "Stefan Gabriel"
+        },
+        {
+          "rolle" : "Mack Dolland",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Eric Mukogawa",
+          "sprecher" : "Marek Harloff"
+        },
+        {
+          "rolle" : "Marilla",
+          "sprecher" : "Saskia Mayerhoff"
+        },
+        {
+          "rolle" : "Kelly",
+          "sprecher" : "Juliane Szalay"
+        },
+        {
+          "rolle" : "Rosie",
+          "sprecher" : "Reinhilt Schneider"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/metadata.json",
@@ -2581,67 +2586,67 @@
           "end" : 10281307
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Mrs. Lydia Candle",
-          "Monika John"
-        ],
-        [
-          "Jeremias Howard",
-          "Gosta Liptow"
-        ],
-        [
-          "Empfangsdame",
-          "Katja Brügger"
-        ],
-        [
-          "Radiosprecherin",
-          "Simona Pahl"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Patricia Handerson",
-          "Janina Richter"
-        ],
-        [
-          "Polizistin",
-          "Carolin Fortenbacher"
-        ],
-        [
-          "Schausteller",
-          "Eckart Dux"
-        ],
-        [
-          "Edward Candle",
-          "Robin Brosch"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Mrs. Lydia Candle",
+          "sprecher" : "Monika John"
+        },
+        {
+          "rolle" : "Jeremias Howard",
+          "sprecher" : "Gosta Liptow"
+        },
+        {
+          "rolle" : "Empfangsdame",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Radiosprecherin",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Patricia Handerson",
+          "sprecher" : "Janina Richter"
+        },
+        {
+          "rolle" : "Polizistin",
+          "sprecher" : "Carolin Fortenbacher"
+        },
+        {
+          "rolle" : "Schausteller",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Edward Candle",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/metadata.json",
@@ -2927,75 +2932,79 @@
           "end" : 9893400
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mr. Nostigan",
-          "Volker Brandt"
-        ],
-        [
-          "Beastor",
-          "Michael Grimm"
-        ],
-        [
-          "Freeman",
-          "Helgo Liebig"
-        ],
-        [
-          "Skulldor",
-          "Herbert Tennigkeit"
-        ],
-        [
-          "Desmond Calbourne",
-          "Martin May"
-        ],
-        [
-          "Charlton Hogart",
-          "Christian Rode"
-        ],
-        [
-          "Santa Claus",
-          "Klaus Dittmann"
-        ],
-        [
-          "Mason Wachinsk",
-          "Achim Schülke"
-        ],
-        [
-          "Elfe",
-          "Linda Fölster"
-        ],
-        [
-          "Elfenbeinfrau",
-          "Heidi Berndt"
-        ],
-        [
-          "Milhouse",
-          "Hans-Joachim Dethlof"
-        ],
-        [
-          "Cafelyn McBryde",
-          "Marianne Bernhardt"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mr. Nostigan",
+          "sprecher" : "Volker Brandt"
+        },
+        {
+          "rolle" : "Beastor",
+          "sprecher" : "Michael Grimm"
+        },
+        {
+          "rolle" : "Freeman",
+          "sprecher" : "Helgo Liebig"
+        },
+        {
+          "rolle" : "Skulldor",
+          "sprecher" : "Herbert Tennigkeit"
+        },
+        {
+          "rolle" : "Desmond Calbourne",
+          "sprecher" : "Monty Arnold"
+        },
+        {
+          "rolle" : "Frederic Barnes",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Charlton Hogart",
+          "sprecher" : "Christian Rode"
+        },
+        {
+          "rolle" : "Santa Claus",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Mason Wachinsk",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Elfe",
+          "sprecher" : "Linda Fölster"
+        },
+        {
+          "rolle" : "Elfenbeinfrau",
+          "sprecher" : "Heidi Berndt"
+        },
+        {
+          "rolle" : "Milhouse",
+          "sprecher" : "Hans-Joachim Dethlof"
+        },
+        {
+          "rolle" : "Cafelyn McBryde",
+          "sprecher" : "Marianne Bernhardt"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json",
@@ -3281,67 +3290,67 @@
           "end" : 9948853
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Gianna",
-          "Celine Fontanges"
-        ],
-        [
-          "Lance",
-          "Armin Schlagwein"
-        ],
-        [
-          "Debra",
-          "Melanie Kastaun"
-        ],
-        [
-          "Audrey",
-          "Anja Topf"
-        ],
-        [
-          "Bellins",
-          "Joachim Kretzer"
-        ],
-        [
-          "Jerry",
-          "Matthias Keller"
-        ],
-        [
-          "Corey",
-          "Andreas Zaron"
-        ],
-        [
-          "Joe",
-          "André Beyer"
-        ],
-        [
-          "Mr. Allister Frain",
-          "Fabian Harloff"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Gianna",
+          "sprecher" : "Celine Fontanges"
+        },
+        {
+          "rolle" : "Lance",
+          "sprecher" : "Armin Schlagwein"
+        },
+        {
+          "rolle" : "Debra",
+          "sprecher" : "Melanie Kastaun"
+        },
+        {
+          "rolle" : "Audrey",
+          "sprecher" : "Anja Topf"
+        },
+        {
+          "rolle" : "Bellins",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Jerry",
+          "sprecher" : "Matthias Keller"
+        },
+        {
+          "rolle" : "Corey",
+          "sprecher" : "Andreas Zaron"
+        },
+        {
+          "rolle" : "Joe",
+          "sprecher" : "André Beyer"
+        },
+        {
+          "rolle" : "Mr. Allister Frain",
+          "sprecher" : "Fabian Harloff"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/metadata.json",
@@ -3618,131 +3627,132 @@
           "end" : 9154760
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Santa Claus",
-          "Claus Wilcke"
-        ],
-        [
-          "Fotograf",
-          "Stephan Schad"
-        ],
-        [
-          "Sandy",
-          "Angela Stresemann"
-        ],
-        [
-          "Mutter",
-          "Pamela Punti"
-        ],
-        [
-          "Mr. Puckle",
-          "Christian Rudolf"
-        ],
-        [
-          "Mrs. Hatchett",
-          "Petra Kleinert"
-        ],
-        [
-          "Matty",
-          "Joshua Rudolf"
-        ],
-        [
-          "1. Security",
-          "Patrick Berg"
-        ],
-        [
-          "2. Security",
-          "Philipp Stumpp"
-        ],
-        [
-          "3. Security",
-          "Max König"
-        ],
-        [
-          "4. Security",
-          "Tony Curting"
-        ],
-        [
-          "Pater",
-          "Achim Schülke"
-        ],
-        [
-          "Engel",
-          "Theresa Underberg"
-        ],
-        [
-          "1. Polizist",
-          "Patrick Baehr"
-        ],
-        [
-          "2. Polizist",
-          "Alexander Mettin"
-        ],
-        [
-          "3. Polizist",
-          "Douglas Welbat"
-        ],
-        [
-          "Angestellte",
-          "Katrin Decker"
-        ],
-        [
-          "Larry",
-          "Jan Langer"
-        ],
-        [
-          "Luke Bigelow",
-          "Harald Effenberg"
-        ],
-        [
-          "Molly",
-          "Regine Lamster"
-        ],
-        [
-          "Emmett",
-          "Reinhold Kammerer"
-        ],
-        [
-          "Durchsage",
-          "Andrea Lüdke"
-        ],
-        [
-          "Krankenschwester",
-          "Scarlett Lubowski"
-        ],
-        [
-          "Mann",
-          "Helge Halvé"
-        ],
-        [
-          "Bandenchef",
-          "Lars Schmidtke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Santa Claus",
+          "sprecher" : "Claus Wilcke"
+        },
+        {
+          "rolle" : "Fotograf",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Sandy",
+          "sprecher" : "Angela Stresemann"
+        },
+        {
+          "rolle" : "Mutter",
+          "sprecher" : "Heikedine Körting",
+          "pseudonym" : "Pamela Punti"
+        },
+        {
+          "rolle" : "Mr. Puckle",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Mrs. Hatchett",
+          "sprecher" : "Petra Kleinert"
+        },
+        {
+          "rolle" : "Matty",
+          "sprecher" : "Joshua Rudolf Goralsky"
+        },
+        {
+          "rolle" : "Security 1",
+          "sprecher" : "Patrick Berg"
+        },
+        {
+          "rolle" : "Security 2",
+          "sprecher" : "Philipp Stumpp"
+        },
+        {
+          "rolle" : "Security 3",
+          "sprecher" : "Max König"
+        },
+        {
+          "rolle" : "Security 4",
+          "sprecher" : "Tony Curting"
+        },
+        {
+          "rolle" : "Pater",
+          "sprecher" : "Achim Schülke"
+        },
+        {
+          "rolle" : "Engel",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Patrick Baehr"
+        },
+        {
+          "rolle" : "Polizist 2",
+          "sprecher" : "Alexander Mettin"
+        },
+        {
+          "rolle" : "Polizist 3",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Angestellte",
+          "sprecher" : "Katrin Decker"
+        },
+        {
+          "rolle" : "Larry",
+          "sprecher" : "Jan Langer"
+        },
+        {
+          "rolle" : "Luke Bigelow",
+          "sprecher" : "Harald Effenberg"
+        },
+        {
+          "rolle" : "Molly",
+          "sprecher" : "Regine Lamster"
+        },
+        {
+          "rolle" : "Emmett",
+          "sprecher" : "Reinhold Kammerer"
+        },
+        {
+          "rolle" : "Durchsage",
+          "sprecher" : "Andrea Lüdke"
+        },
+        {
+          "rolle" : "Krankenschwester",
+          "sprecher" : "Scarlet Cavadenti Lubowski"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "Helge Halvé"
+        },
+        {
+          "rolle" : "Bandenchef",
+          "sprecher" : "Lars Schmidtke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/metadata.json",
@@ -4028,79 +4038,79 @@
           "end" : 12210266
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Erik Schäffler"
-        ],
-        [
-          "Emily",
-          "Gerlinde Dillge"
-        ],
-        [
-          "Glenda",
-          "Saskia Haisch"
-        ],
-        [
-          "Mrs. Kirk",
-          "Suzanne von Borsody"
-        ],
-        [
-          "Desmond",
-          "Patrick Baehr"
-        ],
-        [
-          "Megan",
-          "Henrike Fehrs"
-        ],
-        [
-          "Samuel Leech",
-          "Achim Buch"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Kathy Hiller",
-          "Lucia Angelina Mahler"
-        ],
-        [
-          "Violet Bell",
-          "Andrea Lüdke"
-        ],
-        [
-          "Jack",
-          "Manou Lubowski"
-        ],
-        [
-          "Daniel",
-          "Sebastian König"
-        ],
-        [
-          "Blacky",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Emily",
+          "sprecher" : "Gerlinde Dillge"
+        },
+        {
+          "rolle" : "Glenda",
+          "sprecher" : "Saskia Haisch"
+        },
+        {
+          "rolle" : "Mrs. Kirk",
+          "sprecher" : "Suzanne von Borsody"
+        },
+        {
+          "rolle" : "Desmond",
+          "sprecher" : "Patrick Baehr"
+        },
+        {
+          "rolle" : "Megan",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Samuel Leech",
+          "sprecher" : "Achim Buch"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Kathy Hiller",
+          "sprecher" : "Lucia-Angelina Mahler"
+        },
+        {
+          "rolle" : "Violet Bell",
+          "sprecher" : "Andrea Lüdke"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Daniel",
+          "sprecher" : "Sebastian König"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json",
@@ -4257,99 +4267,100 @@
           "end" : 5382547
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Nayra Paredes",
-          "Sonja Stein"
-        ],
-        [
-          "Andrés Paredes",
-          "Tim Kreuer"
-        ],
-        [
-          "Mr. Gabriel Paredes",
-          "Urs Affolter"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Quentin Montgrove",
-          "Eberhard Haar"
-        ],
-        [
-          "Emma Miller",
-          "Kerstin Draeger"
-        ],
-        [
-          "Der Einzige Inka",
-          "Eckart Dux"
-        ],
-        [
-          "Kassiererin im Museum",
-          "Merete Brettschneider"
-        ],
-        [
-          "Ansagerin im Museum",
-          "Merete Brettschneider"
-        ],
-        [
-          "Eisdielen-Besitzer",
-          "Robert Missler"
-        ],
-        [
-          "Alte Frau",
-          "Katja Brügger"
-        ],
-        [
-          "Mann",
-          "Andre Gatzke"
-        ],
-        [
-          "Frau 1",
-          "Heikedine Körting"
-        ],
-        [
-          "Frau 2",
-          "Susan Jarling"
-        ],
-        [
-          "Frau 3",
-          "Hella von der Osten"
-        ],
-        [
-          "Frau 4",
-          "Saskia Weckler"
-        ],
-        [
-          "Mädchen",
-          "Theresa Unterberg"
-        ],
-        [
-          "Kind 1",
-          "Malon Stahlhut"
-        ],
-        [
-          "Kind 2",
-          "Julia Fölster"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Nayra Paredes",
+          "sprecher" : "Sonja Stein"
+        },
+        {
+          "rolle" : "Andrés Paredes",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Mr. Gabriel Paredes",
+          "sprecher" : "Urs Affolter"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Quentin Montgrove",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Emma Miller",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Der Einzige Inka",
+          "sprecher" : "Eckart Dux"
+        },
+        {
+          "rolle" : "Kassiererin im Museum",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Ansagerin im Museum",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Eisdielen-Besitzer",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Alte Frau",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Mann",
+          "sprecher" : "André Gatzke"
+        },
+        {
+          "rolle" : "Frau 1",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Frau 2",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Frau 3",
+          "sprecher" : "Hella von der Osten-Sacken"
+        },
+        {
+          "rolle" : "Frau 4",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Mädchen",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Kind 1",
+          "sprecher" : "Malon Stahlhuth"
+        },
+        {
+          "rolle" : "Kind 2",
+          "sprecher" : "Julia Fölster"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json",
@@ -4426,71 +4437,71 @@
           "end" : 4300133
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Dylan Harvey",
-          "Stephan Schad"
-        ],
-        [
-          "Mrs. Violet Conroy",
-          "Birte Kretschmer"
-        ],
-        [
-          "Mr. Alex Scott",
-          "Oliver Böttche"
-        ],
-        [
-          "Myriel",
-          "Undine Ullmer"
-        ],
-        [
-          "Zimmermädchen",
-          "Theresa Underberg"
-        ],
-        [
-          "Zimmerjunge",
-          "Jannik Endemann"
-        ],
-        [
-          "Mutter im Stadtpark",
-          "Saskia Weckler"
-        ],
-        [
-          "Klein Peter",
-          "Malon Stahlhut"
-        ],
-        [
-          "Kellnerin im Hotel",
-          "Alexandra Garcia"
-        ],
-        [
-          "Handwerker im Hotel 1",
-          "André Gatzke"
-        ],
-        [
-          "Handwerker im Hotel 2",
-          "Bent Schönemann"
-        ],
-        [
-          "Internetcafébesitzer",
-          "Tim Kreuer"
-        ],
-        [
-          "Vortragsbesucher, Parkbesucher, Frühstücksgäste, Nachbarn",
-          "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Kirchberger, Ingeborg Christiansen, Michaela Kreissler, Theresa Underberg, Kerstin Draeger, Lennart Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Dylan Harvey",
+          "sprecher" : "Stephan Schad"
+        },
+        {
+          "rolle" : "Mrs. Violet Conroy",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Mr. Alex Scott",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Myriel",
+          "sprecher" : "Undine Ullmer"
+        },
+        {
+          "rolle" : "Zimmermädchen",
+          "sprecher" : "Theresa Underberg"
+        },
+        {
+          "rolle" : "Zimmerjunge",
+          "sprecher" : "Jannik Endemann"
+        },
+        {
+          "rolle" : "Mutter im Stadtpark",
+          "sprecher" : "Saskia Weckler"
+        },
+        {
+          "rolle" : "Klein Peter",
+          "sprecher" : "Malon Stahlhuth"
+        },
+        {
+          "rolle" : "Kellnerin im Hotel",
+          "sprecher" : "Alexandra Garcia"
+        },
+        {
+          "rolle" : "Handwerker im Hotel 1",
+          "sprecher" : "André Gatzke"
+        },
+        {
+          "rolle" : "Handwerker im Hotel 2",
+          "sprecher" : "Bent Schönemann"
+        },
+        {
+          "rolle" : "Internetcafébesitzer",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Vortragsbesucher, Parkbesucher, Frühstücksgäste, Nachbarn",
+          "sprecher" : "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Damare, Ingeborg Christiansen, Micaëla Kreißler, Theresa Underberg, Kerstin Draeger, Lennardt Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/metadata.json",
@@ -4638,115 +4649,116 @@
           "end" : 5066480
         }
       ],
-      "sprecher" : [
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Zachary Collister",
-          "Stephan Benson"
-        ],
-        [
-          "Skinny Norris",
-          "Andreas von der Meden"
-        ],
-        [
-          "Mrs. Hilton",
-          "Katja Brügger"
-        ],
-        [
-          "Mr. Warren",
-          "Stephan Schwartz"
-        ],
-        [
-          "Luke Havering",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Colin Havering",
-          "Santiago Ziesmer"
-        ],
-        [
-          "MacKenzie",
-          "Traudel Sperber"
-        ],
-        [
-          "Erial",
-          "Robert Missler"
-        ],
-        [
-          "Andy",
-          "Tim Grobe"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Francine",
-          "Merete Brettschneider"
-        ],
-        [
-          "Matrose",
-          "Eberhard Haar"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Mrs. Watson",
-          "Corinna Wodrich"
-        ],
-        [
-          "Betrunkener",
-          "Patrick Bach"
-        ],
-        [
-          "Kind 1",
-          "Malon Stahlhuth"
-        ],
-        [
-          "Kind 2",
-          "Julia Fölster"
-        ],
-        [
-          "Taxifahrer",
-          "Tillmann Madaus"
-        ],
-        [
-          "Kartenspieler",
-          "Robin Brosch"
-        ],
-        [
-          "Tochter von Erial",
-          "Zelda Jahreis"
-        ],
-        [
-          "AB-Ansage-Stimme",
-          "Susan Jarling"
-        ],
-        [
-          "Reporter",
-          "Ivo Möller"
-        ],
-        [
-          "Journalistin",
-          "Birte Kretschmer"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Zachary Collister",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Mrs. Hilton",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Mr. Warren",
+          "sprecher" : "Stephan Schwartz"
+        },
+        {
+          "rolle" : "Luke Havering",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Colin Havering",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "MacKenzie",
+          "sprecher" : "Traudel Sperber"
+        },
+        {
+          "rolle" : "Erial",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Andy",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Francine",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Matrose",
+          "sprecher" : "Eberhard Haar"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Mrs. Watson",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Betrunkener",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Kind 1",
+          "sprecher" : "Malon Stahlhuth"
+        },
+        {
+          "rolle" : "Kind 2",
+          "sprecher" : "Julia Fölster"
+        },
+        {
+          "rolle" : "Taxifahrer",
+          "sprecher" : "Tilman Madaus"
+        },
+        {
+          "rolle" : "Kartenspieler",
+          "sprecher" : "Robin Brosch"
+        },
+        {
+          "rolle" : "Tochter von Erial",
+          "sprecher" : "Zelda Jahreis"
+        },
+        {
+          "rolle" : "AB-Ansage-Stimme",
+          "sprecher" : "Susan Jarling"
+        },
+        {
+          "rolle" : "Reporter",
+          "sprecher" : "Ivo Möller"
+        },
+        {
+          "rolle" : "Journalistin",
+          "sprecher" : "Birte Kretschmer"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/metadata.json",
@@ -4923,95 +4935,96 @@
           "end" : 5317587
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Andy Carson",
-          "Stefan Schwade"
-        ],
-        [
-          "Carson, Andys Vater",
-          "Hans Kahlert"
-        ],
-        [
-          "Onkel Titus",
-          "Hans Meinhardt"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Gabbo",
-          "Manfred Reddemann"
-        ],
-        [
-          "Wachmann",
-          "Till Huster"
-        ],
-        [
-          "Iwan",
-          "Urs Affolter"
-        ],
-        [
-          "Reynolds",
-          "Christian Redl"
-        ],
-        [
-          "Khan",
-          "Klaus Dittmann"
-        ],
-        [
-          "Schaustellerin",
-          "Ursula Sieg"
-        ],
-        [
-          "Vermieter",
-          "Stephan Benson"
-        ],
-        [
-          "Polizist 1",
-          "Jürgen Holdorf"
-        ],
-        [
-          "Polizist 2 (Prolog)",
-          "Daniel Welbat"
-        ],
-        [
-          "Polizist 3 (Prolog)",
-          "Matthias Krauße"
-        ],
-        [
-          "Losverkäufer",
-          "Joachim Kretzer"
-        ],
-        [
-          "Kassiererin",
-          "Birte Kretschmer"
-        ],
-        [
-          "Feuerschlucker",
-          "Robert Missler"
-        ],
-        [
-          "Jack",
-          "Timo Alexander Wenzel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Andy Carson",
+          "sprecher" : "Stefan Schwade"
+        },
+        {
+          "rolle" : "Carson, Andys Vater",
+          "sprecher" : "Hans Kahlert"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Gabbo",
+          "sprecher" : "Manfred Reddemann"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Iwan",
+          "sprecher" : "Urs Affolter"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Christian Redl"
+        },
+        {
+          "rolle" : "Khan",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Schaustellerin",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Vermieter",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Polizist 1",
+          "sprecher" : "Jürgen Holdorf"
+        },
+        {
+          "rolle" : "Polizist 2 (Prolog)",
+          "sprecher" : "Daniel Welbat"
+        },
+        {
+          "rolle" : "Polizist 3 (Prolog)",
+          "sprecher" : "Matthias Krauße"
+        },
+        {
+          "rolle" : "Losverkäufer",
+          "sprecher" : "Joachim Kretzer"
+        },
+        {
+          "rolle" : "Kassiererin",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Feuerschlucker",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Timo Alexander Wenzel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/metadata.json",
@@ -5208,71 +5221,71 @@
           "end" : 6126040
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Amanda Ellis",
-          "Simona Pahl"
-        ],
-        [
-          "Jo",
-          "Birte Kretschmer"
-        ],
-        [
-          "Steve Young",
-          "Till Huster"
-        ],
-        [
-          "Ford Follows",
-          "Stephan Benson"
-        ],
-        [
-          "Eric Ellis",
-          "Horst Stark"
-        ],
-        [
-          "Ricardo Yarbrough",
-          "Stefan Brönneke"
-        ],
-        [
-          "Bibliothekarin",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Mr. Friedman",
-          "Douglas Welbat"
-        ],
-        [
-          "Mann in der Bibliothek",
-          "Erik Schäffler"
-        ],
-        [
-          "Sekretärin",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Jackson Cooper",
-          "Oliver Bröttcher"
-        ],
-        [
-          "Mr. Miller",
-          "Pierre Brand"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Amanda Ellis",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Jo",
+          "sprecher" : "Birte Kretschmer"
+        },
+        {
+          "rolle" : "Steve Young",
+          "sprecher" : "Till Huster"
+        },
+        {
+          "rolle" : "Ford Follows",
+          "sprecher" : "Stephan Benson"
+        },
+        {
+          "rolle" : "Eric Ellis",
+          "sprecher" : "Horst Stark"
+        },
+        {
+          "rolle" : "Ricardo Yarbrough",
+          "sprecher" : "Stefan Brönneke"
+        },
+        {
+          "rolle" : "Bibliothekarin",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Mr. Friedman",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Mann in der Bibliothek",
+          "sprecher" : "Erik Schäffler"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Jackson Cooper",
+          "sprecher" : "Oliver Böttcher"
+        },
+        {
+          "rolle" : "Mr. Miller",
+          "sprecher" : "Pierre Brand"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/metadata.json",
@@ -5409,95 +5422,87 @@
           "end" : 5753347
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczek"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Onkel Titus",
-          "Rüdiger Schulzki"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Roger Kind",
-          "Holger Mahlich"
-        ],
-        [
-          "R. Kind als Regisseur Kushing",
-          "Holger Mahlich"
-        ],
-        [
-          "R. Kind als Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Regisseur Kushing",
-          "Tim Grobe"
-        ],
-        [
-          "Melanie Shepard",
-          "Christiane Leuchtmann"
-        ],
-        [
-          "Laura",
-          "Henrike Fehrs"
-        ],
-        [
-          "Lara Bix",
-          "Ursula Sieg"
-        ],
-        [
-          "Jason Frost",
-          "Robert Missler"
-        ],
-        [
-          "Kellnerin",
-          "Simona Pahl"
-        ],
-        [
-          "Museumsdame",
-          "Rhea Harder"
-        ],
-        [
-          "Monsterpuppe",
-          "Kerstin Draeger"
-        ],
-        [
-          "Betty Frost",
-          "Rosemarie Wohlbauer"
-        ],
-        [
-          "Wachmann",
-          "Markus Schäfer"
-        ],
-        [
-          "Kameramann",
-          "Helgé Halvé"
-        ],
-        [
-          "Tonmann",
-          "Timo Alexander Wenzel"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Rüdiger Schulzki"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Roger Kind",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Regisseur Kushing",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Melanie Shepard",
+          "sprecher" : "Christiane Leuchtmann"
+        },
+        {
+          "rolle" : "Laura",
+          "sprecher" : "Henrike Fehrs"
+        },
+        {
+          "rolle" : "Lara Bix",
+          "sprecher" : "Ursula Sieg"
+        },
+        {
+          "rolle" : "Jason Frost",
+          "sprecher" : "Robert Missler"
+        },
+        {
+          "rolle" : "Kellnerin",
+          "sprecher" : "Simona Pahl"
+        },
+        {
+          "rolle" : "Museumsdame",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Monsterpuppe",
+          "sprecher" : "Kerstin Draeger"
+        },
+        {
+          "rolle" : "Betty Frost",
+          "sprecher" : "Rosemarie Wohlbauer"
+        },
+        {
+          "rolle" : "Wachmann",
+          "sprecher" : "Markus Schäfer"
+        },
+        {
+          "rolle" : "Kameramann",
+          "sprecher" : "Helge Halvé"
+        },
+        {
+          "rolle" : "Tonmann",
+          "sprecher" : "Timo Alexander Wenzel"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json",
@@ -5734,67 +5739,67 @@
           "end" : 6770387
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Axel Milberg"
-        ],
-        [
-          "Justus Jonas, Erster Detektiv",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw, Zweiter Detektiv",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews, Recherchen und Archiv",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Skinny Norris",
-          "Tim Kreuer"
-        ],
-        [
-          "Sheryl",
-          "Merete Brettschneider"
-        ],
-        [
-          "Professor Burnham",
-          "Jürgen Thormann"
-        ],
-        [
-          "Salvador Pérez",
-          "Matthias Klimsa"
-        ],
-        [
-          "Tuyucim Florentino Ixmatá",
-          "Mario Ramos"
-        ],
-        [
-          "Tuyucim",
-          "Nicolas Klimsa"
-        ],
-        [
-          "Maria Pérez",
-          "Caroline Kiesewetter"
-        ],
-        [
-          "Zachary",
-          "Roman Rossa"
-        ],
-        [
-          "Tante Mathilda",
-          "Karin Lieneweg"
-        ],
-        [
-          "Conrad Williams",
-          "Peter Weis"
-        ],
-        [
-          "Nachrichtensprecher",
-          "André Schünke"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Axel Milberg"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Skinny Norris",
+          "sprecher" : "Tim Kreuer"
+        },
+        {
+          "rolle" : "Sheryl",
+          "sprecher" : "Merete Brettschneider"
+        },
+        {
+          "rolle" : "Professor Burnham",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Salvador Pérez",
+          "sprecher" : "Matthias Klimsa"
+        },
+        {
+          "rolle" : "Tuyucim Florentino Ixmatá",
+          "sprecher" : "Mario Ramos"
+        },
+        {
+          "rolle" : "Tuyucim",
+          "sprecher" : "Nicolás Klimsa"
+        },
+        {
+          "rolle" : "Maria Pérez",
+          "sprecher" : "Caroline Kiesewetter"
+        },
+        {
+          "rolle" : "Zachary",
+          "sprecher" : "Roman Rossa"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Conrad Williams",
+          "sprecher" : "Peter Weis"
+        },
+        {
+          "rolle" : "Nachrichtensprecher",
+          "sprecher" : "André Schünke"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/metadata.json",

--- a/web/data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json
+++ b/web/data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json
@@ -275,79 +275,79 @@
       "end" : 12210266
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Erik Schäffler"
-    ],
-    [
-      "Emily",
-      "Gerlinde Dillge"
-    ],
-    [
-      "Glenda",
-      "Saskia Haisch"
-    ],
-    [
-      "Mrs. Kirk",
-      "Suzanne von Borsody"
-    ],
-    [
-      "Desmond",
-      "Patrick Baehr"
-    ],
-    [
-      "Megan",
-      "Henrike Fehrs"
-    ],
-    [
-      "Samuel Leech",
-      "Achim Buch"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Kathy Hiller",
-      "Lucia Angelina Mahler"
-    ],
-    [
-      "Violet Bell",
-      "Andrea Lüdke"
-    ],
-    [
-      "Jack",
-      "Manou Lubowski"
-    ],
-    [
-      "Daniel",
-      "Sebastian König"
-    ],
-    [
-      "Blacky",
-      "Heikedine Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Emily",
+      "sprecher" : "Gerlinde Dillge"
+    },
+    {
+      "rolle" : "Glenda",
+      "sprecher" : "Saskia Haisch"
+    },
+    {
+      "rolle" : "Mrs. Kirk",
+      "sprecher" : "Suzanne von Borsody"
+    },
+    {
+      "rolle" : "Desmond",
+      "sprecher" : "Patrick Baehr"
+    },
+    {
+      "rolle" : "Megan",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Samuel Leech",
+      "sprecher" : "Achim Buch"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Kathy Hiller",
+      "sprecher" : "Lucia-Angelina Mahler"
+    },
+    {
+      "rolle" : "Violet Bell",
+      "sprecher" : "Andrea Lüdke"
+    },
+    {
+      "rolle" : "Jack",
+      "sprecher" : "Manou Lubowski"
+    },
+    {
+      "rolle" : "Daniel",
+      "sprecher" : "Sebastian König"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json",

--- a/web/data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json
+++ b/web/data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json
@@ -66,99 +66,101 @@
       "end" : 3675453
     }
   ],
-  "sprecher" : [
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Ben",
-      "Fabian Harloff"
-    ],
-    [
-      "Silvia",
-      "Marion von Stengel"
-    ],
-    [
-      "Ralph",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Spud",
-      "Rasmus Borowski"
-    ],
-    [
-      "O-Ian",
-      "Celine Fontanges"
-    ],
-    [
-      "Setch",
-      "Stefan Brönneke"
-    ],
-    [
-      "Hi-Top",
-      "Robin Brosch"
-    ],
-    [
-      "Car",
-      "Volker Hanisch"
-    ],
-    [
-      "Chip-Shape",
-      "Jens Wendland"
-    ],
-    [
-      "Carol",
-      "Alexandra Garcia"
-    ],
-    [
-      "Slide Terranova",
-      "Nico König"
-    ],
-    [
-      "P. \"Pejo\" Joseph McGaskill",
-      "Peter Kirchberger"
-    ],
-    [
-      "Sax Sendler",
-      "Christian Concillio"
-    ],
-    [
-      "Hausmeister",
-      "Edgar Bessen"
-    ],
-    [
-      "Bau-Kollege",
-      "Holger Umbreit"
-    ],
-    [
-      "Junge",
-      "Michael Lampe"
-    ],
-    [
-      "Mädchen",
-      "Pamela Punti"
-    ],
-    [
-      "Weibl. Offstimme",
-      "Susanne Wulkow"
-    ],
-    [
-      "Werbestimme",
-      "Enie van de Meiklokjes"
-    ],
-    [
-      "Menge",
-      "www.dreifragezeichen.de/www/menge-brainwash"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Ben",
+      "sprecher" : "Fabian Harloff"
+    },
+    {
+      "rolle" : "Silvia",
+      "sprecher" : "Marion von Stengel"
+    },
+    {
+      "rolle" : "Ralph",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Spud",
+      "sprecher" : "Rasmus Borowski"
+    },
+    {
+      "rolle" : "O-Ian",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Setch",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Hi-Top",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Car",
+      "sprecher" : "Volker Hanisch"
+    },
+    {
+      "rolle" : "Chip-Shape",
+      "sprecher" : "Jens Wendland"
+    },
+    {
+      "rolle" : "Carol",
+      "sprecher" : "Alexandra Garcia"
+    },
+    {
+      "rolle" : "Slide Terranova",
+      "sprecher" : "Nicolas König"
+    },
+    {
+      "rolle" : "P. \"Pejo\" Joseph McGaskill",
+      "sprecher" : "Peter Kirchberger"
+    },
+    {
+      "rolle" : "Sax Sandler",
+      "sprecher" : "Christian Concilio"
+    },
+    {
+      "rolle" : "Hausmeister",
+      "sprecher" : "Edgar Bessen"
+    },
+    {
+      "rolle" : "Bau-Kollege",
+      "sprecher" : "Holger Umbreit"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "André Minninger",
+      "pseudonym" : "Michael Lampe"
+    },
+    {
+      "rolle" : "Mädchen",
+      "sprecher" : "Heikedine Körting",
+      "pseudonym" : "Pamela Punti"
+    },
+    {
+      "rolle" : "Weibl. Offstimme",
+      "sprecher" : "Susanne Wulkow"
+    },
+    {
+      "rolle" : "Werbestimme",
+      "sprecher" : "Enie van de Meiklokjes"
+    },
+    {
+      "rolle" : "Menge",
+      "sprecher" : "Lauscherlounge-Zuschauer (www.dreifragezeichen.de/www/menge-brainwash)"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json",

--- a/web/data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json
+++ b/web/data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json
@@ -146,99 +146,100 @@
       "end" : 5382547
     }
   ],
-  "sprecher" : [
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Nayra Paredes",
-      "Sonja Stein"
-    ],
-    [
-      "Andrés Paredes",
-      "Tim Kreuer"
-    ],
-    [
-      "Mr. Gabriel Paredes",
-      "Urs Affolter"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Quentin Montgrove",
-      "Eberhard Haar"
-    ],
-    [
-      "Emma Miller",
-      "Kerstin Draeger"
-    ],
-    [
-      "Der Einzige Inka",
-      "Eckart Dux"
-    ],
-    [
-      "Kassiererin im Museum",
-      "Merete Brettschneider"
-    ],
-    [
-      "Ansagerin im Museum",
-      "Merete Brettschneider"
-    ],
-    [
-      "Eisdielen-Besitzer",
-      "Robert Missler"
-    ],
-    [
-      "Alte Frau",
-      "Katja Brügger"
-    ],
-    [
-      "Mann",
-      "Andre Gatzke"
-    ],
-    [
-      "Frau 1",
-      "Heikedine Körting"
-    ],
-    [
-      "Frau 2",
-      "Susan Jarling"
-    ],
-    [
-      "Frau 3",
-      "Hella von der Osten"
-    ],
-    [
-      "Frau 4",
-      "Saskia Weckler"
-    ],
-    [
-      "Mädchen",
-      "Theresa Unterberg"
-    ],
-    [
-      "Kind 1",
-      "Malon Stahlhut"
-    ],
-    [
-      "Kind 2",
-      "Julia Fölster"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Nayra Paredes",
+      "sprecher" : "Sonja Stein"
+    },
+    {
+      "rolle" : "Andrés Paredes",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Mr. Gabriel Paredes",
+      "sprecher" : "Urs Affolter"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Quentin Montgrove",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Emma Miller",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "Der Einzige Inka",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Kassiererin im Museum",
+      "sprecher" : "Merete Brettschneider"
+    },
+    {
+      "rolle" : "Ansagerin im Museum",
+      "sprecher" : "Merete Brettschneider"
+    },
+    {
+      "rolle" : "Eisdielen-Besitzer",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Alte Frau",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "André Gatzke"
+    },
+    {
+      "rolle" : "Frau 1",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Frau 2",
+      "sprecher" : "Susan Jarling"
+    },
+    {
+      "rolle" : "Frau 3",
+      "sprecher" : "Hella von der Osten-Sacken"
+    },
+    {
+      "rolle" : "Frau 4",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Mädchen",
+      "sprecher" : "Theresa Underberg"
+    },
+    {
+      "rolle" : "Kind 1",
+      "sprecher" : "Malon Stahlhuth"
+    },
+    {
+      "rolle" : "Kind 2",
+      "sprecher" : "Julia Fölster"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json",

--- a/web/data/Spezial/Eine-schreckliche-Bescherung/metadata.json
+++ b/web/data/Spezial/Eine-schreckliche-Bescherung/metadata.json
@@ -266,131 +266,132 @@
       "end" : 9154760
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Erik Schäffler"
-    ],
-    [
-      "Santa Claus",
-      "Claus Wilcke"
-    ],
-    [
-      "Fotograf",
-      "Stephan Schad"
-    ],
-    [
-      "Sandy",
-      "Angela Stresemann"
-    ],
-    [
-      "Mutter",
-      "Pamela Punti"
-    ],
-    [
-      "Mr. Puckle",
-      "Christian Rudolf"
-    ],
-    [
-      "Mrs. Hatchett",
-      "Petra Kleinert"
-    ],
-    [
-      "Matty",
-      "Joshua Rudolf"
-    ],
-    [
-      "1. Security",
-      "Patrick Berg"
-    ],
-    [
-      "2. Security",
-      "Philipp Stumpp"
-    ],
-    [
-      "3. Security",
-      "Max König"
-    ],
-    [
-      "4. Security",
-      "Tony Curting"
-    ],
-    [
-      "Pater",
-      "Achim Schülke"
-    ],
-    [
-      "Engel",
-      "Theresa Underberg"
-    ],
-    [
-      "1. Polizist",
-      "Patrick Baehr"
-    ],
-    [
-      "2. Polizist",
-      "Alexander Mettin"
-    ],
-    [
-      "3. Polizist",
-      "Douglas Welbat"
-    ],
-    [
-      "Angestellte",
-      "Katrin Decker"
-    ],
-    [
-      "Larry",
-      "Jan Langer"
-    ],
-    [
-      "Luke Bigelow",
-      "Harald Effenberg"
-    ],
-    [
-      "Molly",
-      "Regine Lamster"
-    ],
-    [
-      "Emmett",
-      "Reinhold Kammerer"
-    ],
-    [
-      "Durchsage",
-      "Andrea Lüdke"
-    ],
-    [
-      "Krankenschwester",
-      "Scarlett Lubowski"
-    ],
-    [
-      "Mann",
-      "Helge Halvé"
-    ],
-    [
-      "Bandenchef",
-      "Lars Schmidtke"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Santa Claus",
+      "sprecher" : "Claus Wilcke"
+    },
+    {
+      "rolle" : "Fotograf",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Sandy",
+      "sprecher" : "Angela Stresemann"
+    },
+    {
+      "rolle" : "Mutter",
+      "sprecher" : "Heikedine Körting",
+      "pseudonym" : "Pamela Punti"
+    },
+    {
+      "rolle" : "Mr. Puckle",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Mrs. Hatchett",
+      "sprecher" : "Petra Kleinert"
+    },
+    {
+      "rolle" : "Matty",
+      "sprecher" : "Joshua Rudolf Goralsky"
+    },
+    {
+      "rolle" : "Security 1",
+      "sprecher" : "Patrick Berg"
+    },
+    {
+      "rolle" : "Security 2",
+      "sprecher" : "Philipp Stumpp"
+    },
+    {
+      "rolle" : "Security 3",
+      "sprecher" : "Max König"
+    },
+    {
+      "rolle" : "Security 4",
+      "sprecher" : "Tony Curting"
+    },
+    {
+      "rolle" : "Pater",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Engel",
+      "sprecher" : "Theresa Underberg"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Patrick Baehr"
+    },
+    {
+      "rolle" : "Polizist 2",
+      "sprecher" : "Alexander Mettin"
+    },
+    {
+      "rolle" : "Polizist 3",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Angestellte",
+      "sprecher" : "Katrin Decker"
+    },
+    {
+      "rolle" : "Larry",
+      "sprecher" : "Jan Langer"
+    },
+    {
+      "rolle" : "Luke Bigelow",
+      "sprecher" : "Harald Effenberg"
+    },
+    {
+      "rolle" : "Molly",
+      "sprecher" : "Regine Lamster"
+    },
+    {
+      "rolle" : "Emmett",
+      "sprecher" : "Reinhold Kammerer"
+    },
+    {
+      "rolle" : "Durchsage",
+      "sprecher" : "Andrea Lüdke"
+    },
+    {
+      "rolle" : "Krankenschwester",
+      "sprecher" : "Scarlet Cavadenti Lubowski"
+    },
+    {
+      "rolle" : "Mann",
+      "sprecher" : "Helge Halvé"
+    },
+    {
+      "rolle" : "Bandenchef",
+      "sprecher" : "Lars Schmidtke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/metadata.json",

--- a/web/data/Spezial/High-Strung-Unter-Hochspannung/metadata.json
+++ b/web/data/Spezial/High-Strung-Unter-Hochspannung/metadata.json
@@ -51,59 +51,59 @@
       "end" : 3170453
     }
   ],
-  "sprecher" : [
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Doktor Ax Me",
-      "Krystian Martinek"
-    ],
-    [
-      "Stinky Rossiter",
-      "Dustin Sattler-Semmelrogge"
-    ],
-    [
-      "Fear Crowther",
-      "Ingo Mommsen"
-    ],
-    [
-      "Mouth Crosby",
-      "Stefan Gabriel"
-    ],
-    [
-      "Mack Dolland",
-      "Mike Olsowski"
-    ],
-    [
-      "Eric Mukogawa",
-      "Marek Harloff"
-    ],
-    [
-      "Marilla",
-      "Saskia Mayerhoff"
-    ],
-    [
-      "Kelly",
-      "Juliane Szalay"
-    ],
-    [
-      "Rosie",
-      "Reinhilt Schneider"
-    ],
-    [
-      "Blacky",
-      "Heikedine Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Doktor Ax Me",
+      "sprecher" : "Krystian Martinek"
+    },
+    {
+      "rolle" : "Stinky Rossiter",
+      "sprecher" : "Dustin Semmelrogge"
+    },
+    {
+      "rolle" : "Fear Crowther",
+      "sprecher" : "Ingo Nommsen"
+    },
+    {
+      "rolle" : "Mouth Crosby",
+      "sprecher" : "Stefan Gabriel"
+    },
+    {
+      "rolle" : "Mack Dolland",
+      "sprecher" : "Mike Olsowski"
+    },
+    {
+      "rolle" : "Eric Mukogawa",
+      "sprecher" : "Marek Harloff"
+    },
+    {
+      "rolle" : "Marilla",
+      "sprecher" : "Saskia Mayerhoff"
+    },
+    {
+      "rolle" : "Kelly",
+      "sprecher" : "Juliane Szalay"
+    },
+    {
+      "rolle" : "Rosie",
+      "sprecher" : "Reinhilt Schneider"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/metadata.json",

--- a/web/data/Spezial/House-of-Horrors-Haus-der-Angst/1/metadata.json
+++ b/web/data/Spezial/House-of-Horrors-Haus-der-Angst/1/metadata.json
@@ -137,91 +137,91 @@
       "end" : 3498480
     }
   ],
-  "sprecher" : [
-    [
-      "Off-Stimme",
-      "Claudia Stocksieker"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tony",
-      "Stefan Kaminski"
-    ],
-    [
-      "Joey",
-      "Tommaso Cacciapuoti"
-    ],
-    [
-      "Ansager in der Schlammringkampfarena",
-      "Christian Rudolf"
-    ],
-    [
-      "Margarine",
-      "Alma Clausen"
-    ],
-    [
-      "Lincolnfahrer",
-      "Mike Olsowski"
-    ],
-    [
-      "Freakshow-Jack",
-      "Peter Bänker"
-    ],
-    [
-      "Der unergründliche Mickey",
-      "Krystian Martinek"
-    ],
-    [
-      "Die bärtige Marilyn",
-      "Santiago Ziesmer"
-    ],
-    [
-      "Miss Luzzy",
-      "Katja Brügger"
-    ],
-    [
-      "Bubba Detroit",
-      "Klaus Dittmann"
-    ],
-    [
-      "Junge",
-      "Patrick Bach"
-    ],
-    [
-      "Burger-Verkäufer Arnie",
-      "Manou Lubowski"
-    ],
-    [
-      "Reporterin",
-      "Mara Bergmann"
-    ],
-    [
-      "Anna Millar",
-      "Christine Pappert"
-    ],
-    [
-      "Bombenattentäter Daniel",
-      "Tim Grobe"
-    ],
-    [
-      "Polizist",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Papagei",
-      "Heikedine Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Off-Stimme",
+      "sprecher" : "Claudia Stocksieker"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tony",
+      "sprecher" : "Stefan Kaminski"
+    },
+    {
+      "rolle" : "Joey",
+      "sprecher" : "Tommaso Cacciapuoti"
+    },
+    {
+      "rolle" : "Ansager in der Schlammringkampfarena",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Margarine",
+      "sprecher" : "Alma Clausen"
+    },
+    {
+      "rolle" : "Lincolnfahrer",
+      "sprecher" : "Mike Olsowski"
+    },
+    {
+      "rolle" : "Freakshow-Jack",
+      "sprecher" : "Peter Bänker"
+    },
+    {
+      "rolle" : "Der unergründliche Mickey",
+      "sprecher" : "Krystian Martinek"
+    },
+    {
+      "rolle" : "Die bärtige Marilyn",
+      "sprecher" : "Santiago Ziesmer"
+    },
+    {
+      "rolle" : "Miss Luzzy",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Bubba Detroit",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Burger-Verkäufer Arnie",
+      "sprecher" : "Manou Lubowski"
+    },
+    {
+      "rolle" : "Reporterin",
+      "sprecher" : "Mara Bergmann"
+    },
+    {
+      "rolle" : "Anna Millar",
+      "sprecher" : "Christine Pappert"
+    },
+    {
+      "rolle" : "Bombenattentäter Daniel",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/1/metadata.json",

--- a/web/data/Spezial/House-of-Horrors-Haus-der-Angst/2/metadata.json
+++ b/web/data/Spezial/House-of-Horrors-Haus-der-Angst/2/metadata.json
@@ -292,79 +292,79 @@
       "end" : 4497427
     }
   ],
-  "sprecher" : [
-    [
-      "Off-Stimme",
-      "Claudia Stocksieker"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tony",
-      "Stefan Kaminski"
-    ],
-    [
-      "Joey",
-      "Tommaso Cacciapuoti"
-    ],
-    [
-      "Anna Millar",
-      "Christine Pappert"
-    ],
-    [
-      "Lily",
-      "Verena Wolfien"
-    ],
-    [
-      "Max",
-      "Holger Umbreit"
-    ],
-    [
-      "Milli",
-      "Ulrike Knief"
-    ],
-    [
-      "Celeste Hummer",
-      "Maria Willer"
-    ],
-    [
-      "Anthem Hummer",
-      "Martin May"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Papagei",
-      "Heikedine Körting"
-    ],
-    [
-      "Bruce Millar",
-      "Ben Hecker"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Mr. Albert Hitfield",
-      "Volker Bogdan"
-    ],
-    [
-      "TV-Sprecher",
-      "Friedel Bott"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Off-Stimme",
+      "sprecher" : "Claudia Stocksieker"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tony",
+      "sprecher" : "Stefan Kaminski"
+    },
+    {
+      "rolle" : "Joey",
+      "sprecher" : "Tommaso Cacciapuoti"
+    },
+    {
+      "rolle" : "Anna Millar",
+      "sprecher" : "Christine Pappert"
+    },
+    {
+      "rolle" : "Lily",
+      "sprecher" : "Verena Wolfien"
+    },
+    {
+      "rolle" : "Max",
+      "sprecher" : "Holger Umbreit"
+    },
+    {
+      "rolle" : "Milli",
+      "sprecher" : "Ulrike Knief"
+    },
+    {
+      "rolle" : "Celeste Hummer",
+      "sprecher" : "Maria Willer"
+    },
+    {
+      "rolle" : "Anthem Hummer",
+      "sprecher" : "Martin May"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    },
+    {
+      "rolle" : "Bruce Millar",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Albert Hitfield",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "TV-Sprecher",
+      "sprecher" : "Friedel Bott"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/2/metadata.json",

--- a/web/data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json
+++ b/web/data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json
@@ -139,91 +139,91 @@
           "end" : 3498480
         }
       ],
-      "sprecher" : [
-        [
-          "Off-Stimme",
-          "Claudia Stocksieker"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tony",
-          "Stefan Kaminski"
-        ],
-        [
-          "Joey",
-          "Tommaso Cacciapuoti"
-        ],
-        [
-          "Ansager in der Schlammringkampfarena",
-          "Christian Rudolf"
-        ],
-        [
-          "Margarine",
-          "Alma Clausen"
-        ],
-        [
-          "Lincolnfahrer",
-          "Mike Olsowski"
-        ],
-        [
-          "Freakshow-Jack",
-          "Peter Bänker"
-        ],
-        [
-          "Der unergründliche Mickey",
-          "Krystian Martinek"
-        ],
-        [
-          "Die bärtige Marilyn",
-          "Santiago Ziesmer"
-        ],
-        [
-          "Miss Luzzy",
-          "Katja Brügger"
-        ],
-        [
-          "Bubba Detroit",
-          "Klaus Dittmann"
-        ],
-        [
-          "Junge",
-          "Patrick Bach"
-        ],
-        [
-          "Burger-Verkäufer Arnie",
-          "Manou Lubowski"
-        ],
-        [
-          "Reporterin",
-          "Mara Bergmann"
-        ],
-        [
-          "Anna Millar",
-          "Christine Pappert"
-        ],
-        [
-          "Bombenattentäter Daniel",
-          "Tim Grobe"
-        ],
-        [
-          "Polizist",
-          "Wolfgang Kaven"
-        ],
-        [
-          "Papagei",
-          "Heikedine Körting"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Off-Stimme",
+          "sprecher" : "Claudia Stocksieker"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Stefan Kaminski"
+        },
+        {
+          "rolle" : "Joey",
+          "sprecher" : "Tommaso Cacciapuoti"
+        },
+        {
+          "rolle" : "Ansager in der Schlammringkampfarena",
+          "sprecher" : "Christian Rudolf"
+        },
+        {
+          "rolle" : "Margarine",
+          "sprecher" : "Alma Clausen"
+        },
+        {
+          "rolle" : "Lincolnfahrer",
+          "sprecher" : "Mike Olsowski"
+        },
+        {
+          "rolle" : "Freakshow-Jack",
+          "sprecher" : "Peter Bänker"
+        },
+        {
+          "rolle" : "Der unergründliche Mickey",
+          "sprecher" : "Krystian Martinek"
+        },
+        {
+          "rolle" : "Die bärtige Marilyn",
+          "sprecher" : "Santiago Ziesmer"
+        },
+        {
+          "rolle" : "Miss Luzzy",
+          "sprecher" : "Katja Brügger"
+        },
+        {
+          "rolle" : "Bubba Detroit",
+          "sprecher" : "Klaus Dittmann"
+        },
+        {
+          "rolle" : "Junge",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Burger-Verkäufer Arnie",
+          "sprecher" : "Manou Lubowski"
+        },
+        {
+          "rolle" : "Reporterin",
+          "sprecher" : "Mara Bergmann"
+        },
+        {
+          "rolle" : "Anna Millar",
+          "sprecher" : "Christine Pappert"
+        },
+        {
+          "rolle" : "Bombenattentäter Daniel",
+          "sprecher" : "Tim Grobe"
+        },
+        {
+          "rolle" : "Polizist",
+          "sprecher" : "Wolfgang Kaven"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/1/metadata.json",
@@ -524,79 +524,79 @@
           "end" : 4497427
         }
       ],
-      "sprecher" : [
-        [
-          "Off-Stimme",
-          "Claudia Stocksieker"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tony",
-          "Stefan Kaminski"
-        ],
-        [
-          "Joey",
-          "Tommaso Cacciapuoti"
-        ],
-        [
-          "Anna Millar",
-          "Christine Pappert"
-        ],
-        [
-          "Lily",
-          "Verena Wolfien"
-        ],
-        [
-          "Max",
-          "Holger Umbreit"
-        ],
-        [
-          "Milli",
-          "Ulrike Knief"
-        ],
-        [
-          "Celeste Hummer",
-          "Maria Willer"
-        ],
-        [
-          "Anthem Hummer",
-          "Martin May"
-        ],
-        [
-          "Morton",
-          "Andreas von der Meden"
-        ],
-        [
-          "Papagei",
-          "Heikedine Körting"
-        ],
-        [
-          "Bruce Millar",
-          "Ben Hecker"
-        ],
-        [
-          "Kommissar Reynolds",
-          "Wolfgang Draeger"
-        ],
-        [
-          "Mr. Albert Hitfield",
-          "Volker Bogdan"
-        ],
-        [
-          "TV-Sprecher",
-          "Friedel Bott"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Off-Stimme",
+          "sprecher" : "Claudia Stocksieker"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tony",
+          "sprecher" : "Stefan Kaminski"
+        },
+        {
+          "rolle" : "Joey",
+          "sprecher" : "Tommaso Cacciapuoti"
+        },
+        {
+          "rolle" : "Anna Millar",
+          "sprecher" : "Christine Pappert"
+        },
+        {
+          "rolle" : "Lily",
+          "sprecher" : "Verena Wolfien"
+        },
+        {
+          "rolle" : "Max",
+          "sprecher" : "Holger Umbreit"
+        },
+        {
+          "rolle" : "Milli",
+          "sprecher" : "Ulrike Knief"
+        },
+        {
+          "rolle" : "Celeste Hummer",
+          "sprecher" : "Maria Willer"
+        },
+        {
+          "rolle" : "Anthem Hummer",
+          "sprecher" : "Martin May"
+        },
+        {
+          "rolle" : "Morton",
+          "sprecher" : "Andreas von der Meden"
+        },
+        {
+          "rolle" : "Blacky",
+          "sprecher" : "Heikedine Körting"
+        },
+        {
+          "rolle" : "Bruce Millar",
+          "sprecher" : "Ben Hecker"
+        },
+        {
+          "rolle" : "Kommissar Reynolds",
+          "sprecher" : "Wolfgang Draeger"
+        },
+        {
+          "rolle" : "Albert Hitfield",
+          "sprecher" : "Volker Bogdan"
+        },
+        {
+          "rolle" : "TV-Sprecher",
+          "sprecher" : "Friedel Bott"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/2/metadata.json",
@@ -901,131 +901,131 @@
       "end" : 7594170
     }
   ],
-  "sprecher" : [
-    [
-      "Off-Stimme",
-      "Claudia Stocksieker"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tony",
-      "Stefan Kaminski"
-    ],
-    [
-      "Joey",
-      "Tommaso Cacciapuoti"
-    ],
-    [
-      "Ansager in der Schlammringkampfarena",
-      "Christian Rudolf"
-    ],
-    [
-      "Margarine",
-      "Alma Clausen"
-    ],
-    [
-      "Lincolnfahrer",
-      "Mike Olsowski"
-    ],
-    [
-      "Freakshow-Jack",
-      "Peter Bänker"
-    ],
-    [
-      "Der unergründliche Mickey",
-      "Krystian Martinek"
-    ],
-    [
-      "Die bärtige Marilyn",
-      "Santiago Ziesmer"
-    ],
-    [
-      "Miss Luzzy",
-      "Katja Brügger"
-    ],
-    [
-      "Bubba Detroit",
-      "Klaus Dittmann"
-    ],
-    [
-      "Junge",
-      "Patrick Bach"
-    ],
-    [
-      "Burger-Verkäufer Arnie",
-      "Manou Lubowski"
-    ],
-    [
-      "Reporterin",
-      "Mara Bergmann"
-    ],
-    [
-      "Anna Millar",
-      "Christine Pappert"
-    ],
-    [
-      "Bombenattentäter Daniel",
-      "Tim Grobe"
-    ],
-    [
-      "Polizist",
-      "Wolfgang Kaven"
-    ],
-    [
-      "Lily",
-      "Verena Wolfien"
-    ],
-    [
-      "Max",
-      "Holger Umbreit"
-    ],
-    [
-      "Milli",
-      "Ulrike Knief"
-    ],
-    [
-      "Celeste Hummer",
-      "Maria Willer"
-    ],
-    [
-      "Anthem Hummer",
-      "Martin May"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Bruce Millar",
-      "Ben Hecker"
-    ],
-    [
-      "Kommissar Reynolds",
-      "Wolfgang Draeger"
-    ],
-    [
-      "Mr. Albert Hitfield",
-      "Volker Bogdan"
-    ],
-    [
-      "TV-Sprecher",
-      "Friedel Bott"
-    ],
-    [
-      "Papagei",
-      "Heikedine Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Off-Stimme",
+      "sprecher" : "Claudia Stocksieker"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tony",
+      "sprecher" : "Stefan Kaminski"
+    },
+    {
+      "rolle" : "Joey",
+      "sprecher" : "Tommaso Cacciapuoti"
+    },
+    {
+      "rolle" : "Ansager in der Schlammringkampfarena",
+      "sprecher" : "Christian Rudolf"
+    },
+    {
+      "rolle" : "Margarine",
+      "sprecher" : "Alma Clausen"
+    },
+    {
+      "rolle" : "Lincolnfahrer",
+      "sprecher" : "Mike Olsowski"
+    },
+    {
+      "rolle" : "Freakshow-Jack",
+      "sprecher" : "Peter Bänker"
+    },
+    {
+      "rolle" : "Der unergründliche Mickey",
+      "sprecher" : "Krystian Martinek"
+    },
+    {
+      "rolle" : "Die bärtige Marilyn",
+      "sprecher" : "Santiago Ziesmer"
+    },
+    {
+      "rolle" : "Miss Luzzy",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Bubba Detroit",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Junge",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Burger-Verkäufer Arnie",
+      "sprecher" : "Manou Lubowski"
+    },
+    {
+      "rolle" : "Reporterin",
+      "sprecher" : "Mara Bergmann"
+    },
+    {
+      "rolle" : "Anna Millar",
+      "sprecher" : "Christine Pappert"
+    },
+    {
+      "rolle" : "Bombenattentäter Daniel",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Polizist",
+      "sprecher" : "Wolfgang Kaven"
+    },
+    {
+      "rolle" : "Lily",
+      "sprecher" : "Verena Wolfien"
+    },
+    {
+      "rolle" : "Max",
+      "sprecher" : "Holger Umbreit"
+    },
+    {
+      "rolle" : "Milli",
+      "sprecher" : "Ulrike Knief"
+    },
+    {
+      "rolle" : "Celeste Hummer",
+      "sprecher" : "Maria Willer"
+    },
+    {
+      "rolle" : "Anthem Hummer",
+      "sprecher" : "Martin May"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Bruce Millar",
+      "sprecher" : "Ben Hecker"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Wolfgang Draeger"
+    },
+    {
+      "rolle" : "Albert Hitfield",
+      "sprecher" : "Volker Bogdan"
+    },
+    {
+      "rolle" : "TV-Sprecher",
+      "sprecher" : "Friedel Bott"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json",

--- a/web/data/Spezial/O-du-finstere/metadata.json
+++ b/web/data/Spezial/O-du-finstere/metadata.json
@@ -275,67 +275,67 @@
       "end" : 9948853
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Gianna",
-      "Celine Fontanges"
-    ],
-    [
-      "Lance",
-      "Armin Schlagwein"
-    ],
-    [
-      "Debra",
-      "Melanie Kastaun"
-    ],
-    [
-      "Audrey",
-      "Anja Topf"
-    ],
-    [
-      "Bellins",
-      "Joachim Kretzer"
-    ],
-    [
-      "Jerry",
-      "Matthias Keller"
-    ],
-    [
-      "Corey",
-      "Andreas Zaron"
-    ],
-    [
-      "Joe",
-      "André Beyer"
-    ],
-    [
-      "Mr. Allister Frain",
-      "Fabian Harloff"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Gianna",
+      "sprecher" : "Celine Fontanges"
+    },
+    {
+      "rolle" : "Lance",
+      "sprecher" : "Armin Schlagwein"
+    },
+    {
+      "rolle" : "Debra",
+      "sprecher" : "Melanie Kastaun"
+    },
+    {
+      "rolle" : "Audrey",
+      "sprecher" : "Anja Topf"
+    },
+    {
+      "rolle" : "Bellins",
+      "sprecher" : "Joachim Kretzer"
+    },
+    {
+      "rolle" : "Jerry",
+      "sprecher" : "Matthias Keller"
+    },
+    {
+      "rolle" : "Corey",
+      "sprecher" : "Andreas Zaron"
+    },
+    {
+      "rolle" : "Joe",
+      "sprecher" : "André Beyer"
+    },
+    {
+      "rolle" : "Mr. Allister Frain",
+      "sprecher" : "Fabian Harloff"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/metadata.json",

--- a/web/data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json
+++ b/web/data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json
@@ -275,75 +275,79 @@
       "end" : 9893400
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mr. Nostigan",
-      "Volker Brandt"
-    ],
-    [
-      "Beastor",
-      "Michael Grimm"
-    ],
-    [
-      "Freeman",
-      "Helgo Liebig"
-    ],
-    [
-      "Skulldor",
-      "Herbert Tennigkeit"
-    ],
-    [
-      "Desmond Calbourne",
-      "Martin May"
-    ],
-    [
-      "Charlton Hogart",
-      "Christian Rode"
-    ],
-    [
-      "Santa Claus",
-      "Klaus Dittmann"
-    ],
-    [
-      "Mason Wachinsk",
-      "Achim Schülke"
-    ],
-    [
-      "Elfe",
-      "Linda Fölster"
-    ],
-    [
-      "Elfenbeinfrau",
-      "Heidi Berndt"
-    ],
-    [
-      "Milhouse",
-      "Hans-Joachim Dethlof"
-    ],
-    [
-      "Cafelyn McBryde",
-      "Marianne Bernhardt"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mr. Nostigan",
+      "sprecher" : "Volker Brandt"
+    },
+    {
+      "rolle" : "Beastor",
+      "sprecher" : "Michael Grimm"
+    },
+    {
+      "rolle" : "Freeman",
+      "sprecher" : "Helgo Liebig"
+    },
+    {
+      "rolle" : "Skulldor",
+      "sprecher" : "Herbert Tennigkeit"
+    },
+    {
+      "rolle" : "Desmond Calbourne",
+      "sprecher" : "Monty Arnold"
+    },
+    {
+      "rolle" : "Frederic Barnes",
+      "sprecher" : "Martin May"
+    },
+    {
+      "rolle" : "Charlton Hogart",
+      "sprecher" : "Christian Rode"
+    },
+    {
+      "rolle" : "Santa Claus",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Mason Wachinsk",
+      "sprecher" : "Achim Schülke"
+    },
+    {
+      "rolle" : "Elfe",
+      "sprecher" : "Linda Fölster"
+    },
+    {
+      "rolle" : "Elfenbeinfrau",
+      "sprecher" : "Heidi Berndt"
+    },
+    {
+      "rolle" : "Milhouse",
+      "sprecher" : "Hans-Joachim Dethlof"
+    },
+    {
+      "rolle" : "Cafelyn McBryde",
+      "sprecher" : "Marianne Bernhardt"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json",

--- a/web/data/Spezial/und-das-Grab-der-Maya/metadata.json
+++ b/web/data/Spezial/und-das-Grab-der-Maya/metadata.json
@@ -226,67 +226,67 @@
       "end" : 6770387
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Axel Milberg"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Skinny Norris",
-      "Tim Kreuer"
-    ],
-    [
-      "Sheryl",
-      "Merete Brettschneider"
-    ],
-    [
-      "Professor Burnham",
-      "Jürgen Thormann"
-    ],
-    [
-      "Salvador Pérez",
-      "Matthias Klimsa"
-    ],
-    [
-      "Tuyucim Florentino Ixmatá",
-      "Mario Ramos"
-    ],
-    [
-      "Tuyucim",
-      "Nicolas Klimsa"
-    ],
-    [
-      "Maria Pérez",
-      "Caroline Kiesewetter"
-    ],
-    [
-      "Zachary",
-      "Roman Rossa"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Conrad Williams",
-      "Peter Weis"
-    ],
-    [
-      "Nachrichtensprecher",
-      "André Schünke"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Axel Milberg"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Sheryl",
+      "sprecher" : "Merete Brettschneider"
+    },
+    {
+      "rolle" : "Professor Burnham",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Salvador Pérez",
+      "sprecher" : "Matthias Klimsa"
+    },
+    {
+      "rolle" : "Tuyucim Florentino Ixmatá",
+      "sprecher" : "Mario Ramos"
+    },
+    {
+      "rolle" : "Tuyucim",
+      "sprecher" : "Nicolás Klimsa"
+    },
+    {
+      "rolle" : "Maria Pérez",
+      "sprecher" : "Caroline Kiesewetter"
+    },
+    {
+      "rolle" : "Zachary",
+      "sprecher" : "Roman Rossa"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Conrad Williams",
+      "sprecher" : "Peter Weis"
+    },
+    {
+      "rolle" : "Nachrichtensprecher",
+      "sprecher" : "André Schünke"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/metadata.json",

--- a/web/data/Spezial/und-das-kalte-Auge/metadata.json
+++ b/web/data/Spezial/und-das-kalte-Auge/metadata.json
@@ -136,115 +136,116 @@
       "end" : 5066480
     }
   ],
-  "sprecher" : [
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Zachary Collister",
-      "Stephan Benson"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Mrs. Hilton",
-      "Katja Brügger"
-    ],
-    [
-      "Mr. Warren",
-      "Stephan Schwartz"
-    ],
-    [
-      "Luke Havering",
-      "Santiago Ziesmer"
-    ],
-    [
-      "Colin Havering",
-      "Santiago Ziesmer"
-    ],
-    [
-      "MacKenzie",
-      "Traudel Sperber"
-    ],
-    [
-      "Erial",
-      "Robert Missler"
-    ],
-    [
-      "Andy",
-      "Tim Grobe"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Francine",
-      "Merete Brettschneider"
-    ],
-    [
-      "Matrose",
-      "Eberhard Haar"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Mrs. Watson",
-      "Corinna Wodrich"
-    ],
-    [
-      "Betrunkener",
-      "Patrick Bach"
-    ],
-    [
-      "Kind 1",
-      "Malon Stahlhuth"
-    ],
-    [
-      "Kind 2",
-      "Julia Fölster"
-    ],
-    [
-      "Taxifahrer",
-      "Tillmann Madaus"
-    ],
-    [
-      "Kartenspieler",
-      "Robin Brosch"
-    ],
-    [
-      "Tochter von Erial",
-      "Zelda Jahreis"
-    ],
-    [
-      "AB-Ansage-Stimme",
-      "Susan Jarling"
-    ],
-    [
-      "Reporter",
-      "Ivo Möller"
-    ],
-    [
-      "Journalistin",
-      "Birte Kretschmer"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Zachary Collister",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Mrs. Hilton",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Mr. Warren",
+      "sprecher" : "Stephan Schwartz"
+    },
+    {
+      "rolle" : "Luke Havering",
+      "sprecher" : "Santiago Ziesmer"
+    },
+    {
+      "rolle" : "Colin Havering",
+      "sprecher" : "Santiago Ziesmer"
+    },
+    {
+      "rolle" : "MacKenzie",
+      "sprecher" : "Traudel Sperber"
+    },
+    {
+      "rolle" : "Erial",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Andy",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Francine",
+      "sprecher" : "Merete Brettschneider"
+    },
+    {
+      "rolle" : "Matrose",
+      "sprecher" : "Eberhard Haar"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Mrs. Watson",
+      "sprecher" : "Corinna Wodrich"
+    },
+    {
+      "rolle" : "Betrunkener",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Kind 1",
+      "sprecher" : "Malon Stahlhuth"
+    },
+    {
+      "rolle" : "Kind 2",
+      "sprecher" : "Julia Fölster"
+    },
+    {
+      "rolle" : "Taxifahrer",
+      "sprecher" : "Tilman Madaus"
+    },
+    {
+      "rolle" : "Kartenspieler",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Tochter von Erial",
+      "sprecher" : "Zelda Jahreis"
+    },
+    {
+      "rolle" : "AB-Ansage-Stimme",
+      "sprecher" : "Susan Jarling"
+    },
+    {
+      "rolle" : "Reporter",
+      "sprecher" : "Ivo Möller"
+    },
+    {
+      "rolle" : "Journalistin",
+      "sprecher" : "Birte Kretschmer"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/metadata.json",

--- a/web/data/Spezial/und-das-versunkene-Schiff/metadata.json
+++ b/web/data/Spezial/und-das-versunkene-Schiff/metadata.json
@@ -186,71 +186,71 @@
       "end" : 6126040
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Amanda Ellis",
-      "Simona Pahl"
-    ],
-    [
-      "Jo",
-      "Birte Kretschmer"
-    ],
-    [
-      "Steve Young",
-      "Till Huster"
-    ],
-    [
-      "Ford Follows",
-      "Stephan Benson"
-    ],
-    [
-      "Eric Ellis",
-      "Horst Stark"
-    ],
-    [
-      "Ricardo Yarbrough",
-      "Stefan Brönneke"
-    ],
-    [
-      "Bibliothekarin",
-      "Rosemarie Wohlbauer"
-    ],
-    [
-      "Mr. Friedman",
-      "Douglas Welbat"
-    ],
-    [
-      "Mann in der Bibliothek",
-      "Erik Schäffler"
-    ],
-    [
-      "Sekretärin",
-      "Christiane Leuchtmann"
-    ],
-    [
-      "Jackson Cooper",
-      "Oliver Bröttcher"
-    ],
-    [
-      "Mr. Miller",
-      "Pierre Brand"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Amanda Ellis",
+      "sprecher" : "Simona Pahl"
+    },
+    {
+      "rolle" : "Jo",
+      "sprecher" : "Birte Kretschmer"
+    },
+    {
+      "rolle" : "Steve Young",
+      "sprecher" : "Till Huster"
+    },
+    {
+      "rolle" : "Ford Follows",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Eric Ellis",
+      "sprecher" : "Horst Stark"
+    },
+    {
+      "rolle" : "Ricardo Yarbrough",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Bibliothekarin",
+      "sprecher" : "Rosemarie Wohlbauer"
+    },
+    {
+      "rolle" : "Mr. Friedman",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Mann in der Bibliothek",
+      "sprecher" : "Erik Schäffler"
+    },
+    {
+      "rolle" : "Sekretärin",
+      "sprecher" : "Christiane Leuchtmann"
+    },
+    {
+      "rolle" : "Jackson Cooper",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Mr. Miller",
+      "sprecher" : "Pierre Brand"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/metadata.json",

--- a/web/data/Spezial/und-der-5-Advent/metadata.json
+++ b/web/data/Spezial/und-der-5-Advent/metadata.json
@@ -275,67 +275,67 @@
       "end" : 10281307
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Mrs. Lydia Candle",
-      "Monika John"
-    ],
-    [
-      "Jeremias Howard",
-      "Gosta Liptow"
-    ],
-    [
-      "Empfangsdame",
-      "Katja Brügger"
-    ],
-    [
-      "Radiosprecherin",
-      "Simona Pahl"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Patricia Handerson",
-      "Janina Richter"
-    ],
-    [
-      "Polizistin",
-      "Carolin Fortenbacher"
-    ],
-    [
-      "Schausteller",
-      "Eckart Dux"
-    ],
-    [
-      "Edward Candle",
-      "Robin Brosch"
-    ],
-    [
-      "Blacky",
-      "Heikedine Körting"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Mrs. Lydia Candle",
+      "sprecher" : "Monika John"
+    },
+    {
+      "rolle" : "Jeremias Howard",
+      "sprecher" : "Gosta Liptow"
+    },
+    {
+      "rolle" : "Empfangsdame",
+      "sprecher" : "Katja Brügger"
+    },
+    {
+      "rolle" : "Radiosprecherin",
+      "sprecher" : "Simona Pahl"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Patricia Handerson",
+      "sprecher" : "Janina Richter"
+    },
+    {
+      "rolle" : "Polizistin",
+      "sprecher" : "Carolin Fortenbacher"
+    },
+    {
+      "rolle" : "Schausteller",
+      "sprecher" : "Eckart Dux"
+    },
+    {
+      "rolle" : "Edward Candle",
+      "sprecher" : "Robin Brosch"
+    },
+    {
+      "rolle" : "Blacky",
+      "sprecher" : "Heikedine Körting"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/metadata.json",

--- a/web/data/Spezial/und-der-Super-Papagei-2004/metadata.json
+++ b/web/data/Spezial/und-der-Super-Papagei-2004/metadata.json
@@ -166,67 +166,68 @@
       "end" : 5400124
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Skinny Norris",
-      "Andreas von der Meden"
-    ],
-    [
-      "Mr. Claudius",
-      "Gerlach Fiedler"
-    ],
-    [
-      "Mrs. Claudius",
-      "Brigitte Böttrich"
-    ],
-    [
-      "Mr. Fentriss",
-      "Detlef Bierstedt"
-    ],
-    [
-      "Hugenay",
-      "Wolfgang Kubach"
-    ],
-    [
-      "Carlos",
-      "Stefan Brönneke"
-    ],
-    [
-      "Ramos",
-      "Dario Bertoli"
-    ],
-    [
-      "Morton",
-      "Andreas von der Meden"
-    ],
-    [
-      "Opa",
-      "Harry Rowohlt"
-    ],
-    [
-      "Miss Waggoner",
-      "Ursula Vogel"
-    ],
-    [
-      "Senora",
-      "Barbara Benuel"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Skinny Norris",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Mr. Claudius, Kunsthändler",
+      "sprecher" : "Gerlach Fiedler"
+    },
+    {
+      "rolle" : "Mrs. Claudius",
+      "sprecher" : "Brigitte Böttrich"
+    },
+    {
+      "rolle" : "Mr. Fentriss, Schriftsteller",
+      "sprecher" : "Detlef Bierstedt"
+    },
+    {
+      "rolle" : "Hugenay",
+      "sprecher" : "Wolfgang Kubach"
+    },
+    {
+      "rolle" : "Carlos",
+      "sprecher" : "Stefan Brönneke"
+    },
+    {
+      "rolle" : "Onkel Ramos",
+      "sprecher" : "Detlef Bierstedt",
+      "pseudonym" : "Dario Bertoli"
+    },
+    {
+      "rolle" : "Morton",
+      "sprecher" : "Andreas von der Meden"
+    },
+    {
+      "rolle" : "Opa",
+      "sprecher" : "Harry Rowohlt"
+    },
+    {
+      "rolle" : "Miss Waggoner",
+      "sprecher" : "Ursula Vogel"
+    },
+    {
+      "rolle" : "Senora",
+      "sprecher" : "Barbara Benuel"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/metadata.json",

--- a/web/data/Spezial/und-der-Tornadojaeger/metadata.json
+++ b/web/data/Spezial/und-der-Tornadojaeger/metadata.json
@@ -66,71 +66,71 @@
       "end" : 4300133
     }
   ],
-  "sprecher" : [
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Dylan Harvey",
-      "Stephan Schad"
-    ],
-    [
-      "Mrs. Violet Conroy",
-      "Birte Kretschmer"
-    ],
-    [
-      "Mr. Alex Scott",
-      "Oliver Böttche"
-    ],
-    [
-      "Myriel",
-      "Undine Ullmer"
-    ],
-    [
-      "Zimmermädchen",
-      "Theresa Underberg"
-    ],
-    [
-      "Zimmerjunge",
-      "Jannik Endemann"
-    ],
-    [
-      "Mutter im Stadtpark",
-      "Saskia Weckler"
-    ],
-    [
-      "Klein Peter",
-      "Malon Stahlhut"
-    ],
-    [
-      "Kellnerin im Hotel",
-      "Alexandra Garcia"
-    ],
-    [
-      "Handwerker im Hotel 1",
-      "André Gatzke"
-    ],
-    [
-      "Handwerker im Hotel 2",
-      "Bent Schönemann"
-    ],
-    [
-      "Internetcafébesitzer",
-      "Tim Kreuer"
-    ],
-    [
-      "Vortragsbesucher, Parkbesucher, Frühstücksgäste, Nachbarn",
-      "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Kirchberger, Ingeborg Christiansen, Michaela Kreissler, Theresa Underberg, Kerstin Draeger, Lennart Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Dylan Harvey",
+      "sprecher" : "Stephan Schad"
+    },
+    {
+      "rolle" : "Mrs. Violet Conroy",
+      "sprecher" : "Birte Kretschmer"
+    },
+    {
+      "rolle" : "Mr. Alex Scott",
+      "sprecher" : "Oliver Böttcher"
+    },
+    {
+      "rolle" : "Myriel",
+      "sprecher" : "Undine Ullmer"
+    },
+    {
+      "rolle" : "Zimmermädchen",
+      "sprecher" : "Theresa Underberg"
+    },
+    {
+      "rolle" : "Zimmerjunge",
+      "sprecher" : "Jannik Endemann"
+    },
+    {
+      "rolle" : "Mutter im Stadtpark",
+      "sprecher" : "Saskia Weckler"
+    },
+    {
+      "rolle" : "Klein Peter",
+      "sprecher" : "Malon Stahlhuth"
+    },
+    {
+      "rolle" : "Kellnerin im Hotel",
+      "sprecher" : "Alexandra Garcia"
+    },
+    {
+      "rolle" : "Handwerker im Hotel 1",
+      "sprecher" : "André Gatzke"
+    },
+    {
+      "rolle" : "Handwerker im Hotel 2",
+      "sprecher" : "Bent Schönemann"
+    },
+    {
+      "rolle" : "Internetcafébesitzer",
+      "sprecher" : "Tim Kreuer"
+    },
+    {
+      "rolle" : "Vortragsbesucher, Parkbesucher, Frühstücksgäste, Nachbarn",
+      "sprecher" : "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Damare, Ingeborg Christiansen, Micaëla Kreißler, Theresa Underberg, Kerstin Draeger, Lennardt Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/metadata.json",

--- a/web/data/Spezial/und-der-dreiTag/1/metadata.json
+++ b/web/data/Spezial/und-der-dreiTag/1/metadata.json
@@ -71,99 +71,100 @@
       "end" : 4757160
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Officer Flann Doyle",
-      "Douglas Welbat"
-    ],
-    [
-      "Tanya Sullivan",
-      "Marion Elskis"
-    ],
-    [
-      "Sebastian Dawson",
-      "Bastian Pastewka"
-    ],
-    [
-      "Miss Tomkins",
-      "Steffi Kirchberger"
-    ],
-    [
-      "Mr. Foley",
-      "Dirk Bach"
-    ],
-    [
-      "John Gabbin",
-      "Tobias Schmidt"
-    ],
-    [
-      "Matthew Gabbin",
-      "Jürgen Thormann"
-    ],
-    [
-      "Georgina",
-      "Maud Ackermann"
-    ],
-    [
-      "Gil Renard",
-      "Udo Schenk"
-    ],
-    [
-      "Hedy Carlson",
-      "Luise Helm"
-    ],
-    [
-      "Steve",
-      "Sascha Draeger"
-    ],
-    [
-      "Jack",
-      "Hendrik Buchna"
-    ],
-    [
-      "Laury",
-      "Rhea Harder-Vennewald"
-    ],
-    [
-      "Gast 1",
-      "Christian Senger"
-    ],
-    [
-      "Fahrerin",
-      "Corinna Wodrich"
-    ],
-    [
-      "Radiosprecher",
-      "Tobias Meister"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Officer Flann Doyle",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Tanya Sullivan",
+      "sprecher" : "Marion Elskis"
+    },
+    {
+      "rolle" : "Sebastian Dawson",
+      "sprecher" : "Bastian Pastewka"
+    },
+    {
+      "rolle" : "Miss Tomkins",
+      "sprecher" : "Stephanie Damare"
+    },
+    {
+      "rolle" : "Mr. Foley",
+      "sprecher" : "Dirk Bach"
+    },
+    {
+      "rolle" : "John Gabbin",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Matthew Gabbin",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Georgina",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Gil Renard",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Hedy Carlson",
+      "sprecher" : "Luise Helm"
+    },
+    {
+      "rolle" : "Steve",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Jack",
+      "sprecher" : "Hendrik Buchna"
+    },
+    {
+      "rolle" : "Laury",
+      "sprecher" : "Rhea Harder-Vennewald"
+    },
+    {
+      "rolle" : "Gast 1",
+      "sprecher" : "Christian Senger"
+    },
+    {
+      "rolle" : "Fahrerin",
+      "sprecher" : "Corinna Wodrich"
+    },
+    {
+      "rolle" : "Radiosprecher",
+      "sprecher" : "Tobias Meister"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/1/metadata.json",

--- a/web/data/Spezial/und-der-dreiTag/2/metadata.json
+++ b/web/data/Spezial/und-der-dreiTag/2/metadata.json
@@ -66,95 +66,95 @@
       "end" : 3904933
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Officer Flann Doyle",
-      "Douglas Welbat"
-    ],
-    [
-      "Gil Renard",
-      "Udo Schenk"
-    ],
-    [
-      "Hedy Carlson",
-      "Luise Helm"
-    ],
-    [
-      "Peter Foster",
-      "Gerrit Schmidt-Foss"
-    ],
-    [
-      "Mrs. Shaw",
-      "Isabella Grote"
-    ],
-    [
-      "Sebastian Dawson",
-      "Bastian Pastewka"
-    ],
-    [
-      "Annie Wilkes",
-      "Regina Lemnitz"
-    ],
-    [
-      "Mädchen 1",
-      "Katinka Körting"
-    ],
-    [
-      "Mädchen 2",
-      "Jacqueline Meybauer"
-    ],
-    [
-      "Georgina",
-      "Maud Ackermann"
-    ],
-    [
-      "Alter Mann",
-      "Jörg Gillner"
-    ],
-    [
-      "Junger Mann",
-      "Patrick Bach"
-    ],
-    [
-      "Dick Perry",
-      "Ernst H. Hilbich"
-    ],
-    [
-      "Matthew Gabbin",
-      "Jürgen Thormann"
-    ],
-    [
-      "Steve",
-      "Sascha Draeger"
-    ],
-    [
-      "Radiosprecher",
-      "Tobias Meister"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Officer Flann Doyle",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Gil Renard",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Hedy Carlson",
+      "sprecher" : "Luise Helm"
+    },
+    {
+      "rolle" : "Peter Foster",
+      "sprecher" : "Gerrit Schmidt-Foß"
+    },
+    {
+      "rolle" : "Mrs. Shaw",
+      "sprecher" : "Isabella Grothe"
+    },
+    {
+      "rolle" : "Sebastian Dawson",
+      "sprecher" : "Bastian Pastewka"
+    },
+    {
+      "rolle" : "Annie Wilkes",
+      "sprecher" : "Regina Lemnitz"
+    },
+    {
+      "rolle" : "Mädchen 1",
+      "sprecher" : "Katinka Körting"
+    },
+    {
+      "rolle" : "Mädchen 2",
+      "sprecher" : "Jacqueline Meybauer"
+    },
+    {
+      "rolle" : "Georgina",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Alter Mann",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Junger Mann",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Dick Perry",
+      "sprecher" : "Ernst H. Hilbich"
+    },
+    {
+      "rolle" : "Matthew Gabbin",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Steve",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Radiosprecher",
+      "sprecher" : "Tobias Meister"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/2/metadata.json",

--- a/web/data/Spezial/und-der-dreiTag/3/metadata.json
+++ b/web/data/Spezial/und-der-dreiTag/3/metadata.json
@@ -81,131 +81,131 @@
       "end" : 4416000
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Bill Andrews",
-      "Henry König"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Miss Bennett",
-      "Renate Pilcher"
-    ],
-    [
-      "Dick Perry",
-      "Ernst H. Hilbich"
-    ],
-    [
-      "Walter Bush",
-      "Rolf E. Schenker"
-    ],
-    [
-      "Officer Flann Doyle",
-      "Douglas Welbat"
-    ],
-    [
-      "Ian Bush",
-      "Sky du Mont / Lucas Sperber"
-    ],
-    [
-      "Jimmy Sinclair",
-      "Siegfried Kernen / Nils Noller"
-    ],
-    [
-      "Charlie Parker",
-      "Jörg Gillner / Laurence Kalaidjan"
-    ],
-    [
-      "Brianna Jackson",
-      "Hansi Jochmann / Natalie Demtröder"
-    ],
-    [
-      "Chloe Smathers",
-      "Valerie Demtröder"
-    ],
-    [
-      "Joseph Quick",
-      "Harry Rowohlt"
-    ],
-    [
-      "Mr. Raynes",
-      "Olaf Kreuzenbeck"
-    ],
-    [
-      "Jeff White",
-      "Horst Naumann"
-    ],
-    [
-      "Hedy Carlson",
-      "Luise Helm"
-    ],
-    [
-      "Gil Renard",
-      "Udo Schenk"
-    ],
-    [
-      "Peter Foster",
-      "Gerrit Schmidt-Foss"
-    ],
-    [
-      "Matthew Gabbin",
-      "Jürgen Thormann"
-    ],
-    [
-      "Steve",
-      "Sascha Draeger"
-    ],
-    [
-      "Laury",
-      "Rhea Harder-Vennewald"
-    ],
-    [
-      "Georgina",
-      "Maud Ackermann"
-    ],
-    [
-      "Bedienung",
-      "Tim Wenderoth"
-    ],
-    [
-      "Gast",
-      "Andreas Otto"
-    ],
-    [
-      "Sekretärin",
-      "Corinna Wodrich"
-    ],
-    [
-      "Sebastian Dawson",
-      "Bastian Pastewka"
-    ],
-    [
-      "Radiosprecher",
-      "Tobias Meister"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Miss Bennett",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Dick Perry",
+      "sprecher" : "Ernst H. Hilbich"
+    },
+    {
+      "rolle" : "Walter Bush",
+      "sprecher" : "Rolf E. Schenker"
+    },
+    {
+      "rolle" : "Officer Flann Doyle",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Ian Bush",
+      "sprecher" : "Sky du Mont / Lukas T. Sperber"
+    },
+    {
+      "rolle" : "Jimmy Sinclair",
+      "sprecher" : "Siegfried W. Kernen / Nils Noller"
+    },
+    {
+      "rolle" : "Charlie Parker",
+      "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+    },
+    {
+      "rolle" : "Brianna Jackson",
+      "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+    },
+    {
+      "rolle" : "Chloe Smathers",
+      "sprecher" : "Valerie Demtrøder"
+    },
+    {
+      "rolle" : "Joseph Quick",
+      "sprecher" : "Harry Rowohlt"
+    },
+    {
+      "rolle" : "Mr. Raynes",
+      "sprecher" : "Olaf Kreutzenbeck"
+    },
+    {
+      "rolle" : "Jeff White",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Hedy Carlson",
+      "sprecher" : "Luise Helm"
+    },
+    {
+      "rolle" : "Gil Renard",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Peter Foster",
+      "sprecher" : "Gerrit Schmidt-Foß"
+    },
+    {
+      "rolle" : "Matthew Gabbin",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Steve",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Laury",
+      "sprecher" : "Rhea Harder-Vennewald"
+    },
+    {
+      "rolle" : "Georgina",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Bedienung",
+      "sprecher" : "Tim Wenderoth"
+    },
+    {
+      "rolle" : "Gast",
+      "sprecher" : "Andreas Otto"
+    },
+    {
+      "rolle" : "Sekretärin",
+      "sprecher" : "Corinna Wodrich"
+    },
+    {
+      "rolle" : "Sebastian Dawson",
+      "sprecher" : "Bastian Pastewka"
+    },
+    {
+      "rolle" : "Radiosprecher",
+      "sprecher" : "Tobias Meister"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/3/metadata.json",

--- a/web/data/Spezial/und-der-dreiTag/metadata.json
+++ b/web/data/Spezial/und-der-dreiTag/metadata.json
@@ -73,99 +73,100 @@
           "end" : 4757160
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Onkel Titus Jonas",
-          "Hans Meinhardt"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Officer Flann Doyle",
-          "Douglas Welbat"
-        ],
-        [
-          "Tanya Sullivan",
-          "Marion Elskis"
-        ],
-        [
-          "Sebastian Dawson",
-          "Bastian Pastewka"
-        ],
-        [
-          "Miss Tomkins",
-          "Steffi Kirchberger"
-        ],
-        [
-          "Mr. Foley",
-          "Dirk Bach"
-        ],
-        [
-          "John Gabbin",
-          "Tobias Schmidt"
-        ],
-        [
-          "Matthew Gabbin",
-          "Jürgen Thormann"
-        ],
-        [
-          "Georgina",
-          "Maud Ackermann"
-        ],
-        [
-          "Gil Renard",
-          "Udo Schenk"
-        ],
-        [
-          "Hedy Carlson",
-          "Luise Helm"
-        ],
-        [
-          "Steve",
-          "Sascha Draeger"
-        ],
-        [
-          "Jack",
-          "Hendrik Buchna"
-        ],
-        [
-          "Laury",
-          "Rhea Harder-Vennewald"
-        ],
-        [
-          "Gast 1",
-          "Christian Senger"
-        ],
-        [
-          "Fahrerin",
-          "Corinna Wodrich"
-        ],
-        [
-          "Radiosprecher",
-          "Tobias Meister"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Onkel Titus",
+          "sprecher" : "Andreas E. Beurmann",
+          "pseudonym" : "Hans Meinhardt"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Officer Flann Doyle",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Tanya Sullivan",
+          "sprecher" : "Marion Elskis"
+        },
+        {
+          "rolle" : "Sebastian Dawson",
+          "sprecher" : "Bastian Pastewka"
+        },
+        {
+          "rolle" : "Miss Tomkins",
+          "sprecher" : "Stephanie Damare"
+        },
+        {
+          "rolle" : "Mr. Foley",
+          "sprecher" : "Dirk Bach"
+        },
+        {
+          "rolle" : "John Gabbin",
+          "sprecher" : "Tobias Schmidt"
+        },
+        {
+          "rolle" : "Matthew Gabbin",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Georgina",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Gil Renard",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Hedy Carlson",
+          "sprecher" : "Luise Helm"
+        },
+        {
+          "rolle" : "Steve",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Jack",
+          "sprecher" : "Hendrik Buchna"
+        },
+        {
+          "rolle" : "Laury",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Gast 1",
+          "sprecher" : "Christian Senger"
+        },
+        {
+          "rolle" : "Fahrerin",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Radiosprecher",
+          "sprecher" : "Tobias Meister"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/1/metadata.json",
@@ -241,95 +242,95 @@
           "end" : 3904933
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Officer Flann Doyle",
-          "Douglas Welbat"
-        ],
-        [
-          "Gil Renard",
-          "Udo Schenk"
-        ],
-        [
-          "Hedy Carlson",
-          "Luise Helm"
-        ],
-        [
-          "Peter Foster",
-          "Gerrit Schmidt-Foss"
-        ],
-        [
-          "Mrs. Shaw",
-          "Isabella Grote"
-        ],
-        [
-          "Sebastian Dawson",
-          "Bastian Pastewka"
-        ],
-        [
-          "Annie Wilkes",
-          "Regina Lemnitz"
-        ],
-        [
-          "Mädchen 1",
-          "Katinka Körting"
-        ],
-        [
-          "Mädchen 2",
-          "Jacqueline Meybauer"
-        ],
-        [
-          "Georgina",
-          "Maud Ackermann"
-        ],
-        [
-          "Alter Mann",
-          "Jörg Gillner"
-        ],
-        [
-          "Junger Mann",
-          "Patrick Bach"
-        ],
-        [
-          "Dick Perry",
-          "Ernst H. Hilbich"
-        ],
-        [
-          "Matthew Gabbin",
-          "Jürgen Thormann"
-        ],
-        [
-          "Steve",
-          "Sascha Draeger"
-        ],
-        [
-          "Radiosprecher",
-          "Tobias Meister"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Officer Flann Doyle",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Gil Renard",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Hedy Carlson",
+          "sprecher" : "Luise Helm"
+        },
+        {
+          "rolle" : "Peter Foster",
+          "sprecher" : "Gerrit Schmidt-Foß"
+        },
+        {
+          "rolle" : "Mrs. Shaw",
+          "sprecher" : "Isabella Grothe"
+        },
+        {
+          "rolle" : "Sebastian Dawson",
+          "sprecher" : "Bastian Pastewka"
+        },
+        {
+          "rolle" : "Annie Wilkes",
+          "sprecher" : "Regina Lemnitz"
+        },
+        {
+          "rolle" : "Mädchen 1",
+          "sprecher" : "Katinka Körting"
+        },
+        {
+          "rolle" : "Mädchen 2",
+          "sprecher" : "Jacqueline Meybauer"
+        },
+        {
+          "rolle" : "Georgina",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Alter Mann",
+          "sprecher" : "Jörg Gillner"
+        },
+        {
+          "rolle" : "Junger Mann",
+          "sprecher" : "Patrick Bach"
+        },
+        {
+          "rolle" : "Dick Perry",
+          "sprecher" : "Ernst H. Hilbich"
+        },
+        {
+          "rolle" : "Matthew Gabbin",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Steve",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Radiosprecher",
+          "sprecher" : "Tobias Meister"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/2/metadata.json",
@@ -420,131 +421,131 @@
           "end" : 4416000
         }
       ],
-      "sprecher" : [
-        [
-          "Erzähler",
-          "Thomas Fritsch"
-        ],
-        [
-          "Justus Jonas",
-          "Oliver Rohrbeck"
-        ],
-        [
-          "Peter Shaw",
-          "Jens Wawrczeck"
-        ],
-        [
-          "Bob Andrews",
-          "Andreas Fröhlich"
-        ],
-        [
-          "Tante Mathilda Jonas",
-          "Karin Lieneweg"
-        ],
-        [
-          "Bill Andrews",
-          "Henry König"
-        ],
-        [
-          "Inspektor Cotta",
-          "Holger Mahlich"
-        ],
-        [
-          "Miss Bennett",
-          "Renate Pilcher"
-        ],
-        [
-          "Dick Perry",
-          "Ernst H. Hilbich"
-        ],
-        [
-          "Walter Bush",
-          "Rolf E. Schenker"
-        ],
-        [
-          "Officer Flann Doyle",
-          "Douglas Welbat"
-        ],
-        [
-          "Ian Bush",
-          "Sky du Mont / Lucas Sperber"
-        ],
-        [
-          "Jimmy Sinclair",
-          "Siegfried Kernen / Nils Noller"
-        ],
-        [
-          "Charlie Parker",
-          "Jörg Gillner / Laurence Kalaidjan"
-        ],
-        [
-          "Brianna Jackson",
-          "Hansi Jochmann / Natalie Demtröder"
-        ],
-        [
-          "Chloe Smathers",
-          "Valerie Demtröder"
-        ],
-        [
-          "Joseph Quick",
-          "Harry Rowohlt"
-        ],
-        [
-          "Mr. Raynes",
-          "Olaf Kreuzenbeck"
-        ],
-        [
-          "Jeff White",
-          "Horst Naumann"
-        ],
-        [
-          "Hedy Carlson",
-          "Luise Helm"
-        ],
-        [
-          "Gil Renard",
-          "Udo Schenk"
-        ],
-        [
-          "Peter Foster",
-          "Gerrit Schmidt-Foss"
-        ],
-        [
-          "Matthew Gabbin",
-          "Jürgen Thormann"
-        ],
-        [
-          "Steve",
-          "Sascha Draeger"
-        ],
-        [
-          "Laury",
-          "Rhea Harder-Vennewald"
-        ],
-        [
-          "Georgina",
-          "Maud Ackermann"
-        ],
-        [
-          "Bedienung",
-          "Tim Wenderoth"
-        ],
-        [
-          "Gast",
-          "Andreas Otto"
-        ],
-        [
-          "Sekretärin",
-          "Corinna Wodrich"
-        ],
-        [
-          "Sebastian Dawson",
-          "Bastian Pastewka"
-        ],
-        [
-          "Radiosprecher",
-          "Tobias Meister"
-        ]
+      "sprechrollen" : [
+        {
+          "rolle" : "Erzähler",
+          "sprecher" : "Thomas Fritsch"
+        },
+        {
+          "rolle" : "Justus Jonas, Erster Detektiv",
+          "sprecher" : "Oliver Rohrbeck"
+        },
+        {
+          "rolle" : "Peter Shaw, Zweiter Detektiv",
+          "sprecher" : "Jens Wawrczeck"
+        },
+        {
+          "rolle" : "Bob Andrews, Recherchen und Archiv",
+          "sprecher" : "Andreas Fröhlich"
+        },
+        {
+          "rolle" : "Tante Mathilda",
+          "sprecher" : "Karin Lieneweg"
+        },
+        {
+          "rolle" : "Mr. Andrews",
+          "sprecher" : "Henry König"
+        },
+        {
+          "rolle" : "Inspektor Cotta",
+          "sprecher" : "Holger Mahlich"
+        },
+        {
+          "rolle" : "Miss Bennett",
+          "sprecher" : "Renate Pichler"
+        },
+        {
+          "rolle" : "Dick Perry",
+          "sprecher" : "Ernst H. Hilbich"
+        },
+        {
+          "rolle" : "Walter Bush",
+          "sprecher" : "Rolf E. Schenker"
+        },
+        {
+          "rolle" : "Officer Flann Doyle",
+          "sprecher" : "Douglas Welbat"
+        },
+        {
+          "rolle" : "Ian Bush",
+          "sprecher" : "Sky du Mont / Lukas T. Sperber"
+        },
+        {
+          "rolle" : "Jimmy Sinclair",
+          "sprecher" : "Siegfried W. Kernen / Nils Noller"
+        },
+        {
+          "rolle" : "Charlie Parker",
+          "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+        },
+        {
+          "rolle" : "Brianna Jackson",
+          "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+        },
+        {
+          "rolle" : "Chloe Smathers",
+          "sprecher" : "Valerie Demtrøder"
+        },
+        {
+          "rolle" : "Joseph Quick",
+          "sprecher" : "Harry Rowohlt"
+        },
+        {
+          "rolle" : "Mr. Raynes",
+          "sprecher" : "Olaf Kreutzenbeck"
+        },
+        {
+          "rolle" : "Jeff White",
+          "sprecher" : "Horst Naumann"
+        },
+        {
+          "rolle" : "Hedy Carlson",
+          "sprecher" : "Luise Helm"
+        },
+        {
+          "rolle" : "Gil Renard",
+          "sprecher" : "Udo Schenk"
+        },
+        {
+          "rolle" : "Peter Foster",
+          "sprecher" : "Gerrit Schmidt-Foß"
+        },
+        {
+          "rolle" : "Matthew Gabbin",
+          "sprecher" : "Jürgen Thormann"
+        },
+        {
+          "rolle" : "Steve",
+          "sprecher" : "Sascha Draeger"
+        },
+        {
+          "rolle" : "Laury",
+          "sprecher" : "Rhea Harder-Vennewald"
+        },
+        {
+          "rolle" : "Georgina",
+          "sprecher" : "Maud Ackermann"
+        },
+        {
+          "rolle" : "Bedienung",
+          "sprecher" : "Tim Wenderoth"
+        },
+        {
+          "rolle" : "Gast",
+          "sprecher" : "Andreas Otto"
+        },
+        {
+          "rolle" : "Sekretärin",
+          "sprecher" : "Corinna Wodrich"
+        },
+        {
+          "rolle" : "Sebastian Dawson",
+          "sprecher" : "Bastian Pastewka"
+        },
+        {
+          "rolle" : "Radiosprecher",
+          "sprecher" : "Tobias Meister"
+        }
       ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/3/metadata.json",
@@ -557,187 +558,188 @@
   "hörspielskriptautor" : "André Minninger",
   "beschreibung" : "Kann ein und derselbe Tag dreimal völlig unterschiedlich verlaufen? Kann ein unscheinbares Detail wie ein Colaglas darüber entscheiden, wie sich alle weiteren Geschehnisse entwickeln? Erlebe, wie Justus, Peter und Bob auf den unheimlichen Fluch der Sheldon Street, die mysteriösen Zeichen der Ritter stoßen und den bedrohlichen Fremden Freund stoßen – und zwar zeitgleich am selben Tag!\nDrei Geschichten von drei Autoren führen dich dreimal durch einen Tag, wie er unterschiedlicher nicht verlaufen könnte.",
   "veröffentlichungsdatum" : "2010-10-01",
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Tante Mathilda Jonas",
-      "Karin Lieneweg"
-    ],
-    [
-      "Onkel Titus Jonas",
-      "Hans Meinhardt"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Officer Flann Doyle",
-      "Douglas Welbat"
-    ],
-    [
-      "Tanya Sullivan",
-      "Marion Elskis"
-    ],
-    [
-      "Sebastian Dawson",
-      "Bastian Pastewka"
-    ],
-    [
-      "Miss Tomkins",
-      "Steffi Kirchberger"
-    ],
-    [
-      "Mr. Foley",
-      "Dirk Bach"
-    ],
-    [
-      "John Gabbin",
-      "Tobias Schmidt"
-    ],
-    [
-      "Matthew Gabbin",
-      "Jürgen Thormann"
-    ],
-    [
-      "Georgina",
-      "Maud Ackermann"
-    ],
-    [
-      "Gil Renard",
-      "Udo Schenk"
-    ],
-    [
-      "Hedy Carlson",
-      "Luise Helm"
-    ],
-    [
-      "Steve",
-      "Sascha Draeger"
-    ],
-    [
-      "Jack",
-      "Hendrik Buchna"
-    ],
-    [
-      "Laury",
-      "Rhea Harder-Vennewald"
-    ],
-    [
-      "Gast 1",
-      "Christian Senger"
-    ],
-    [
-      "Fahrerin",
-      "Corinna Wodrich"
-    ],
-    [
-      "Radiosprecher",
-      "Tobias Meister"
-    ],
-    [
-      "Peter Foster",
-      "Gerrit Schmidt-Foss"
-    ],
-    [
-      "Mrs. Shaw",
-      "Isabella Grote"
-    ],
-    [
-      "Annie Wilkes",
-      "Regina Lemnitz"
-    ],
-    [
-      "Mädchen 1",
-      "Katinka Körting"
-    ],
-    [
-      "Mädchen 2",
-      "Jacqueline Meybauer"
-    ],
-    [
-      "Alter Mann",
-      "Jörg Gillner"
-    ],
-    [
-      "Junger Mann",
-      "Patrick Bach"
-    ],
-    [
-      "Dick Perry",
-      "Ernst H. Hilbich"
-    ],
-    [
-      "Bill Andrews",
-      "Henry König"
-    ],
-    [
-      "Miss Bennett",
-      "Renate Pilcher"
-    ],
-    [
-      "Walter Bush",
-      "Rolf E. Schenker"
-    ],
-    [
-      "Ian Bush",
-      "Sky du Mont / Lucas Sperber"
-    ],
-    [
-      "Jimmy Sinclair",
-      "Siegfried Kernen / Nils Noller"
-    ],
-    [
-      "Charlie Parker",
-      "Jörg Gillner / Laurence Kalaidjan"
-    ],
-    [
-      "Brianna Jackson",
-      "Hansi Jochmann / Natalie Demtröder"
-    ],
-    [
-      "Chloe Smathers",
-      "Valerie Demtröder"
-    ],
-    [
-      "Joseph Quick",
-      "Harry Rowohlt"
-    ],
-    [
-      "Mr. Raynes",
-      "Olaf Kreuzenbeck"
-    ],
-    [
-      "Jeff White",
-      "Horst Naumann"
-    ],
-    [
-      "Bedienung",
-      "Tim Wenderoth"
-    ],
-    [
-      "Gast 2",
-      "Andreas Otto"
-    ],
-    [
-      "Sekretärin",
-      "Corinna Wodrich"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Officer Flann Doyle",
+      "sprecher" : "Douglas Welbat"
+    },
+    {
+      "rolle" : "Tanya Sullivan",
+      "sprecher" : "Marion Elskis"
+    },
+    {
+      "rolle" : "Sebastian Dawson",
+      "sprecher" : "Bastian Pastewka"
+    },
+    {
+      "rolle" : "Miss Tomkins",
+      "sprecher" : "Stephanie Damare"
+    },
+    {
+      "rolle" : "Mr. Foley",
+      "sprecher" : "Dirk Bach"
+    },
+    {
+      "rolle" : "John Gabbin",
+      "sprecher" : "Tobias Schmidt"
+    },
+    {
+      "rolle" : "Matthew Gabbin",
+      "sprecher" : "Jürgen Thormann"
+    },
+    {
+      "rolle" : "Georgina",
+      "sprecher" : "Maud Ackermann"
+    },
+    {
+      "rolle" : "Gil Renard",
+      "sprecher" : "Udo Schenk"
+    },
+    {
+      "rolle" : "Hedy Carlson",
+      "sprecher" : "Luise Helm"
+    },
+    {
+      "rolle" : "Steve",
+      "sprecher" : "Sascha Draeger"
+    },
+    {
+      "rolle" : "Jack",
+      "sprecher" : "Hendrik Buchna"
+    },
+    {
+      "rolle" : "Laury",
+      "sprecher" : "Rhea Harder-Vennewald"
+    },
+    {
+      "rolle" : "Gast 1",
+      "sprecher" : "Christian Senger"
+    },
+    {
+      "rolle" : "Fahrerin",
+      "sprecher" : "Corinna Wodrich"
+    },
+    {
+      "rolle" : "Radiosprecher",
+      "sprecher" : "Tobias Meister"
+    },
+    {
+      "rolle" : "Peter Foster",
+      "sprecher" : "Gerrit Schmidt-Foß"
+    },
+    {
+      "rolle" : "Mrs. Shaw",
+      "sprecher" : "Isabella Grothe"
+    },
+    {
+      "rolle" : "Annie Wilkes",
+      "sprecher" : "Regina Lemnitz"
+    },
+    {
+      "rolle" : "Mädchen 1",
+      "sprecher" : "Katinka Körting"
+    },
+    {
+      "rolle" : "Mädchen 2",
+      "sprecher" : "Jacqueline Meybauer"
+    },
+    {
+      "rolle" : "Alter Mann",
+      "sprecher" : "Jörg Gillner"
+    },
+    {
+      "rolle" : "Junger Mann",
+      "sprecher" : "Patrick Bach"
+    },
+    {
+      "rolle" : "Dick Perry",
+      "sprecher" : "Ernst H. Hilbich"
+    },
+    {
+      "rolle" : "Mr. Andrews",
+      "sprecher" : "Henry König"
+    },
+    {
+      "rolle" : "Miss Bennett",
+      "sprecher" : "Renate Pichler"
+    },
+    {
+      "rolle" : "Walter Bush",
+      "sprecher" : "Rolf E. Schenker"
+    },
+    {
+      "rolle" : "Ian Bush",
+      "sprecher" : "Sky du Mont / Lukas T. Sperber"
+    },
+    {
+      "rolle" : "Jimmy Sinclair",
+      "sprecher" : "Siegfried W. Kernen / Nils Noller"
+    },
+    {
+      "rolle" : "Charlie Parker",
+      "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+    },
+    {
+      "rolle" : "Brianna Jackson",
+      "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+    },
+    {
+      "rolle" : "Chloe Smathers",
+      "sprecher" : "Valerie Demtrøder"
+    },
+    {
+      "rolle" : "Joseph Quick",
+      "sprecher" : "Harry Rowohlt"
+    },
+    {
+      "rolle" : "Mr. Raynes",
+      "sprecher" : "Olaf Kreutzenbeck"
+    },
+    {
+      "rolle" : "Jeff White",
+      "sprecher" : "Horst Naumann"
+    },
+    {
+      "rolle" : "Bedienung",
+      "sprecher" : "Tim Wenderoth"
+    },
+    {
+      "rolle" : "Gast 2",
+      "sprecher" : "Andreas Otto"
+    },
+    {
+      "rolle" : "Sekretärin",
+      "sprecher" : "Corinna Wodrich"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/metadata.json",

--- a/web/data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json
+++ b/web/data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json
@@ -126,95 +126,87 @@
       "end" : 5753347
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw",
-      "Jens Wawrczek"
-    ],
-    [
-      "Bob Andrews",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Onkel Titus",
-      "Rüdiger Schulzki"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Roger Kind",
-      "Holger Mahlich"
-    ],
-    [
-      "R. Kind als Regisseur Kushing",
-      "Holger Mahlich"
-    ],
-    [
-      "R. Kind als Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Inspektor Cotta",
-      "Holger Mahlich"
-    ],
-    [
-      "Regisseur Kushing",
-      "Tim Grobe"
-    ],
-    [
-      "Melanie Shepard",
-      "Christiane Leuchtmann"
-    ],
-    [
-      "Laura",
-      "Henrike Fehrs"
-    ],
-    [
-      "Lara Bix",
-      "Ursula Sieg"
-    ],
-    [
-      "Jason Frost",
-      "Robert Missler"
-    ],
-    [
-      "Kellnerin",
-      "Simona Pahl"
-    ],
-    [
-      "Museumsdame",
-      "Rhea Harder"
-    ],
-    [
-      "Monsterpuppe",
-      "Kerstin Draeger"
-    ],
-    [
-      "Betty Frost",
-      "Rosemarie Wohlbauer"
-    ],
-    [
-      "Wachmann",
-      "Markus Schäfer"
-    ],
-    [
-      "Kameramann",
-      "Helgé Halvé"
-    ],
-    [
-      "Tonmann",
-      "Timo Alexander Wenzel"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Rüdiger Schulzki"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Roger Kind",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Inspektor Cotta",
+      "sprecher" : "Holger Mahlich"
+    },
+    {
+      "rolle" : "Regisseur Kushing",
+      "sprecher" : "Tim Grobe"
+    },
+    {
+      "rolle" : "Melanie Shepard",
+      "sprecher" : "Christiane Leuchtmann"
+    },
+    {
+      "rolle" : "Laura",
+      "sprecher" : "Henrike Fehrs"
+    },
+    {
+      "rolle" : "Lara Bix",
+      "sprecher" : "Ursula Sieg"
+    },
+    {
+      "rolle" : "Jason Frost",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Kellnerin",
+      "sprecher" : "Simona Pahl"
+    },
+    {
+      "rolle" : "Museumsdame",
+      "sprecher" : "Rhea Harder-Vennewald"
+    },
+    {
+      "rolle" : "Monsterpuppe",
+      "sprecher" : "Kerstin Draeger"
+    },
+    {
+      "rolle" : "Betty Frost",
+      "sprecher" : "Rosemarie Wohlbauer"
+    },
+    {
+      "rolle" : "Wachmann",
+      "sprecher" : "Markus Schäfer"
+    },
+    {
+      "rolle" : "Kameramann",
+      "sprecher" : "Helge Halvé"
+    },
+    {
+      "rolle" : "Tonmann",
+      "sprecher" : "Timo Alexander Wenzel"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json",

--- a/web/data/Spezial/und-die-schwarze-Katze/metadata.json
+++ b/web/data/Spezial/und-die-schwarze-Katze/metadata.json
@@ -166,95 +166,96 @@
       "end" : 5317587
     }
   ],
-  "sprecher" : [
-    [
-      "Erzähler",
-      "Thomas Fritsch"
-    ],
-    [
-      "Justus Jonas, Erster Detektiv",
-      "Oliver Rohrbeck"
-    ],
-    [
-      "Peter Shaw, Zweiter Detektiv",
-      "Jens Wawrczeck"
-    ],
-    [
-      "Bob Andrews, Recherchen und Archiv",
-      "Andreas Fröhlich"
-    ],
-    [
-      "Andy Carson",
-      "Stefan Schwade"
-    ],
-    [
-      "Carson, Andys Vater",
-      "Hans Kahlert"
-    ],
-    [
-      "Onkel Titus",
-      "Hans Meinhardt"
-    ],
-    [
-      "Tante Mathilda",
-      "Karin Lieneweg"
-    ],
-    [
-      "Gabbo",
-      "Manfred Reddemann"
-    ],
-    [
-      "Wachmann",
-      "Till Huster"
-    ],
-    [
-      "Iwan",
-      "Urs Affolter"
-    ],
-    [
-      "Reynolds",
-      "Christian Redl"
-    ],
-    [
-      "Khan",
-      "Klaus Dittmann"
-    ],
-    [
-      "Schaustellerin",
-      "Ursula Sieg"
-    ],
-    [
-      "Vermieter",
-      "Stephan Benson"
-    ],
-    [
-      "Polizist 1",
-      "Jürgen Holdorf"
-    ],
-    [
-      "Polizist 2 (Prolog)",
-      "Daniel Welbat"
-    ],
-    [
-      "Polizist 3 (Prolog)",
-      "Matthias Krauße"
-    ],
-    [
-      "Losverkäufer",
-      "Joachim Kretzer"
-    ],
-    [
-      "Kassiererin",
-      "Birte Kretschmer"
-    ],
-    [
-      "Feuerschlucker",
-      "Robert Missler"
-    ],
-    [
-      "Jack",
-      "Timo Alexander Wenzel"
-    ]
+  "sprechrollen" : [
+    {
+      "rolle" : "Erzähler",
+      "sprecher" : "Thomas Fritsch"
+    },
+    {
+      "rolle" : "Justus Jonas, Erster Detektiv",
+      "sprecher" : "Oliver Rohrbeck"
+    },
+    {
+      "rolle" : "Peter Shaw, Zweiter Detektiv",
+      "sprecher" : "Jens Wawrczeck"
+    },
+    {
+      "rolle" : "Bob Andrews, Recherchen und Archiv",
+      "sprecher" : "Andreas Fröhlich"
+    },
+    {
+      "rolle" : "Andy Carson",
+      "sprecher" : "Stefan Schwade"
+    },
+    {
+      "rolle" : "Carson, Andys Vater",
+      "sprecher" : "Hans Kahlert"
+    },
+    {
+      "rolle" : "Onkel Titus",
+      "sprecher" : "Andreas E. Beurmann",
+      "pseudonym" : "Hans Meinhardt"
+    },
+    {
+      "rolle" : "Tante Mathilda",
+      "sprecher" : "Karin Lieneweg"
+    },
+    {
+      "rolle" : "Gabbo",
+      "sprecher" : "Manfred Reddemann"
+    },
+    {
+      "rolle" : "Wachmann",
+      "sprecher" : "Till Huster"
+    },
+    {
+      "rolle" : "Iwan",
+      "sprecher" : "Urs Affolter"
+    },
+    {
+      "rolle" : "Kommissar Reynolds",
+      "sprecher" : "Christian Redl"
+    },
+    {
+      "rolle" : "Khan",
+      "sprecher" : "Klaus Dittmann"
+    },
+    {
+      "rolle" : "Schaustellerin",
+      "sprecher" : "Ursula Sieg"
+    },
+    {
+      "rolle" : "Vermieter",
+      "sprecher" : "Stephan Benson"
+    },
+    {
+      "rolle" : "Polizist 1",
+      "sprecher" : "Jürgen Holdorf"
+    },
+    {
+      "rolle" : "Polizist 2 (Prolog)",
+      "sprecher" : "Daniel Welbat"
+    },
+    {
+      "rolle" : "Polizist 3 (Prolog)",
+      "sprecher" : "Matthias Krauße"
+    },
+    {
+      "rolle" : "Losverkäufer",
+      "sprecher" : "Joachim Kretzer"
+    },
+    {
+      "rolle" : "Kassiererin",
+      "sprecher" : "Birte Kretschmer"
+    },
+    {
+      "rolle" : "Feuerschlucker",
+      "sprecher" : "Robert Missler"
+    },
+    {
+      "rolle" : "Jack",
+      "sprecher" : "Timo Alexander Wenzel"
+    }
   ],
   "links" : {
     "json" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/metadata.json",

--- a/web/data/metadata_structure.swift
+++ b/web/data/metadata_structure.swift
@@ -14,7 +14,7 @@ class Höreinheit {
 	var beschreibung: String?
 	var veröffentlichungsdatum: String?
 	var kapitel: [Kapitel]?
-	var sprecher: [[String]]?
+	var sprechrollen: [Sprechrolle]?
 	var links: Links?
 	var unvollständig: Bool?
 }
@@ -33,6 +33,12 @@ class Kapitel {
 	let titel: String
 	var start: Int?
 	var end: Int?
+}
+
+class Sprechrolle {
+	var rolle: String
+	var sprecher: String
+	var pseudonym: String?
 }
 
 class Links {


### PR DESCRIPTION
## Fix "sprecher" data

### Actors ([~360 changes](https://github.com/YourMJK/dreimetadaten/commit/4f4b1861f50da21a6ab54ad110d5dad6f86775aa))
Using data from hoerspielforscher.de, Wikipedia and Google search:
* fixed typos in names
* fixed wrong attributions
* updated names to current preference
* deobfuscated pseudonyms by adding real name in brackets
* **one canonical name per person**

### Roles ([~480 changes](https://github.com/YourMJK/dreimetadaten/commit/15ba3cecba0f0a9f16b8033febb7d20bb0370a18))

* fixed typos and punctuation in names
* updated names to most recent/common usage
* **one canonical name per role**

## Migrate array-based "sprecher" to object-based "sprechrollen"
Changed JSON structure by replacing all previous `"sprecher"`, e.g.:
``` json
"sprecher" : [
  [
    "Role name 1",
    "Actor name 1"
  ],
  [
    "Role name 2",
    "Pseudonym [Actor name 2]"
  ],
  ...
]
```  
with new `"sprechrollen"`, e.g.:
``` json
"sprechrollen" : [
  {
    "rolle" : "Role name 1",
    "sprecher" : "Actor name 1"
  },
  {
    "rolle" : "Role name 2",
    "sprecher" : "Actor name 2",
    "pseudonym" : "Pseudonym"
  },
  ...
]
```


