### PR TITLE
Add object model instantiation and JSON export from database

### DIFF
--- a/code/Package.swift
+++ b/code/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
 	name: "dreimetadaten",
+	platforms: [.macOS(.v10_15)],
 	products: [
 		.executable(name: "dreimetadaten", targets: ["dreimetadaten"]),
 	],
@@ -11,6 +12,7 @@ let package = Package(
 		.package(url: "https://github.com/YourMJK/CommandLineTool", from: "1.1.0"),
 		.package(url: "https://github.com/dehesa/CodableCSV", from: "0.6.0"),
 		.package(url: "https://github.com/groue/GRDB.swift", from: "6.27.0"),
+		.package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
 	],
 	targets: [
 		.executableTarget(
@@ -19,6 +21,7 @@ let package = Package(
 				"CommandLineTool",
 				"CodableCSV",
 				.product(name: "GRDB", package: "GRDB.swift"),
+				.product(name: "Collections", package: "swift-collections")
 			],
 			path: "dreimetadaten"
 		)

--- a/code/dreimetadaten/CollectionType.swift
+++ b/code/dreimetadaten/CollectionType.swift
@@ -40,10 +40,13 @@ enum CollectionType: String, ArgumentEnum {
 		}
 	}
 	
+	var titleNummerFormat: String? {
+		nummerFormat.map { "Nr. \($0)" }
+	}
 	var nummerFormat: String? {
 		switch self {
-			case .serie: return "Nr. %03d"
-			case .die_dr3i: return "Nr. %d"
+			case .serie: return "%03d"
+			case .die_dr3i: return "%d"
 			default: return nil
 		}
 	}

--- a/code/dreimetadaten/Command/Command.Export.JSON.swift
+++ b/code/dreimetadaten/Command/Command.Export.JSON.swift
@@ -1,0 +1,61 @@
+//
+//  Command.Export.JSON.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 29.06.24.
+//
+
+import Foundation
+import CommandLineTool
+import ArgumentParser
+import GRDB
+
+
+extension Command.Export {
+	struct JSON: ParsableCommand {
+		static let configuration = CommandConfiguration(
+			abstract: "Export object model as JSON files.",
+			alwaysCompactUsageOptions: true
+		)
+		
+		@Argument(help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
+		var databaseFilePath: String = Command.databaseFile.relativePath
+		
+		@Argument(help: ArgumentHelp("The path to the JSON output directory.", valueName: "output directory"))
+		var jsonDirectoryPath: String = Command.jsonDir.relativePath
+		
+		@Option(name: .customLong("webDataURL"), help: ArgumentHelp("The URL pointing to the web data directory. Used as the base URL for generated metadata links.", valueName: "URL"))
+		var webDataURLString: String = Command.webDataURL.absoluteString
+		
+		func run() throws {
+			let jsonDirectoryURL = URL(fileURLWithPath: jsonDirectoryPath, isDirectory: true)
+			guard let webDataURL = URL(string: webDataURLString) else {
+				throw ArgumentsError.invalidURL(string: webDataURLString)
+			}
+			
+			if !FileManager.default.fileExists(atPath: jsonDirectoryURL.path) {
+				try FileManager.default.createDirectory(at: jsonDirectoryURL, withIntermediateDirectories: false)
+			}
+			
+			let dbQueue = try DatabaseQueue(path: databaseFilePath)
+			try dbQueue.read { db in
+				let exporter = JSONExporter(db: db, webDataURL: webDataURL)
+				try exporter.export(to: jsonDirectoryURL)
+			}
+		}
+	}
+}
+
+
+extension Command.Export.JSON {
+	enum ArgumentsError: LocalizedError {
+		case invalidURL(string: String)
+		
+		var errorDescription: String? {
+			switch self {
+				case .invalidURL(let string):
+					return "Invalid URL \"\(string)\""
+			}
+		}
+	}
+}

--- a/code/dreimetadaten/Command/Command.Export.swift
+++ b/code/dreimetadaten/Command/Command.Export.swift
@@ -14,7 +14,7 @@ extension Command {
 	struct Export: ParsableCommand {
 		static let configuration = CommandConfiguration(
 			abstract: "Export dataset into various (more convenient) formats.",
-			subcommands: [Web.self, SQL.self, TSV.self],
+			subcommands: [SQL.self, TSV.self, JSON.self, Web.self],
 			helpMessageLabelColumnWidth: 20,
 			alwaysCompactUsageOptions: true
 		)

--- a/code/dreimetadaten/Command/Command.swift
+++ b/code/dreimetadaten/Command/Command.swift
@@ -13,7 +13,7 @@ import ArgumentParser
 struct Command: ParsableCommand {
 	static let configuration = CommandConfiguration(
 		commandName: executableName,
-		version: "1.1.0",
+		version: "1.2.0",
 		subcommands: [Migrate.self, Export.self, WebBuild.self, Load.self],
 		helpMessageLabelColumnWidth: 20
 	)
@@ -27,6 +27,13 @@ struct Command: ParsableCommand {
 	static let databaseFile = metadataDir.appendingPathComponent("db.sqlite")
 	static let sqlFile = metadataDir.appendingPathComponent("db.sql")
 	static let tsvDir = metadataDir.appendingPathComponent("tsv")
+	static let jsonDir = metadataDir.appendingPathComponent("json")
+	
+	static let webURL = URL(string: "http://dreimetadaten.de")!
+	static let webDir = url(projectRelativePath: "web")
+	private static let webDataDirRelativePath = "data"
+	static var webDataURL: URL { webURL.appendingPathComponent(webDataDirRelativePath) }
+	static var webDataDir: URL { webDir.appendingPathComponent(webDataDirRelativePath) }
 	
 	static func url(projectRelativePath projectDirRelativePath: String) -> URL {
 		let dest = URL(fileURLWithPath: projectDirRelativePath, relativeTo: projectDir)

--- a/code/dreimetadaten/Export/FFMetadata.swift
+++ b/code/dreimetadaten/Export/FFMetadata.swift
@@ -157,7 +157,7 @@ extension FFmetadata {
 	
 	/// Create the FFmetadata for a collection item of type `type` with `Self.init(withBasicTagsFrom:)` and using the type's specific `titlePrefix` (e.g. "Die drei ???") and `nummerFormat` (e.g. "Nr. %03d") to form a title.
 	static func create(forCollectionItem hörspiel: MetadataObjectModel.Hörspiel, type: CollectionType) -> Self {
-		create(forCollectionItem: hörspiel, titlePrefix: type.titlePrefix, nummerFormat: type.nummerFormat)
+		create(forCollectionItem: hörspiel, titlePrefix: type.titlePrefix, nummerFormat: type.titleNummerFormat)
 	}
 	
 	/// Create the FFmetadata for a generic collection item with `Self.init(withBasicTagsFrom:)` and using the specified `titlePrefix` (e.g. "Die drei ???") and `nummerFormat` (e.g. "Nr. %03d") to form a title.

--- a/code/dreimetadaten/Export/JSONExporter.swift
+++ b/code/dreimetadaten/Export/JSONExporter.swift
@@ -1,0 +1,25 @@
+//
+//  JSONExporter.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 07.07.24.
+//
+
+import Foundation
+import GRDB
+
+
+struct JSONExporter {
+	let db: Database
+	let webDataURL: URL
+	
+	func export(to outputDir: URL) throws {
+		let objectModels = try MetadataObjectModel(fromDatabase: db, withBaseURL: webDataURL).separateByCollectionType()
+		
+		for (objectModel, collectionType) in objectModels {
+			let jsonURL = outputDir.appendingPathComponent("\(collectionType.fileName).json")
+			let jsonString = try objectModel.jsonString()
+			try jsonString.write(to: jsonURL, atomically: true, encoding: .utf8)
+		}
+	}
+}

--- a/code/dreimetadaten/MetadataModel/MetadataObjectModel.swift
+++ b/code/dreimetadaten/MetadataModel/MetadataObjectModel.swift
@@ -29,12 +29,18 @@ extension MetadataObjectModel {
 		var veröffentlichungsdatum: String?
 		var kapitel: [Kapitel]?
 		var sprechrollen: [Sprechrolle]?
+		var medien: [Medium]?
 		var links: Links?
 		var unvollständig: Bool?
 	}
 	
 	class Folge: Hörspiel {
 		var nummer: Int
+		
+		init(nummer: Int) {
+			self.nummer = nummer
+			super.init()
+		}
 		
 		// Codable
 		enum CodingKeys: CodingKey {
@@ -55,6 +61,11 @@ extension MetadataObjectModel {
 	class Teil: Hörspiel {
 		var teilNummer: UInt
 		var buchstabe: String?
+		
+		init(teilNummer: UInt) {
+			self.teilNummer = teilNummer
+			super.init()
+		}
 		
 		// Codable
 		enum CodingKeys: CodingKey {
@@ -87,10 +98,15 @@ extension MetadataObjectModel {
 		var pseudonym: String?
 	}
 	
+	struct Medium: Codable {
+		var tracks: [Kapitel]
+		var xld_log: String?
+	}
+	
 	struct Links: Codable {
 		var json: String?
 		var ffmetadata: String?
-		var xld_log: String?
+		var xld_log: String?  // Only kept for backwards-compatibility
 		var cover: String?
 		var cover_itunes: String?
 		var cover_kosmos: String?
@@ -140,6 +156,7 @@ extension MetadataObjectModel {
 			"veröffentlichungsdatum",
 			"kapitel",
 			"sprechrollen",
+			"medien",
 			"links",
 			"unvollständig",
 			
@@ -151,9 +168,11 @@ extension MetadataObjectModel {
 			"sprecher",
 			"pseudonym",
 			
+			"tracks",
+			"xld_log",
+			
 			"json",
 			"ffmetadata",
-			"xld_log",
 			"cover",
 			"cover_itunes",
 			"cover_kosmos"

--- a/code/dreimetadaten/MetadataModel/MetadataObjectModel.swift
+++ b/code/dreimetadaten/MetadataModel/MetadataObjectModel.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import GRDB
+import Collections
 
 
 struct MetadataObjectModel: Codable {
@@ -259,6 +261,296 @@ extension MetadataObjectModel {
 		}
 		catch {
 			throw JSONError.decodingError(error: error)
+		}
+	}
+	
+}
+
+
+// MARK: - Database Reading
+
+extension MetadataObjectModel {
+	
+	init(fromDatabase db: Database, withBaseURL baseURL: URL) throws {
+		self.init(serie: [], spezial: [], kurzgeschichten: [], die_dr3i: [])
+		
+		let columnHörspielID = Column(MetadataRelationalModel.Hörspiel.primaryKeyName)
+		let columnSprechrolleID = Column(MetadataRelationalModel.Sprechrolle.primaryKeyName)
+		let columnMediumID = Column(MetadataRelationalModel.Medium.primaryKeyName)
+		let columnPosition = Column("position")
+		
+		func nilForEmpty<C: Collection>(_ collection: C) -> C? {
+			collection.isEmpty ? nil : collection
+		}
+		func copy(from: Hörspiel, to: Hörspiel) {
+			to.teile = from.teile
+			to.titel = from.titel
+			to.autor = from.autor
+			to.hörspielskriptautor = from.hörspielskriptautor
+			to.kurzbeschreibung = from.kurzbeschreibung
+			to.beschreibung = from.beschreibung
+			to.metabeschreibung = from.metabeschreibung
+			to.veröffentlichungsdatum = from.veröffentlichungsdatum
+			to.kapitel = from.kapitel
+			to.sprechrollen = from.sprechrollen
+			to.medien = from.medien
+			to.links = from.links
+			to.unvollständig = from.unvollständig
+		}
+		
+		var hörspielObjects = [MetadataRelationalModel.Hörspiel.ID: MetadataObjectModel.Hörspiel]()
+		let hörspielArray = try MetadataRelationalModel.Hörspiel.fetchAll(db)
+		for hörspiel in hörspielArray {
+			// autor
+			let buchautorArray = try MetadataRelationalModel.HörspielBuchautor
+				.filter(columnHörspielID == hörspiel.hörspielID)
+				.fetchAll(db)
+				.map {
+					try MetadataRelationalModel.Person.find(db, id: $0.personID).name
+				}
+				.sorted()
+			let buchautor = nilForEmpty(buchautorArray)?.joined(separator: ", ")
+			
+			// hörspielskriptautor
+			let skriptautorArray = try MetadataRelationalModel.HörspielSkriptautor
+				.filter(columnHörspielID == hörspiel.hörspielID)
+				.fetchAll(db)
+				.map {
+					try MetadataRelationalModel.Person.find(db, id: $0.personID).name
+				}
+				.sorted()
+			let skriptautor = nilForEmpty(skriptautorArray)?.joined(separator: ", ")
+			
+			// sprechrollen
+			// Merge entries from table sprechrolle and sprechrolleTeil (in practice one of them is going to be empty)
+			var sprechrollenRows = try MetadataRelationalModel.Sprechrolle
+				.filter(columnHörspielID == hörspiel.hörspielID)
+				.order(columnPosition)
+				.fetchAll(db)
+			try MetadataRelationalModel.SprechrolleTeil
+				.filter(columnHörspielID == hörspiel.hörspielID)
+				.order(columnPosition)
+				.fetchAll(db)
+				.forEach {
+					let row = try MetadataRelationalModel.Sprechrolle.find(db, id: $0.sprechrolleID)
+					sprechrollenRows.append(row)
+				}
+			// Grossly inefficient (this should really be joins) but works for now until I figure out GRDB's associations
+			let sprechrollen: [Sprechrolle] = try sprechrollenRows.map { sprechrolle in
+				let rolle = try MetadataRelationalModel.Rolle.find(db, id: sprechrolle.rolleID).name
+				let sprecherPseudonymArray = try MetadataRelationalModel.Spricht
+					.filter(columnSprechrolleID == sprechrolle.sprechrolleID)
+					.order(columnPosition)
+					.fetchAll(db)
+					.map { spricht in
+						let name = try MetadataRelationalModel.Person.find(db, id: spricht.personID).name
+						let pseudonym = try spricht.pseudonymID.map {
+							try MetadataRelationalModel.Pseudonym.find(db, id: $0).name
+						}
+						return (name: name, pseudonym: pseudonym)
+					}
+				let sprecherArray = sprecherPseudonymArray.map(\.name)
+				let pseudonym = sprecherPseudonymArray.compactMap(\.pseudonym)
+				return Sprechrolle(
+					rolle: rolle,
+					sprecher: sprecherArray.joined(separator: ", "),
+					pseudonym: pseudonym.isEmpty ? nil : pseudonym.joined(separator: ", ")
+				)
+			}
+			
+			// kapitel
+			var start = 0
+			let kapitelArray = try MetadataRelationalModel.Kapitel
+				.filter(columnHörspielID == hörspiel.hörspielID)
+				.order(columnPosition)
+				.fetchAll(db)
+				.map { kapitel in
+					let track = try MetadataRelationalModel.Track.find(db, id: kapitel.trackID)
+					let titel = kapitel.abweichenderTitel ?? track.titel
+					let end = start + Int(track.dauer)
+					let kapitelObject = Kapitel(titel: titel, start: start, end: end)
+					start = end
+					return kapitelObject
+				}
+			
+			// medien
+			var medien = try MetadataRelationalModel.Medium
+				.filter(columnHörspielID == hörspiel.hörspielID)
+				.order(columnPosition)
+				.fetchAll(db)
+				.map { medium in
+					start = 0
+					let tracks = try MetadataRelationalModel.Track
+						.filter(columnMediumID == medium.mediumID)
+						.order(columnPosition)
+						.fetchAll(db)
+						.map { track in
+							let end = start + Int(track.dauer)
+							let trackObject = Kapitel(titel: track.titel, start: start, end: end)
+							start = end
+							return trackObject
+						}
+					return Medium(
+						tracks: tracks,
+						xld_log: medium.xldLog ? "" : nil
+					)
+				}
+			let multipleMedien = medien.count > 1
+			for index in medien.indices {
+				if medien[index].xld_log != nil {
+					medien[index].xld_log = "rip_log\(multipleMedien ? String(index+1) : "").txt"
+				}
+			}
+			
+			// veröffentlichungsdatum
+			let veröffentlichungsdatum = try hörspiel.veröffentlichungsdatum.map {
+				guard $0.format == .YMD else {
+					throw DatabaseError.invalidDateFormat(date: $0)
+				}
+				return String.fromDatabaseValue($0.databaseValue)!
+			}
+			
+			// Create and remember object model item
+			let hörspielObject = Hörspiel()
+			hörspielObject.titel = hörspiel.titel
+			hörspielObject.autor = buchautor
+			hörspielObject.hörspielskriptautor = skriptautor
+			hörspielObject.kurzbeschreibung = hörspiel.kurzbeschreibung
+			hörspielObject.beschreibung = hörspiel.beschreibung
+			hörspielObject.metabeschreibung = hörspiel.metabeschreibung
+			hörspielObject.veröffentlichungsdatum = veröffentlichungsdatum
+			hörspielObject.kapitel = nilForEmpty(kapitelArray)
+			hörspielObject.sprechrollen = nilForEmpty(sprechrollen)
+			hörspielObject.medien = nilForEmpty(medien)
+			hörspielObject.links = Links(
+				json: "metadata.json",
+				ffmetadata: !hörspiel.unvollständig ? "ffmetadata.txt" : nil,
+				cover: hörspiel.cover ? "cover.png" : nil,
+				cover_itunes: hörspiel.urlCoverApple,
+				cover_kosmos: hörspiel.urlCoverKosmos
+			)
+			hörspielObject.unvollständig = hörspiel.unvollständig ? true : nil
+			
+			hörspielObjects[hörspiel.hörspielID] = hörspielObject
+		}
+		
+		
+		func findHörspielObject<T: TableRecord>(id: MetadataRelationalModel.Hörspiel.ID, from: T.Type) throws -> MetadataObjectModel.Hörspiel {
+			guard let object = hörspielObjects[id] else {
+				throw DatabaseError.foreignKeyViolation(table: T.databaseTableName)
+			}
+			return object
+		}
+		
+		// teile
+		for (hörspielID, hörspiel) in hörspielObjects {
+			let teile = try MetadataRelationalModel.HörspielTeil
+				.filter(Column("hörspiel") == hörspielID)
+				.order(columnPosition)
+				.fetchAll(db)
+				.map { hörspielTeil in
+					let teilH = try findHörspielObject(id: hörspielTeil.teil, from: MetadataRelationalModel.HörspielTeil.self)
+					let teil = Teil(teilNummer: hörspielTeil.position)
+					teil.buchstabe = hörspielTeil.buchstabe
+					copy(from: teilH, to: teil)
+					
+					func inheritFromParent<T>(_ keypath: ReferenceWritableKeyPath<Hörspiel, T?>) {
+						teil[keyPath: keypath] = teil[keyPath: keypath] ?? hörspiel[keyPath: keypath]
+					}
+					inheritFromParent(\.autor)
+					inheritFromParent(\.hörspielskriptautor)
+					inheritFromParent(\.veröffentlichungsdatum)
+					
+					return teil
+				}
+			hörspiel.teile = nilForEmpty(teile)
+			if !teile.isEmpty {
+				hörspiel.links?.ffmetadata = nil
+			}
+		}
+		
+		// url
+		func apply(url: URL, to hörspiel: Hörspiel) {
+			func prepend(to fileName: inout String?) {
+				fileName = fileName.map { url.appendingPathComponent($0).absoluteString }
+			}
+			if hörspiel.links != nil {
+				prepend(to: &hörspiel.links!.json)
+				prepend(to: &hörspiel.links!.ffmetadata)
+				prepend(to: &hörspiel.links!.cover)
+			}
+			hörspiel.medien?.indices.forEach {
+				prepend(to: &hörspiel.medien![$0].xld_log)
+			}
+			hörspiel.teile?.enumerated().forEach { (index, teil) in
+				apply(url: url.appendingPathComponent(String(teil.teilNummer)), to: teil)
+			}
+		}
+		func addURL(to hörspiel: Hörspiel, as collectionType: CollectionType) throws {
+			let dirname = try WebDataExporter.dirname(for: hörspiel, nummerFormat: collectionType.nummerFormat)
+			let url = baseURL
+				.appendingPathComponent(collectionType.fileName)
+				.appendingPathComponent(dirname)
+			apply(url: url, to: hörspiel)
+		}
+		
+		// serie
+		serie = try MetadataRelationalModel.SerieFolge
+			.orderByPrimaryKey()
+			.fetchAll(db)
+			.map {
+				let hörspiel = try findHörspielObject(id: $0.hörspielID, from: MetadataRelationalModel.SerieFolge.self)
+				let folge = Folge(nummer: $0.nummer)
+				copy(from: hörspiel, to: folge)
+				try addURL(to: folge, as: .serie)
+				return folge
+			}
+		
+		// spezial
+		spezial = try MetadataRelationalModel.SpezialFolge
+			.order(columnPosition)
+			.fetchAll(db)
+			.map {
+				let hörspiel = try findHörspielObject(id: $0.hörspielID, from: MetadataRelationalModel.SpezialFolge.self)
+				try addURL(to: hörspiel, as: .spezial)
+				return hörspiel
+			}
+		
+		// kurzgeschichten
+		kurzgeschichten = try MetadataRelationalModel.KurzgeschichtenFolge
+			.orderByPrimaryKey()
+			.fetchAll(db)
+			.map {
+				let hörspiel = try findHörspielObject(id: $0.hörspielID, from: MetadataRelationalModel.KurzgeschichtenFolge.self)
+				try addURL(to: hörspiel, as: .kurzgeschichten)
+				return hörspiel
+			}
+		
+		// die_dr3i
+		die_dr3i = try MetadataRelationalModel.DieDr3iFolge
+			.orderByPrimaryKey()
+			.fetchAll(db)
+			.map {
+				let hörspiel = try findHörspielObject(id: $0.hörspielID, from: MetadataRelationalModel.DieDr3iFolge.self)
+				let folge = Folge(nummer: $0.nummer)
+				copy(from: hörspiel, to: folge)
+				try addURL(to: folge, as: .die_dr3i)
+				return folge
+			}
+	}
+	
+	
+	enum DatabaseError: LocalizedError {
+		case foreignKeyViolation(table: String)
+		case invalidDateFormat(date: DatabaseDateComponents)
+		
+		var errorDescription: String? {
+			switch self {
+				case .foreignKeyViolation(let table):
+					return "Foreign key contraint violation in \"\(table)\""
+				case .invalidDateFormat(let date):
+					return "Invalid date format for \"\(date)\""
+			}
 		}
 	}
 	

--- a/code/dreimetadaten/MetadataModel/MetadataObjectModel.swift
+++ b/code/dreimetadaten/MetadataModel/MetadataObjectModel.swift
@@ -264,6 +264,24 @@ extension MetadataObjectModel {
 		}
 	}
 	
+	
+	// MARK: - Collection Type Masking
+	
+	func separateByCollectionType() -> [(objectModel: Self, collectionType: CollectionType)] {
+		CollectionType.allCases.map { collectionType in
+			var maskedObjectModel = Self()
+			switch collectionType.objectModelKeyPath {
+				case let keyPath as WritableKeyPath<Self, [Folge]?>:
+					maskedObjectModel[keyPath: keyPath] = self[keyPath: keyPath]
+				case let keyPath as WritableKeyPath<Self, [Hörspiel]?>:
+					maskedObjectModel[keyPath: keyPath] = self[keyPath: keyPath]
+				default:
+					fatalError("Unrecognized type for CollectionType.objectModelKeyPath")
+			}
+			return (maskedObjectModel, collectionType)
+		}
+	}
+	
 }
 
 

--- a/metadata/json/DiE_DR3i.json
+++ b/metadata/json/DiE_DR3i.json
@@ -6,6 +6,9 @@
         {
           "teilNummer" : 1,
           "titel" : "Zimmer",
+          "autor" : "Ivar Leon Menger",
+          "hörspielskriptautor" : "Ivar Leon Menger",
+          "veröffentlichungsdatum" : "2006-11-24",
           "kapitel" : [
             {
               "titel" : "Intro",
@@ -136,13 +139,15 @@
           "links" : {
             "json" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/1/metadata.json",
             "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/1/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/1/rip_log.txt",
             "cover" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/1/cover.png"
           }
         },
         {
           "teilNummer" : 2,
           "titel" : "Restaurant",
+          "autor" : "Ivar Leon Menger",
+          "hörspielskriptautor" : "Ivar Leon Menger",
+          "veröffentlichungsdatum" : "2006-11-24",
           "kapitel" : [
             {
               "titel" : "Intro",
@@ -273,7 +278,6 @@
           "links" : {
             "json" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/2/metadata.json",
             "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/2/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/2/rip_log.txt",
             "cover" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/2/cover.png"
           }
         }
@@ -350,6 +354,268 @@
           "sprecher" : "Bernd Klose"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Intro",
+              "start" : 0,
+              "end" : 127747
+            },
+            {
+              "titel" : "Ankunft Hotel",
+              "start" : 127747,
+              "end" : 680947
+            },
+            {
+              "titel" : "Entscheidung: Zimmer oder Restaurant",
+              "start" : 680947,
+              "end" : 744707
+            },
+            {
+              "titel" : "Zimmer",
+              "start" : 744707,
+              "end" : 932960
+            },
+            {
+              "titel" : "Entscheidung: Tür offen oder Klimaanlage",
+              "start" : 932960,
+              "end" : 1007760
+            },
+            {
+              "titel" : "Tür offen",
+              "start" : 1007760,
+              "end" : 1165333
+            },
+            {
+              "titel" : "Entscheidung: Tür schließen oder Flur",
+              "start" : 1165333,
+              "end" : 1211827
+            },
+            {
+              "titel" : "Tür schließen",
+              "start" : 1211827,
+              "end" : 1412120
+            },
+            {
+              "titel" : "Entscheidung: Mr. Stanley oder Auto holen",
+              "start" : 1412120,
+              "end" : 1457520
+            },
+            {
+              "titel" : "Mr. Stanley",
+              "start" : 1457520,
+              "end" : 1694933
+            },
+            {
+              "titel" : "Auto holen",
+              "start" : 1694933,
+              "end" : 1915213
+            },
+            {
+              "titel" : "Flur",
+              "start" : 1915213,
+              "end" : 2061227
+            },
+            {
+              "titel" : "Entscheidung: Flucht oder Ausrede",
+              "start" : 2061227,
+              "end" : 2104347
+            },
+            {
+              "titel" : "Flucht",
+              "start" : 2104347,
+              "end" : 2354680
+            },
+            {
+              "titel" : "Ausrede",
+              "start" : 2354680,
+              "end" : 2578267
+            },
+            {
+              "titel" : "Klimaanlage",
+              "start" : 2578267,
+              "end" : 2864440
+            },
+            {
+              "titel" : "Entscheidung: Annehmen oder Ablehnen",
+              "start" : 2864440,
+              "end" : 2916507
+            },
+            {
+              "titel" : "Annehmen",
+              "start" : 2916507,
+              "end" : 3054173
+            },
+            {
+              "titel" : "Entscheidung: Essen oder Auflegen",
+              "start" : 3054173,
+              "end" : 3127520
+            },
+            {
+              "titel" : "Essen",
+              "start" : 3127520,
+              "end" : 3315400
+            },
+            {
+              "titel" : "Auflegen",
+              "start" : 3315400,
+              "end" : 3603307
+            },
+            {
+              "titel" : "Ablehnen",
+              "start" : 3603307,
+              "end" : 3721707
+            },
+            {
+              "titel" : "Entscheidung: Befreien oder Fragen stellen",
+              "start" : 3721707,
+              "end" : 3806013
+            },
+            {
+              "titel" : "Befreien",
+              "start" : 3806013,
+              "end" : 4062120
+            },
+            {
+              "titel" : "Fragen stellen",
+              "start" : 4062120,
+              "end" : 4302080
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Intro",
+              "start" : 0,
+              "end" : 118600
+            },
+            {
+              "titel" : "Ankunft Hotel",
+              "start" : 118600,
+              "end" : 630147
+            },
+            {
+              "titel" : "Entscheidung: Zimmer oder Restaurant",
+              "start" : 630147,
+              "end" : 690733
+            },
+            {
+              "titel" : "Restaurant",
+              "start" : 690733,
+              "end" : 932747
+            },
+            {
+              "titel" : "Entscheidung: Gästebuch oder Sachen holen",
+              "start" : 932747,
+              "end" : 1024293
+            },
+            {
+              "titel" : "Gästebuch",
+              "start" : 1024293,
+              "end" : 1166507
+            },
+            {
+              "titel" : "Entscheidung: Zimmer 113 oder Flucht",
+              "start" : 1166507,
+              "end" : 1233293
+            },
+            {
+              "titel" : "Zimmer 113",
+              "start" : 1233293,
+              "end" : 1458520
+            },
+            {
+              "titel" : "Entscheidung: Verstecken oder Polizei",
+              "start" : 1458520,
+              "end" : 1523587
+            },
+            {
+              "titel" : "Verstecken",
+              "start" : 1523587,
+              "end" : 1716960
+            },
+            {
+              "titel" : "Polizei",
+              "start" : 1716960,
+              "end" : 1917160
+            },
+            {
+              "titel" : "Flucht",
+              "start" : 1917160,
+              "end" : 2191253
+            },
+            {
+              "titel" : "Entscheidung: Laufen oder Ausleihen",
+              "start" : 2191253,
+              "end" : 2239787
+            },
+            {
+              "titel" : "Laufen",
+              "start" : 2239787,
+              "end" : 2462373
+            },
+            {
+              "titel" : "Ausleihen",
+              "start" : 2462373,
+              "end" : 2759013
+            },
+            {
+              "titel" : "Sachen holen",
+              "start" : 2759013,
+              "end" : 2967867
+            },
+            {
+              "titel" : "Entscheidung: 7. Stock oder Zimmer",
+              "start" : 2967867,
+              "end" : 3029867
+            },
+            {
+              "titel" : "7. Stock",
+              "start" : 3029867,
+              "end" : 3107373
+            },
+            {
+              "titel" : "Entscheidung: Hilferuf oder Autoschlüssel",
+              "start" : 3107373,
+              "end" : 3169533
+            },
+            {
+              "titel" : "Hilferuf",
+              "start" : 3169533,
+              "end" : 3486840
+            },
+            {
+              "titel" : "Autoschlüssel",
+              "start" : 3486840,
+              "end" : 3694973
+            },
+            {
+              "titel" : "Zimmer",
+              "start" : 3694973,
+              "end" : 4080360
+            },
+            {
+              "titel" : "Entscheidung: Wecken oder KO schlagen",
+              "start" : 4080360,
+              "end" : 4179547
+            },
+            {
+              "titel" : "Wecken",
+              "start" : 4179547,
+              "end" : 4638867
+            },
+            {
+              "titel" : "KO schlagen",
+              "start" : 4638867,
+              "end" : 4828320
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/metadata.json",
         "cover" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/cover.png"
@@ -357,156 +623,6 @@
     },
     {
       "nummer" : 1,
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Der Phantom-Anwalt",
-              "start" : 0,
-              "end" : 553040
-            },
-            {
-              "titel" : "Der Untergang der Liberty Bell",
-              "start" : 553040,
-              "end" : 915680
-            },
-            {
-              "titel" : "Erfolgreiche Recherche",
-              "start" : 915680,
-              "end" : 1283907
-            },
-            {
-              "titel" : "Folgenschwerer Anruf",
-              "start" : 1283907,
-              "end" : 1404987
-            },
-            {
-              "titel" : "Mysteriöses Testament",
-              "start" : 1404987,
-              "end" : 1795267
-            },
-            {
-              "titel" : "Held ohne Ehre",
-              "start" : 1795267,
-              "end" : 2091800
-            },
-            {
-              "titel" : "Beschattet",
-              "start" : 2091800,
-              "end" : 2317507
-            },
-            {
-              "titel" : "O'Malley's Rock",
-              "start" : 2317507,
-              "end" : 2563667
-            },
-            {
-              "titel" : "Der zweite Fall",
-              "start" : 2563667,
-              "end" : 2916627
-            },
-            {
-              "titel" : "Leviathan",
-              "start" : 2916627,
-              "end" : 3377427
-            },
-            {
-              "titel" : "Das Geisterhaus am Meer",
-              "start" : 3377427,
-              "end" : 3602520
-            },
-            {
-              "titel" : "Ein schreckliches Geheimnis",
-              "start" : 3602520,
-              "end" : 3767440
-            },
-            {
-              "titel" : "Jagd auf den Unbekannten",
-              "start" : 3767440,
-              "end" : 3918160
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/DiE_DR3i/1/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Feindbesuch",
-              "start" : 0,
-              "end" : 327707
-            },
-            {
-              "titel" : "Die Geliebte des Globetrotters",
-              "start" : 327707,
-              "end" : 575827
-            },
-            {
-              "titel" : "Apelles post tabulam",
-              "start" : 575827,
-              "end" : 784987
-            },
-            {
-              "titel" : "Monsterbesuche",
-              "start" : 784987,
-              "end" : 1390253
-            },
-            {
-              "titel" : "Einbruch in der Zentrale!",
-              "start" : 1390253,
-              "end" : 1611853
-            },
-            {
-              "titel" : "Der Mikrochip",
-              "start" : 1611853,
-              "end" : 2069920
-            },
-            {
-              "titel" : "Die Zeit läuft ab",
-              "start" : 2069920,
-              "end" : 2471813
-            },
-            {
-              "titel" : "Das Seeungeheuer",
-              "start" : 2471813,
-              "end" : 2652533
-            },
-            {
-              "titel" : "Versteck in den Felsen",
-              "start" : 2652533,
-              "end" : 2825280
-            },
-            {
-              "titel" : "Die Falle schnappt zu",
-              "start" : 2825280,
-              "end" : 3305600
-            },
-            {
-              "titel" : "Tödliche Fluten",
-              "start" : 3305600,
-              "end" : 3496547
-            },
-            {
-              "titel" : "Alle vereint",
-              "start" : 3496547,
-              "end" : 3907093
-            },
-            {
-              "titel" : "Das Rätsel aller Rätsel",
-              "start" : 3907093,
-              "end" : 4075613
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/DiE_DR3i/1/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "Das Seeungeheuer",
       "autor" : "Hendrik Buchna",
       "hörspielskriptautor" : "André Minninger",
@@ -706,6 +822,148 @@
           "sprecher" : "Lutz Schnell"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Phantom-Anwalt",
+              "start" : 0,
+              "end" : 553040
+            },
+            {
+              "titel" : "Der Untergang der Liberty Bell",
+              "start" : 553040,
+              "end" : 915680
+            },
+            {
+              "titel" : "Erfolgreiche Recherche",
+              "start" : 915680,
+              "end" : 1283907
+            },
+            {
+              "titel" : "Folgenschwerer Anruf",
+              "start" : 1283907,
+              "end" : 1404987
+            },
+            {
+              "titel" : "Mysteriöses Testament",
+              "start" : 1404987,
+              "end" : 1795267
+            },
+            {
+              "titel" : "Held ohne Ehre",
+              "start" : 1795267,
+              "end" : 2091800
+            },
+            {
+              "titel" : "Beschattet",
+              "start" : 2091800,
+              "end" : 2317507
+            },
+            {
+              "titel" : "O'Malley's Rock",
+              "start" : 2317507,
+              "end" : 2563667
+            },
+            {
+              "titel" : "Der zweite Fall",
+              "start" : 2563667,
+              "end" : 2916627
+            },
+            {
+              "titel" : "Leviathan",
+              "start" : 2916627,
+              "end" : 3377427
+            },
+            {
+              "titel" : "Das Geisterhaus am Meer",
+              "start" : 3377427,
+              "end" : 3602520
+            },
+            {
+              "titel" : "Ein schreckliches Geheimnis",
+              "start" : 3602520,
+              "end" : 3767440
+            },
+            {
+              "titel" : "Jagd auf den Unbekannten",
+              "start" : 3767440,
+              "end" : 3918160
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Feindbesuch",
+              "start" : 0,
+              "end" : 327707
+            },
+            {
+              "titel" : "Die Geliebte des Globetrotters",
+              "start" : 327707,
+              "end" : 575827
+            },
+            {
+              "titel" : "Apelles post tabulam",
+              "start" : 575827,
+              "end" : 784987
+            },
+            {
+              "titel" : "Monsterbesuche",
+              "start" : 784987,
+              "end" : 1390253
+            },
+            {
+              "titel" : "Einbruch in der Zentrale!",
+              "start" : 1390253,
+              "end" : 1611853
+            },
+            {
+              "titel" : "Der Mikrochip",
+              "start" : 1611853,
+              "end" : 2069920
+            },
+            {
+              "titel" : "Die Zeit läuft ab",
+              "start" : 2069920,
+              "end" : 2471813
+            },
+            {
+              "titel" : "Das Seeungeheuer",
+              "start" : 2471813,
+              "end" : 2652533
+            },
+            {
+              "titel" : "Versteck in den Felsen",
+              "start" : 2652533,
+              "end" : 2825280
+            },
+            {
+              "titel" : "Die Falle schnappt zu",
+              "start" : 2825280,
+              "end" : 3305600
+            },
+            {
+              "titel" : "Tödliche Fluten",
+              "start" : 3305600,
+              "end" : 3496547
+            },
+            {
+              "titel" : "Alle vereint",
+              "start" : 3496547,
+              "end" : 3907093
+            },
+            {
+              "titel" : "Das Rätsel aller Rätsel",
+              "start" : 3907093,
+              "end" : 4075613
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/1/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/1/ffmetadata.txt",
@@ -835,10 +1093,76 @@
           "sprecher" : "André Minninger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Aus den Träumen gerissen",
+              "start" : 0,
+              "end" : 186960
+            },
+            {
+              "titel" : "Vom Blitz getroffen!",
+              "start" : 186960,
+              "end" : 878600
+            },
+            {
+              "titel" : "Tödliche Bowle",
+              "start" : 878600,
+              "end" : 1274613
+            },
+            {
+              "titel" : "Unsichtbarer Mitbewohner",
+              "start" : 1274613,
+              "end" : 1803653
+            },
+            {
+              "titel" : "Spielverderber",
+              "start" : 1803653,
+              "end" : 2099720
+            },
+            {
+              "titel" : "Abgelehnt",
+              "start" : 2099720,
+              "end" : 2202013
+            },
+            {
+              "titel" : "Albtraum",
+              "start" : 2202013,
+              "end" : 2778973
+            },
+            {
+              "titel" : "Schlachtplan",
+              "start" : 2778973,
+              "end" : 2962547
+            },
+            {
+              "titel" : "Film ab!",
+              "start" : 2962547,
+              "end" : 3428947
+            },
+            {
+              "titel" : "Überreagiert",
+              "start" : 3428947,
+              "end" : 3740907
+            },
+            {
+              "titel" : "Erstens kommt es anders …",
+              "start" : 3740907,
+              "end" : 4502293
+            },
+            {
+              "titel" : "… und zweitens, als man denkt",
+              "start" : 4502293,
+              "end" : 4634013
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/2/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/2/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/2/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/2/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/DiE_DR3i/2/cover.png"
       }
     },
@@ -962,10 +1286,81 @@
           "sprecher" : "Patrick Bach"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Start in den Traumurlaub",
+              "start" : 0,
+              "end" : 219400
+            },
+            {
+              "titel" : "Unsanftes Erwachen",
+              "start" : 219400,
+              "end" : 731040
+            },
+            {
+              "titel" : "Notlandung im Nirgendwo",
+              "start" : 731040,
+              "end" : 940187
+            },
+            {
+              "titel" : "Das Bermuda-Dreieck",
+              "start" : 940187,
+              "end" : 1337333
+            },
+            {
+              "titel" : "Ein unheimliches Haus",
+              "start" : 1337333,
+              "end" : 1609173
+            },
+            {
+              "titel" : "Schockierende Erkenntnis",
+              "start" : 1609173,
+              "end" : 1922800
+            },
+            {
+              "titel" : "Verschollen in der Zeit",
+              "start" : 1922800,
+              "end" : 2104307
+            },
+            {
+              "titel" : "Flucht in den Dschungel",
+              "start" : 2104307,
+              "end" : 2338080
+            },
+            {
+              "titel" : "Die rätselhafte Uniform",
+              "start" : 2338080,
+              "end" : 2882627
+            },
+            {
+              "titel" : "Triumph der Logik",
+              "start" : 2882627,
+              "end" : 3025933
+            },
+            {
+              "titel" : "Der Hinterhalt",
+              "start" : 3025933,
+              "end" : 3369253
+            },
+            {
+              "titel" : "Die Maske fällt",
+              "start" : 3369253,
+              "end" : 3933893
+            },
+            {
+              "titel" : "Zurück in der Gegenwart",
+              "start" : 3933893,
+              "end" : 4113813
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/3/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/3/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/3/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/3/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/DiE_DR3i/3/cover.png"
       }
     },
@@ -973,7 +1368,7 @@
       "nummer" : 4,
       "titel" : "Zug um Zug",
       "autor" : "Tim Wenderoth",
-      "hörspielskriptautor" : "Tim Wenderoth, Yona Franke, Moritz von Fulmenstöcker",
+      "hörspielskriptautor" : "Moritz von Fulmenstöcker, Tim Wenderoth, Yona Franke",
       "beschreibung" : "Ein alter Zeitungsartikel weckt die Neugier des ersten Detektivs. Wo sind die $500.000 aus dem Überfall auf den Postzug geblieben? Was geschah wirklich vor 12 Jahren am alten Bahnhof von Rocky Beach? Was wusste die verstorbene Ellie Sparrow und inwieweit war die ehemalige Postangestellte in den Raubüberfall verwickelt? Ein leeres Blatt Papier und eine wirre Buchstabenkombination sind nur zwei der zahlreichen kleinen Puzzleteile, die zusammengefügt werden müssen. Als sich auch noch andere Gestalten für das verschollene Geld zu interessieren scheinen, wird es erst recht Zeit für Die Dr3i sich mit dem Fall zu beschäftigen.\nZug um Zug suchen sie nach den Antworten auf die vielen Fragen, die sich ihnen stellen …",
       "veröffentlichungsdatum" : "2006-11-24",
       "kapitel" : [
@@ -1092,10 +1487,71 @@
           "sprecher" : "Fabian Harloff"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der gelöste Kriminalfall",
+              "start" : 0,
+              "end" : 234067
+            },
+            {
+              "titel" : "Neue Spuren?",
+              "start" : 234067,
+              "end" : 693853
+            },
+            {
+              "titel" : "Besuch bei Mr. Walker",
+              "start" : 693853,
+              "end" : 1389773
+            },
+            {
+              "titel" : "Ein leeres Blatt Papier",
+              "start" : 1389773,
+              "end" : 1720627
+            },
+            {
+              "titel" : "Der alte Bahnhofsvorsteher",
+              "start" : 1720627,
+              "end" : 2434187
+            },
+            {
+              "titel" : "Unter den Gleisen",
+              "start" : 2434187,
+              "end" : 2824720
+            },
+            {
+              "titel" : "Der unbekannte Sohn",
+              "start" : 2824720,
+              "end" : 3283893
+            },
+            {
+              "titel" : "CC-DC-DC-OA 14, AAH-CI-CA-EC 23",
+              "start" : 3283893,
+              "end" : 3590640
+            },
+            {
+              "titel" : "Doc Brown",
+              "start" : 3590640,
+              "end" : 3972893
+            },
+            {
+              "titel" : "Lebenslänglich für drei Detektive",
+              "start" : 3972893,
+              "end" : 4297867
+            },
+            {
+              "titel" : "Jeden Tag eine gute Tat",
+              "start" : 4297867,
+              "end" : 4747133
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/4/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/4/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/4/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/4/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/DiE_DR3i/4/cover.png"
       }
     },
@@ -1205,10 +1661,71 @@
           "sprecher" : "Karl-Friedrich Gerster"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Star braucht Hilfe",
+              "start" : 0,
+              "end" : 232867
+            },
+            {
+              "titel" : "Gürtel, Karte, Taste",
+              "start" : 232867,
+              "end" : 601240
+            },
+            {
+              "titel" : "Die Fährte nach Marokko",
+              "start" : 601240,
+              "end" : 1232173
+            },
+            {
+              "titel" : "Eine legendäre Bar",
+              "start" : 1232173,
+              "end" : 1720267
+            },
+            {
+              "titel" : "Der rätselhafte Drink",
+              "start" : 1720267,
+              "end" : 2217320
+            },
+            {
+              "titel" : "Salon Moskva",
+              "start" : 2217320,
+              "end" : 2669573
+            },
+            {
+              "titel" : "Mademoiselle Nadine",
+              "start" : 2669573,
+              "end" : 3015507
+            },
+            {
+              "titel" : "Bobs Frisuren-Trauma",
+              "start" : 3015507,
+              "end" : 3338973
+            },
+            {
+              "titel" : "Smith & Wesson weisen den Weg",
+              "start" : 3338973,
+              "end" : 3587240
+            },
+            {
+              "titel" : "Showdown in der Finsternis",
+              "start" : 3587240,
+              "end" : 3871573
+            },
+            {
+              "titel" : "Lektion für den Meisterdetektiv",
+              "start" : 3871573,
+              "end" : 4409520
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/5/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/5/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/5/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/5/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/DiE_DR3i/5/cover.png"
       }
     },
@@ -1317,10 +1834,66 @@
           "sprecher" : "Dirk Bach"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Gewonnen!",
+              "start" : 0,
+              "end" : 231600
+            },
+            {
+              "titel" : "Attentat",
+              "start" : 231600,
+              "end" : 891573
+            },
+            {
+              "titel" : "Kreidebleich",
+              "start" : 891573,
+              "end" : 1035507
+            },
+            {
+              "titel" : "Spiegel der Seele",
+              "start" : 1035507,
+              "end" : 1561547
+            },
+            {
+              "titel" : "Attacke",
+              "start" : 1561547,
+              "end" : 1735040
+            },
+            {
+              "titel" : "Vollgas",
+              "start" : 1735040,
+              "end" : 2439600
+            },
+            {
+              "titel" : "Gage",
+              "start" : 2439600,
+              "end" : 2573720
+            },
+            {
+              "titel" : "Überwacht",
+              "start" : 2573720,
+              "end" : 2731053
+            },
+            {
+              "titel" : "Verhaftet",
+              "start" : 2731053,
+              "end" : 2941027
+            },
+            {
+              "titel" : "Endspiel",
+              "start" : 2941027,
+              "end" : 3924760
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/6/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/6/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/6/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/6/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/DiE_DR3i/6/cover.png"
       }
     },
@@ -1446,10 +2019,66 @@
           "sprecher" : "Tim Wenderoth"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Nebel",
+              "start" : 0,
+              "end" : 387347
+            },
+            {
+              "titel" : "Ashoona",
+              "start" : 387347,
+              "end" : 777520
+            },
+            {
+              "titel" : "Geisterstunde",
+              "start" : 777520,
+              "end" : 1259467
+            },
+            {
+              "titel" : "Erdbeben",
+              "start" : 1259467,
+              "end" : 1668467
+            },
+            {
+              "titel" : "Treffen im Wald",
+              "start" : 1668467,
+              "end" : 2098133
+            },
+            {
+              "titel" : "Fehlende Seiten",
+              "start" : 2098133,
+              "end" : 2703173
+            },
+            {
+              "titel" : "Im Filmstudio",
+              "start" : 2703173,
+              "end" : 3014480
+            },
+            {
+              "titel" : "Der Plan",
+              "start" : 3014480,
+              "end" : 3301640
+            },
+            {
+              "titel" : "Explosion",
+              "start" : 3301640,
+              "end" : 3724440
+            },
+            {
+              "titel" : "Ashoonas Schatz",
+              "start" : 3724440,
+              "end" : 3920920
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/7/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/7/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/7/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/7/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/DiE_DR3i/7/cover.png"
       }
     },
@@ -1564,10 +2193,56 @@
           "sprecher" : "Stephanie Damare"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Nächtliche Begegnung",
+              "start" : 0,
+              "end" : 415427
+            },
+            {
+              "titel" : "Ein Geist in der Zentrale",
+              "start" : 415427,
+              "end" : 997027
+            },
+            {
+              "titel" : "Gut versichert!",
+              "start" : 997027,
+              "end" : 1698120
+            },
+            {
+              "titel" : "Les Centuries",
+              "start" : 1698120,
+              "end" : 2367280
+            },
+            {
+              "titel" : "Dunkle Vorahnungen",
+              "start" : 2367280,
+              "end" : 2943987
+            },
+            {
+              "titel" : "Ausgetrickst",
+              "start" : 2943987,
+              "end" : 3620293
+            },
+            {
+              "titel" : "Erklärungen",
+              "start" : 3620293,
+              "end" : 4009120
+            },
+            {
+              "titel" : "Blick in die Zukunft",
+              "start" : 4009120,
+              "end" : 4627360
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/8/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/DiE_DR3i/8/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/DiE_DR3i/8/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/8/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/DiE_DR3i/8/cover.png"
       }
     }

--- a/metadata/json/Kurzgeschichten.json
+++ b/metadata/json/Kurzgeschichten.json
@@ -3,620 +3,536 @@
     {
       "teile" : [
         {
-          "teile" : [
-            {
-              "teilNummer" : 1,
-              "titel" : "und die Geisterlampe",
-              "autor" : "Kari Erlhoff",
-              "beschreibung" : "Mr. Vancura ist Schauspieler und sammelt alles, was mit dem Orient zu tun hat. Sein ganzer Stolz ist eine Wunderlampe, in der ein richtiger Dschinn lebt. Aber der Dschinn ist verschwunden …",
-              "veröffentlichungsdatum" : "2011-12-02",
-              "kapitel" : [
-                {
-                  "titel" : "und die Geisterlampe",
-                  "start" : 0,
-                  "end" : 1109933
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Mr. Vancura",
-                  "sprecher" : "Lutz Herkenrath"
-                },
-                {
-                  "rolle" : "Mrs. Fox",
-                  "sprecher" : "Susan Jarling"
-                },
-                {
-                  "rolle" : "Inspektor Cotta",
-                  "sprecher" : "Holger Mahlich"
-                },
-                {
-                  "rolle" : "Mr. Shaw",
-                  "sprecher" : "Rasmus Borowski"
-                },
-                {
-                  "rolle" : "Shannon",
-                  "sprecher" : "Kerstin Draeger"
-                },
-                {
-                  "rolle" : "Mr. Mosley",
-                  "sprecher" : "Neil Malik Abdullah"
-                },
-                {
-                  "rolle" : "Mann 1",
-                  "sprecher" : "Thor W. Müller"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/1/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/1/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 2,
-              "titel" : "Dunkle Vergangenheit",
-              "autor" : "Marco Sonnleitner",
-              "beschreibung" : "Das neuste Hobby von Justus Jonas ist die Ahnenforschung.\nUnd dabei macht er eines Tages eine unglaubliche Entdeckung …",
-              "veröffentlichungsdatum" : "2011-12-04",
-              "kapitel" : [
-                {
-                  "titel" : "Dunkle Vergangenheit",
-                  "start" : 0,
-                  "end" : 687480
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Cowboy",
-                  "sprecher" : "Achim Schülke"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/2/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/2/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 3,
-              "titel" : "Entführt",
-              "autor" : "Marco Sonnleitner",
-              "beschreibung" : "Peter erhält eine E-Mail: Kelly ist entführt worden! Den drei ??? bleibt weniger als eine Stunde Zeit, sie zu finden und zu befreien …",
-              "veröffentlichungsdatum" : "2011-12-06",
-              "kapitel" : [
-                {
-                  "titel" : "Entführt",
-                  "start" : 0,
-                  "end" : 852774
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Patricia",
-                  "sprecher" : "Rhea Harder-Vennewald"
-                },
-                {
-                  "rolle" : "Peter Shawn",
-                  "sprecher" : "Leonhard Mahlich"
-                },
-                {
-                  "rolle" : "Mann 2",
-                  "sprecher" : "Helgo Liebig"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/3/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/3/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 4,
-              "titel" : "Verschwörung auf der Eagle Ranch",
-              "autor" : "Hendrik Buchna",
-              "beschreibung" : "Auf dem Autorasthof \"Eagle Ranch\" geschehen merkwürdige Dinge und die drei ??? erhalten den Auftrag, herauszufinden, was es damit auf sich hat …",
-              "veröffentlichungsdatum" : "2011-12-08",
-              "kapitel" : [
-                {
-                  "titel" : "Verschwörung auf der Eagle Ranch",
-                  "start" : 0,
-                  "end" : 1367653
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/4/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/4/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 1,
-          "buchstabe" : "A",
+          "titel" : "und die Geisterlampe",
+          "autor" : "Kari Erlhoff",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Mr. Vancura ist Schauspieler und sammelt alles, was mit dem Orient zu tun hat. Sein ganzer Stolz ist eine Wunderlampe, in der ein richtiger Dschinn lebt. Aber der Dschinn ist verschwunden …",
+          "veröffentlichungsdatum" : "2011-12-02",
           "kapitel" : [
             {
               "titel" : "und die Geisterlampe",
               "start" : 0,
               "end" : 1109933
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
             },
             {
-              "titel" : "Dunkle Vergangenheit",
-              "start" : 1109933,
-              "end" : 1797413
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Entführt",
-              "start" : 1797413,
-              "end" : 2650187
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Verschwörung auf der Eagle Ranch",
-              "start" : 2650187,
-              "end" : 4017840
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mr. Vancura",
+              "sprecher" : "Lutz Herkenrath"
+            },
+            {
+              "rolle" : "Mrs. Fox",
+              "sprecher" : "Susan Jarling"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Mr. Shaw",
+              "sprecher" : "Rasmus Borowski"
+            },
+            {
+              "rolle" : "Shannon",
+              "sprecher" : "Kerstin Draeger"
+            },
+            {
+              "rolle" : "Mr. Mosley",
+              "sprecher" : "Neil Malik Abdullah"
+            },
+            {
+              "rolle" : "Mann 1",
+              "sprecher" : "Thor W. Müller"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/1/ffmetadata.txt"
           }
         },
         {
-          "teile" : [
+          "teilNummer" : 2,
+          "titel" : "Dunkle Vergangenheit",
+          "autor" : "Marco Sonnleitner",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Das neuste Hobby von Justus Jonas ist die Ahnenforschung.\nUnd dabei macht er eines Tages eine unglaubliche Entdeckung …",
+          "veröffentlichungsdatum" : "2011-12-04",
+          "kapitel" : [
             {
-              "teilNummer" : 5,
-              "titel" : "SOS",
-              "autor" : "Marco Sonnleitner",
-              "beschreibung" : "Als die drei ??? vom Strand kommen und auf dem Weg nach Hause sind, sehen sie ein SOS-Signal, das aus einem Haus gesendet wird. Eigentlich steht das Haus doch leer …",
-              "veröffentlichungsdatum" : "2011-12-10",
-              "kapitel" : [
-                {
-                  "titel" : "SOS",
-                  "start" : 0,
-                  "end" : 661640
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Marty",
-                  "sprecher" : "Philipp Draeger"
-                },
-                {
-                  "rolle" : "Fred",
-                  "sprecher" : "Guido Bernadotte"
-                },
-                {
-                  "rolle" : "Mann 3",
-                  "sprecher" : "Rasmus Rakete"
-                },
-                {
-                  "rolle" : "Mann 4",
-                  "sprecher" : "Patrick Perales"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/5/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/5/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 6,
-              "titel" : "Der graue Dämon",
-              "autor" : "Hendrik Buchna",
-              "beschreibung" : "Auf dem Weg nach Hause wird Peter plötzlich von einem unheimlichen, grauen Dämon verfolgt. Ihm bleibt nur noch ein Ausweg: die Flucht …",
-              "veröffentlichungsdatum" : "2011-12-12",
-              "kapitel" : [
-                {
-                  "titel" : "Der graue Dämon",
-                  "start" : 0,
-                  "end" : 556307
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/6/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/6/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 7,
-              "titel" : "Das Lehrstück",
-              "autor" : "Kari Erlhoff",
-              "beschreibung" : "Peters ehemalige Klavierlehrerin, Mrs. Floyd, engagiert die drei ???, um herauszufinden, wo ihre verstorbene Mutter ihr Erbe versteckt haben könnte …",
-              "veröffentlichungsdatum" : "2011-12-14",
-              "kapitel" : [
-                {
-                  "titel" : "Das Lehrstück",
-                  "start" : 0,
-                  "end" : 749413
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Mrs. Floyd",
-                  "sprecher" : "Gabriele Libbach"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/7/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/7/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 8,
-              "titel" : "Das Rätsel der schwarzen Nadel",
-              "autor" : "Hendrik Buchna",
-              "beschreibung" : "Die drei ??? erhalten den Auftrag, bei der Übergabe einer schwarzen Nadel dabei zu sein. Aber geht es dabei wirklich nur um das Schmuckstück?",
-              "veröffentlichungsdatum" : "2011-12-16",
-              "kapitel" : [
-                {
-                  "titel" : "Das Rätsel der schwarzen Nadel",
-                  "start" : 0,
-                  "end" : 711680
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Tante Mathilda",
-                  "sprecher" : "Karin Lieneweg"
-                },
-                {
-                  "rolle" : "Vincent Grimes",
-                  "sprecher" : "Konstantin Graudus"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/8/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/8/ffmetadata.txt"
-              }
+              "titel" : "Dunkle Vergangenheit",
+              "start" : 0,
+              "end" : 687480
             }
           ],
-          "teilNummer" : 2,
-          "buchstabe" : "B",
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Cowboy",
+              "sprecher" : "Achim Schülke"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 3,
+          "titel" : "Entführt",
+          "autor" : "Marco Sonnleitner",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Peter erhält eine E-Mail: Kelly ist entführt worden! Den drei ??? bleibt weniger als eine Stunde Zeit, sie zu finden und zu befreien …",
+          "veröffentlichungsdatum" : "2011-12-06",
+          "kapitel" : [
+            {
+              "titel" : "Entführt",
+              "start" : 0,
+              "end" : 852774
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Patricia",
+              "sprecher" : "Rhea Harder-Vennewald"
+            },
+            {
+              "rolle" : "Peter Shawn",
+              "sprecher" : "Leonhard Mahlich"
+            },
+            {
+              "rolle" : "Mann 2",
+              "sprecher" : "Helgo Liebig"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 4,
+          "titel" : "Verschwörung auf der Eagle Ranch",
+          "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Auf dem Autorasthof \"Eagle Ranch\" geschehen merkwürdige Dinge und die drei ??? erhalten den Auftrag, herauszufinden, was es damit auf sich hat …",
+          "veröffentlichungsdatum" : "2011-12-08",
+          "kapitel" : [
+            {
+              "titel" : "Verschwörung auf der Eagle Ranch",
+              "start" : 0,
+              "end" : 1367653
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/4/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/4/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 5,
+          "titel" : "SOS",
+          "autor" : "Marco Sonnleitner",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Als die drei ??? vom Strand kommen und auf dem Weg nach Hause sind, sehen sie ein SOS-Signal, das aus einem Haus gesendet wird. Eigentlich steht das Haus doch leer …",
+          "veröffentlichungsdatum" : "2011-12-10",
           "kapitel" : [
             {
               "titel" : "SOS",
               "start" : 0,
               "end" : 661640
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
             },
             {
-              "titel" : "Der graue Dämon",
-              "start" : 661640,
-              "end" : 1217947
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Das Lehrstück",
-              "start" : 1217947,
-              "end" : 1967360
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Das Rätsel der schwarzen Nadel",
-              "start" : 1967360,
-              "end" : 2679040
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Marty",
+              "sprecher" : "Philipp Draeger"
+            },
+            {
+              "rolle" : "Fred",
+              "sprecher" : "Guido Bernadotte"
+            },
+            {
+              "rolle" : "Mann 3",
+              "sprecher" : "Rasmus Rakete"
+            },
+            {
+              "rolle" : "Mann 4",
+              "sprecher" : "Patrick Perales"
             }
           ],
           "links" : {
-            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/2/rip_log.txt"
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/5/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/5/ffmetadata.txt"
           }
         },
         {
-          "teile" : [
+          "teilNummer" : 6,
+          "titel" : "Der graue Dämon",
+          "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Auf dem Weg nach Hause wird Peter plötzlich von einem unheimlichen, grauen Dämon verfolgt. Ihm bleibt nur noch ein Ausweg: die Flucht …",
+          "veröffentlichungsdatum" : "2011-12-12",
+          "kapitel" : [
             {
-              "teilNummer" : 9,
-              "titel" : "Der verschwundene Superstar",
-              "autor" : "Kari Erlhoff",
-              "beschreibung" : "Blacky, der Papagei der drei ???, benimmt sich seit ein paar Tagen höchst sonderbar.\nWas ist der Grund für die merkwürdigen Sprüche, die der Vogel plötzlich zitiert …",
-              "veröffentlichungsdatum" : "2011-12-18",
-              "kapitel" : [
-                {
-                  "titel" : "Der verschwundene Superstar",
-                  "start" : 0,
-                  "end" : 1055280
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Tante Mathilda",
-                  "sprecher" : "Karin Lieneweg"
-                },
-                {
-                  "rolle" : "Blacky",
-                  "sprecher" : "Heikedine Körting"
-                },
-                {
-                  "rolle" : "Juliet",
-                  "sprecher" : "Anne Moll"
-                },
-                {
-                  "rolle" : "Scott",
-                  "sprecher" : "Tommaso Cacciapuoti"
-                },
-                {
-                  "rolle" : "John",
-                  "sprecher" : "Sascha Draeger",
-                  "pseudonym" : "Martin Sichel"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/9/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/9/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 10,
-              "titel" : "Manches verlernt man nie",
-              "autor" : "Marco Sonnleitner",
-              "beschreibung" : "Die drei ??? sollen von der Stadt Rocky Beach für ihr Lebenswerk geehrt werden. Und prompt sitzen sie gleich wieder mitten in einem neuen Fall …",
-              "veröffentlichungsdatum" : "2011-12-20",
-              "kapitel" : [
-                {
-                  "titel" : "Manches verlernt man nie",
-                  "start" : 0,
-                  "end" : 955600
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/10/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/10/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 11,
-              "titel" : "Psychomoon",
-              "autor" : "Kari Erlhoff",
-              "beschreibung" : "Kellys Tante wird erpresst und die drei ??? sollen bei der Übergabe des Geldes behilflich sein. Aber in dem Motel, in dem Peter und Kelly absteigen, passieren merkwürdige Dinge …",
-              "veröffentlichungsdatum" : "2011-12-22",
-              "kapitel" : [
-                {
-                  "titel" : "Psychomoon",
-                  "start" : 0,
-                  "end" : 670160
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Kelly",
-                  "sprecher" : "Juliane Szalay"
-                },
-                {
-                  "rolle" : "Norman",
-                  "sprecher" : "Eckart Dux"
-                },
-                {
-                  "rolle" : "Frau",
-                  "sprecher" : "Anja Topf"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/11/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/11/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 12,
-              "titel" : "Jagd auf den Weihnachtsmann",
-              "autor" : "Hendrik Buchna",
-              "beschreibung" : "Rocky Beach versinkt im Schnee. Und zu allem Überfluss treibt gerade jetzt, wo die Polizei mehr oder weniger handlungsunfähig ist, ein krimineller Weihnachtsmann in der Stadt sein Unwesen …",
-              "veröffentlichungsdatum" : "2011-12-24",
-              "kapitel" : [
-                {
-                  "titel" : "Jagd auf den Weihnachtsmann",
-                  "start" : 0,
-                  "end" : 921440
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Inspektor Cotta",
-                  "sprecher" : "Holger Mahlich"
-                },
-                {
-                  "rolle" : "Mr. Darrow",
-                  "sprecher" : "Joachim Kappl"
-                },
-                {
-                  "rolle" : "Mann 5",
-                  "sprecher" : "Patrick Bach"
-                },
-                {
-                  "rolle" : "Mann 6",
-                  "sprecher" : "Frank Meyer-Brockmann"
-                },
-                {
-                  "rolle" : "Mann 7",
-                  "sprecher" : "Roy Martens"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/12/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/12/ffmetadata.txt"
-              }
+              "titel" : "Der graue Dämon",
+              "start" : 0,
+              "end" : 556307
             }
           ],
-          "teilNummer" : 3,
-          "buchstabe" : "C",
+          "sprechrollen" : [
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/6/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/6/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 7,
+          "titel" : "Das Lehrstück",
+          "autor" : "Kari Erlhoff",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Peters ehemalige Klavierlehrerin, Mrs. Floyd, engagiert die drei ???, um herauszufinden, wo ihre verstorbene Mutter ihr Erbe versteckt haben könnte …",
+          "veröffentlichungsdatum" : "2011-12-14",
+          "kapitel" : [
+            {
+              "titel" : "Das Lehrstück",
+              "start" : 0,
+              "end" : 749413
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mrs. Floyd",
+              "sprecher" : "Gabriele Libbach"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/7/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/7/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 8,
+          "titel" : "Das Rätsel der schwarzen Nadel",
+          "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Die drei ??? erhalten den Auftrag, bei der Übergabe einer schwarzen Nadel dabei zu sein. Aber geht es dabei wirklich nur um das Schmuckstück?",
+          "veröffentlichungsdatum" : "2011-12-16",
+          "kapitel" : [
+            {
+              "titel" : "Das Rätsel der schwarzen Nadel",
+              "start" : 0,
+              "end" : 711680
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Vincent Grimes",
+              "sprecher" : "Konstantin Graudus"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/8/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/8/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 9,
+          "titel" : "Der verschwundene Superstar",
+          "autor" : "Kari Erlhoff",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Blacky, der Papagei der drei ???, benimmt sich seit ein paar Tagen höchst sonderbar.\nWas ist der Grund für die merkwürdigen Sprüche, die der Vogel plötzlich zitiert …",
+          "veröffentlichungsdatum" : "2011-12-18",
           "kapitel" : [
             {
               "titel" : "Der verschwundene Superstar",
               "start" : 0,
               "end" : 1055280
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
             },
             {
-              "titel" : "Manches verlernt man nie",
-              "start" : 1055280,
-              "end" : 2010880
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Psychomoon",
-              "start" : 2010880,
-              "end" : 2681040
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Jagd auf den Weihnachtsmann",
-              "start" : 2681040,
-              "end" : 3602480
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Blacky",
+              "sprecher" : "Heikedine Körting"
+            },
+            {
+              "rolle" : "Juliet",
+              "sprecher" : "Anne Moll"
+            },
+            {
+              "rolle" : "Scott",
+              "sprecher" : "Tommaso Cacciapuoti"
+            },
+            {
+              "rolle" : "John",
+              "sprecher" : "Sascha Draeger",
+              "pseudonym" : "Martin Sichel"
             }
           ],
           "links" : {
-            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/3/rip_log.txt"
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/9/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/9/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 10,
+          "titel" : "Manches verlernt man nie",
+          "autor" : "Marco Sonnleitner",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Die drei ??? sollen von der Stadt Rocky Beach für ihr Lebenswerk geehrt werden. Und prompt sitzen sie gleich wieder mitten in einem neuen Fall …",
+          "veröffentlichungsdatum" : "2011-12-20",
+          "kapitel" : [
+            {
+              "titel" : "Manches verlernt man nie",
+              "start" : 0,
+              "end" : 955600
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/10/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/10/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 11,
+          "titel" : "Psychomoon",
+          "autor" : "Kari Erlhoff",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Kellys Tante wird erpresst und die drei ??? sollen bei der Übergabe des Geldes behilflich sein. Aber in dem Motel, in dem Peter und Kelly absteigen, passieren merkwürdige Dinge …",
+          "veröffentlichungsdatum" : "2011-12-22",
+          "kapitel" : [
+            {
+              "titel" : "Psychomoon",
+              "start" : 0,
+              "end" : 670160
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Kelly",
+              "sprecher" : "Juliane Szalay"
+            },
+            {
+              "rolle" : "Norman",
+              "sprecher" : "Eckart Dux"
+            },
+            {
+              "rolle" : "Frau",
+              "sprecher" : "Anja Topf"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/11/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/11/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 12,
+          "titel" : "Jagd auf den Weihnachtsmann",
+          "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Rocky Beach versinkt im Schnee. Und zu allem Überfluss treibt gerade jetzt, wo die Polizei mehr oder weniger handlungsunfähig ist, ein krimineller Weihnachtsmann in der Stadt sein Unwesen …",
+          "veröffentlichungsdatum" : "2011-12-24",
+          "kapitel" : [
+            {
+              "titel" : "Jagd auf den Weihnachtsmann",
+              "start" : 0,
+              "end" : 921440
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            },
+            {
+              "rolle" : "Mr. Darrow",
+              "sprecher" : "Joachim Kappl"
+            },
+            {
+              "rolle" : "Mann 5",
+              "sprecher" : "Patrick Bach"
+            },
+            {
+              "rolle" : "Mann 6",
+              "sprecher" : "Frank Meyer-Brockmann"
+            },
+            {
+              "rolle" : "Mann 7",
+              "sprecher" : "Roy Martens"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/12/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/12/ffmetadata.txt"
           }
         }
       ],
@@ -759,6 +675,83 @@
           "sprecher" : "Roy Martens"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "und die Geisterlampe",
+              "start" : 0,
+              "end" : 1109933
+            },
+            {
+              "titel" : "Dunkle Vergangenheit",
+              "start" : 1109933,
+              "end" : 1797413
+            },
+            {
+              "titel" : "Entführt",
+              "start" : 1797413,
+              "end" : 2650187
+            },
+            {
+              "titel" : "Verschwörung auf der Eagle Ranch",
+              "start" : 2650187,
+              "end" : 4017840
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "SOS",
+              "start" : 0,
+              "end" : 661640
+            },
+            {
+              "titel" : "Der graue Dämon",
+              "start" : 661640,
+              "end" : 1217947
+            },
+            {
+              "titel" : "Das Lehrstück",
+              "start" : 1217947,
+              "end" : 1967360
+            },
+            {
+              "titel" : "Das Rätsel der schwarzen Nadel",
+              "start" : 1967360,
+              "end" : 2679040
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Der verschwundene Superstar",
+              "start" : 0,
+              "end" : 1055280
+            },
+            {
+              "titel" : "Manches verlernt man nie",
+              "start" : 1055280,
+              "end" : 2010880
+            },
+            {
+              "titel" : "Psychomoon",
+              "start" : 2010880,
+              "end" : 2681040
+            },
+            {
+              "titel" : "Jagd auf den Weihnachtsmann",
+              "start" : 2681040,
+              "end" : 3602480
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/metadata.json",
         "cover" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/cover.png"
@@ -767,590 +760,466 @@
     {
       "teile" : [
         {
-          "teile" : [
-            {
-              "teilNummer" : 1,
-              "titel" : "Der siebte Gast",
-              "autor" : "André Minninger",
-              "beschreibung" : "Mrs. Emily White spürt instinktiv, dass an dem Schreiben von ihrer Freundin Judy Fradkin etwas faul ist. Warum wurde die alte Dame von dem Jahrestreffen der Märchenfiguren so urplötzlich ausgeladen? Um der Sache auf den Grund zu gehen, holt sich Mrs White die Unterstützung der drei ???.",
-              "kapitel" : [
-                {
-                  "titel" : "Inszenierung neuer Geschichten",
-                  "start" : 0,
-                  "end" : 439267
-                },
-                {
-                  "titel" : "Die Worte einer Lügenhexe",
-                  "start" : 439267,
-                  "end" : 774387
-                },
-                {
-                  "titel" : "Prinzessin in Champagnerlaune",
-                  "start" : 774387,
-                  "end" : 1596747
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Emily White",
-                  "sprecher" : "Sabine Hahn"
-                },
-                {
-                  "rolle" : "Judy Fradkin",
-                  "sprecher" : "Ursula Heyer"
-                },
-                {
-                  "rolle" : "Aladin",
-                  "sprecher" : "Heidi Schaffrath"
-                },
-                {
-                  "rolle" : "Aschenputtel",
-                  "sprecher" : "Regina Lemnitz"
-                },
-                {
-                  "rolle" : "Prinzessin",
-                  "sprecher" : "Renate Pichler"
-                },
-                {
-                  "rolle" : "Rotkäppchen",
-                  "sprecher" : "Angela Stresemann"
-                },
-                {
-                  "rolle" : "Meerjungfrau",
-                  "sprecher" : "Heikedine Körting",
-                  "pseudonym" : "Pamela Punti"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/1/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 2,
-              "titel" : "Bis um sieben zurück",
-              "autor" : "Kari Erlhoff",
-              "beschreibung" : "Bob Andrews rutscht auf dem glitschigen Boden des Schuppens aus und wird ohnmächtig. Als er kurze Zeit später erwacht, scheinen einige Dinge plötzlich recht merkwürdig zu sein … Doch nicht nur für ihn; denn auch seine Eltern scheinen ihn kaum wiederzuerkennen und machen sich die größten Sorgen um ihren Sohn. In ihrer Angst ziehen sie einen Arzt hinzu …",
-              "kapitel" : [
-                {
-                  "titel" : "Kopfschmerzen",
-                  "start" : 0,
-                  "end" : 694933
-                },
-                {
-                  "titel" : "Erwischt!",
-                  "start" : 694933,
-                  "end" : 1199813
-                },
-                {
-                  "titel" : "Bobby",
-                  "start" : 1199813,
-                  "end" : 1477173
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Mr. Andrews",
-                  "sprecher" : "Henry König"
-                },
-                {
-                  "rolle" : "Mrs. Andrews",
-                  "sprecher" : "Konstanze Ullmer"
-                },
-                {
-                  "rolle" : "Arzt",
-                  "sprecher" : "Erik Schäffler"
-                },
-                {
-                  "rolle" : "Mrs. Wallace",
-                  "sprecher" : "Angela Stresemann"
-                },
-                {
-                  "rolle" : "Bobby",
-                  "sprecher" : "Merete Brettschneider"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/2/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 1,
+          "titel" : "Der siebte Gast",
+          "autor" : "André Minninger",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Mrs. Emily White spürt instinktiv, dass an dem Schreiben von ihrer Freundin Judy Fradkin etwas faul ist. Warum wurde die alte Dame von dem Jahrestreffen der Märchenfiguren so urplötzlich ausgeladen? Um der Sache auf den Grund zu gehen, holt sich Mrs White die Unterstützung der drei ???.",
+          "veröffentlichungsdatum" : "2014-02-21",
           "kapitel" : [
             {
-              "titel" : "Der siebte Gast – Inszenierung neuer Geschichten",
+              "titel" : "Inszenierung neuer Geschichten",
               "start" : 0,
               "end" : 439267
             },
             {
-              "titel" : "Der siebte Gast – Die Worte einer Lügenhexe",
+              "titel" : "Die Worte einer Lügenhexe",
               "start" : 439267,
               "end" : 774387
             },
             {
-              "titel" : "Der siebte Gast – Prinzessin in Champagnerlaune",
+              "titel" : "Prinzessin in Champagnerlaune",
               "start" : 774387,
               "end" : 1596747
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
             },
             {
-              "titel" : "Bis um sieben zurück – Kopfschmerzen",
-              "start" : 1596747,
-              "end" : 2291680
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Bis um sieben zurück – Erwischt!",
-              "start" : 2291680,
-              "end" : 2796560
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Bis um sieben zurück – Bobby",
-              "start" : 2796560,
-              "end" : 3073920
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Emily White",
+              "sprecher" : "Sabine Hahn"
+            },
+            {
+              "rolle" : "Judy Fradkin",
+              "sprecher" : "Ursula Heyer"
+            },
+            {
+              "rolle" : "Aladin",
+              "sprecher" : "Heidi Schaffrath"
+            },
+            {
+              "rolle" : "Aschenputtel",
+              "sprecher" : "Regina Lemnitz"
+            },
+            {
+              "rolle" : "Prinzessin",
+              "sprecher" : "Renate Pichler"
+            },
+            {
+              "rolle" : "Rotkäppchen",
+              "sprecher" : "Angela Stresemann"
+            },
+            {
+              "rolle" : "Meerjungfrau",
+              "sprecher" : "Heikedine Körting",
+              "pseudonym" : "Pamela Punti"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/1/ffmetadata.txt"
           }
         },
         {
-          "teile" : [
-            {
-              "teilNummer" : 3,
-              "titel" : "Bobs schwerste Stunde",
-              "autor" : "Hendrik Buchna",
-              "beschreibung" : "Bob weicht jede Farbe aus dem Gesicht. Wie vom Blitz getroffen steht er vor dem geöffneten Aktenschrank und lässt seinen Blick über die leeren Regale schweifen. Einbrecher haben das gesamte Fall-Archiv der drei Detektive gestohlen! Die Sammlung scheint für immer verloren zu sein. Doch dann entdeckt Justus einen Zettel mit einer merkwürdigen Botschaft …",
-              "kapitel" : [
-                {
-                  "titel" : "Alles weg!",
-                  "start" : 0,
-                  "end" : 433867
-                },
-                {
-                  "titel" : "Gruselstimme",
-                  "start" : 433867,
-                  "end" : 973600
-                },
-                {
-                  "titel" : "Aufwendiges Vorhaben",
-                  "start" : 973600,
-                  "end" : 1574187
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Tante Mathilda",
-                  "sprecher" : "Karin Lieneweg"
-                },
-                {
-                  "rolle" : "Onkel Titus",
-                  "sprecher" : "Andreas E. Beurmann",
-                  "pseudonym" : "Hans Meinhardt"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/3/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 4,
-              "titel" : "Die rote Sieben",
-              "autor" : "Marco Sonnleitner",
-              "beschreibung" : "\"Ihre Einsätze bitte!\" Während der Croupier im Casino des Luxusdampfers die Kugel in der Roulette-Schüssel kreisen lässt, wird in Kabine 347 ein Passagier niedergeschlagen und ausgeraubt! Ein Fall für die drei Detektive, die auf dem Schiff gerade als Aushilfskellner arbeiten …",
-              "kapitel" : [
-                {
-                  "titel" : "Rien ne va plus",
-                  "start" : 0,
-                  "end" : 295293
-                },
-                {
-                  "titel" : "Blutspuren",
-                  "start" : 295293,
-                  "end" : 729440
-                },
-                {
-                  "titel" : "Abgekartetes Spiel",
-                  "start" : 729440,
-                  "end" : 1174080
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Croupier",
-                  "sprecher" : "Gosta Liptow"
-                },
-                {
-                  "rolle" : "Carl Hopkins, Physiker",
-                  "sprecher" : "Ben Hecker"
-                },
-                {
-                  "rolle" : "Miller, Schiffsdetektiv",
-                  "sprecher" : "Michael Grimm"
-                },
-                {
-                  "rolle" : "Kapitän Sherwood",
-                  "sprecher" : "Horst Naumann"
-                },
-                {
-                  "rolle" : "Theodore Quaid",
-                  "sprecher" : "Dietrich Adam"
-                },
-                {
-                  "rolle" : "Jamie Peterson, Barmann",
-                  "sprecher" : "Patrick Bach"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/4/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 2,
+          "titel" : "Bis um sieben zurück",
+          "autor" : "Kari Erlhoff",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Bob Andrews rutscht auf dem glitschigen Boden des Schuppens aus und wird ohnmächtig. Als er kurze Zeit später erwacht, scheinen einige Dinge plötzlich recht merkwürdig zu sein … Doch nicht nur für ihn; denn auch seine Eltern scheinen ihn kaum wiederzuerkennen und machen sich die größten Sorgen um ihren Sohn. In ihrer Angst ziehen sie einen Arzt hinzu …",
+          "veröffentlichungsdatum" : "2014-02-21",
           "kapitel" : [
             {
-              "titel" : "Bobs schwerste Stunde – Alles weg!",
+              "titel" : "Kopfschmerzen",
               "start" : 0,
-              "end" : 433867
+              "end" : 694933
             },
             {
-              "titel" : "Bobs schwerste Stunde – Gruselstimme",
-              "start" : 433867,
-              "end" : 973600
+              "titel" : "Erwischt!",
+              "start" : 694933,
+              "end" : 1199813
             },
             {
-              "titel" : "Bobs schwerste Stunde – Aufwendiges Vorhaben",
-              "start" : 973600,
-              "end" : 1574187
+              "titel" : "Bobby",
+              "start" : 1199813,
+              "end" : 1477173
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
             },
             {
-              "titel" : "Die rote Sieben – Rien ne va plus",
-              "start" : 1574187,
-              "end" : 1869480
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Die rote Sieben – Blutspuren",
-              "start" : 1869480,
-              "end" : 2303627
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Die rote Sieben – Abgekartetes Spiel",
-              "start" : 2303627,
-              "end" : 2748267
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mr. Andrews",
+              "sprecher" : "Henry König"
+            },
+            {
+              "rolle" : "Mrs. Andrews",
+              "sprecher" : "Konstanze Ullmer"
+            },
+            {
+              "rolle" : "Arzt",
+              "sprecher" : "Erik Schäffler"
+            },
+            {
+              "rolle" : "Mrs. Wallace",
+              "sprecher" : "Angela Stresemann"
+            },
+            {
+              "rolle" : "Bobby",
+              "sprecher" : "Merete Brettschneider"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/2/ffmetadata.txt"
           }
         },
         {
-          "teile" : [
-            {
-              "teilNummer" : 5,
-              "titel" : "Schutzgeld",
-              "autor" : "Ben Nevis",
-              "beschreibung" : "Wer ist die seltsame Dame, die so auffällig unauffällig durch die Einkaufsstraße schleicht, und sich dabei immer wieder ängstlich umsieht? Als sich die drei Detektive an ihre Fersen heften und die Verdächtige demaskieren, erleben sie eine große Überraschung. Doch jetzt fangen die Schwierigkeiten erst an …",
-              "kapitel" : [
-                {
-                  "titel" : "Überraschung!",
-                  "start" : 0,
-                  "end" : 277693
-                },
-                {
-                  "titel" : "Arges Misstrauen",
-                  "start" : 277693,
-                  "end" : 941400
-                },
-                {
-                  "titel" : "Sieben harte Stunden",
-                  "start" : 941400,
-                  "end" : 1389800
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Onkel Titus",
-                  "sprecher" : "Andreas E. Beurmann",
-                  "pseudonym" : "Hans Meinhardt"
-                },
-                {
-                  "rolle" : "Tante Mathilda",
-                  "sprecher" : "Karin Lieneweg"
-                },
-                {
-                  "rolle" : "Handerson",
-                  "sprecher" : "Wolfgang Rositzka"
-                },
-                {
-                  "rolle" : "Diego",
-                  "sprecher" : "Stephan Benson"
-                },
-                {
-                  "rolle" : "Mercedes",
-                  "sprecher" : "Hella von der Osten-Sacken",
-                  "pseudonym" : "Wanda Osten"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/5/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 6,
-              "titel" : "Die siebte Frau des Leuchters",
-              "autor" : "Christoph Dittert",
-              "beschreibung" : "\"Mein Name ist Nayeli. Und ich bin ein Dieb!\" Der junge Mann, der bei den drei Detektiven auf dem Schrottplatz auftaucht, zieht einen antiken Kerzenhalter aus seinem Rucksack und erzählt dazu eine seltsame Geschichte. Doch wer ist der Fremde, der urplötzlich auftaucht und Nayeli dann in die Flucht schlägt? Unversehens geraten Justus, Bob und Peter in große Gefahr …",
-              "kapitel" : [
-                {
-                  "titel" : "Böse Macht im Grab",
-                  "start" : 0,
-                  "end" : 285107
-                },
-                {
-                  "titel" : "Auf dem Geisterschiff",
-                  "start" : 285107,
-                  "end" : 629667
-                },
-                {
-                  "titel" : "Freier Wille",
-                  "start" : 629667,
-                  "end" : 1409027
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Nayeli",
-                  "sprecher" : "Stefan Brönneke"
-                },
-                {
-                  "rolle" : "Barker",
-                  "sprecher" : "Ben Hecker"
-                },
-                {
-                  "rolle" : "Onkel Titus",
-                  "sprecher" : "Andreas E. Beurmann",
-                  "pseudonym" : "Hans Meinhardt"
-                },
-                {
-                  "rolle" : "Off-Sprecherin",
-                  "sprecher" : "Claudia Stocksieker"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/6/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 7,
-              "titel" : "Die verschwundene Torte",
-              "autor" : "André Marx",
-              "beschreibung" : "An Justus' Geburtstag muss der Erste Detektiv eine schwere Niederlage einstecken: Ausgerechnet seine Geburtstagstorte wurde über Nacht aus der Freiluftwerkstatt gestohlen! Doch wer kommt als Täter in Frage? Mit Hilfe einer Überwachungskamera sollte der Dieb doch zu identifizieren sein – oder etwa nicht?",
-              "kapitel" : [
-                {
-                  "titel" : "In Angst und Schrecken",
-                  "start" : 0,
-                  "end" : 367840
-                },
-                {
-                  "titel" : "Gescanntes Areal",
-                  "start" : 367840,
-                  "end" : 528413
-                },
-                {
-                  "titel" : "Des Rätsels Lösung",
-                  "start" : 528413,
-                  "end" : 1099640
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Tante Mathilda",
-                  "sprecher" : "Karin Lieneweg"
-                },
-                {
-                  "rolle" : "Onkel Titus",
-                  "sprecher" : "Andreas E. Beurmann",
-                  "pseudonym" : "Hans Meinhardt"
-                },
-                {
-                  "rolle" : "Ian Carew",
-                  "sprecher" : "Sascha Draeger"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/7/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 3,
+          "titel" : "Bobs schwerste Stunde",
+          "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Bob weicht jede Farbe aus dem Gesicht. Wie vom Blitz getroffen steht er vor dem geöffneten Aktenschrank und lässt seinen Blick über die leeren Regale schweifen. Einbrecher haben das gesamte Fall-Archiv der drei Detektive gestohlen! Die Sammlung scheint für immer verloren zu sein. Doch dann entdeckt Justus einen Zettel mit einer merkwürdigen Botschaft …",
+          "veröffentlichungsdatum" : "2014-02-21",
           "kapitel" : [
             {
-              "titel" : "Schutzgeld – Überraschung!",
+              "titel" : "Alles weg!",
               "start" : 0,
-              "end" : 277693
+              "end" : 433867
             },
             {
-              "titel" : "Schutzgeld – Arges Misstrauen",
-              "start" : 277693,
-              "end" : 941400
+              "titel" : "Gruselstimme",
+              "start" : 433867,
+              "end" : 973600
             },
             {
-              "titel" : "Schutzgeld – Sieben harte Stunden",
-              "start" : 941400,
-              "end" : 1389800
+              "titel" : "Aufwendiges Vorhaben",
+              "start" : 973600,
+              "end" : 1574187
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
             },
             {
-              "titel" : "Die siebte Frau des Leuchters – Böse Macht im Grab",
-              "start" : 1389800,
-              "end" : 1674907
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Die siebte Frau des Leuchters – Auf dem Geisterschiff",
-              "start" : 1674907,
-              "end" : 2019467
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Die siebte Frau des Leuchters – Freier Wille",
-              "start" : 2019467,
-              "end" : 2798827
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
             },
             {
-              "titel" : "Die verschwundene Torte – In Angst und Schrecken",
-              "start" : 2798827,
-              "end" : 3166667
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
             },
             {
-              "titel" : "Die verschwundene Torte – Gescanntes Areal",
-              "start" : 3166667,
-              "end" : 3327240
-            },
-            {
-              "titel" : "Die verschwundene Torte – Des Rätsels Lösung",
-              "start" : 3327240,
-              "end" : 3898467
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/3/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 4,
+          "titel" : "Die rote Sieben",
+          "autor" : "Marco Sonnleitner",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "\"Ihre Einsätze bitte!\" Während der Croupier im Casino des Luxusdampfers die Kugel in der Roulette-Schüssel kreisen lässt, wird in Kabine 347 ein Passagier niedergeschlagen und ausgeraubt! Ein Fall für die drei Detektive, die auf dem Schiff gerade als Aushilfskellner arbeiten …",
+          "veröffentlichungsdatum" : "2014-02-21",
+          "kapitel" : [
+            {
+              "titel" : "Rien ne va plus",
+              "start" : 0,
+              "end" : 295293
+            },
+            {
+              "titel" : "Blutspuren",
+              "start" : 295293,
+              "end" : 729440
+            },
+            {
+              "titel" : "Abgekartetes Spiel",
+              "start" : 729440,
+              "end" : 1174080
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Croupier",
+              "sprecher" : "Gosta Liptow"
+            },
+            {
+              "rolle" : "Carl Hopkins, Physiker",
+              "sprecher" : "Ben Hecker"
+            },
+            {
+              "rolle" : "Miller, Schiffsdetektiv",
+              "sprecher" : "Michael Grimm"
+            },
+            {
+              "rolle" : "Kapitän Sherwood",
+              "sprecher" : "Horst Naumann"
+            },
+            {
+              "rolle" : "Theodore Quaid",
+              "sprecher" : "Dietrich Adam"
+            },
+            {
+              "rolle" : "Jamie Peterson, Barmann",
+              "sprecher" : "Patrick Bach"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/4/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/4/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 5,
+          "titel" : "Schutzgeld",
+          "autor" : "Ben Nevis",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Wer ist die seltsame Dame, die so auffällig unauffällig durch die Einkaufsstraße schleicht, und sich dabei immer wieder ängstlich umsieht? Als sich die drei Detektive an ihre Fersen heften und die Verdächtige demaskieren, erleben sie eine große Überraschung. Doch jetzt fangen die Schwierigkeiten erst an …",
+          "veröffentlichungsdatum" : "2014-02-21",
+          "kapitel" : [
+            {
+              "titel" : "Überraschung!",
+              "start" : 0,
+              "end" : 277693
+            },
+            {
+              "titel" : "Arges Misstrauen",
+              "start" : 277693,
+              "end" : 941400
+            },
+            {
+              "titel" : "Sieben harte Stunden",
+              "start" : 941400,
+              "end" : 1389800
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Handerson",
+              "sprecher" : "Wolfgang Rositzka"
+            },
+            {
+              "rolle" : "Diego",
+              "sprecher" : "Stephan Benson"
+            },
+            {
+              "rolle" : "Mercedes",
+              "sprecher" : "Hella von der Osten-Sacken",
+              "pseudonym" : "Wanda Osten"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/5/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/5/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 6,
+          "titel" : "Die siebte Frau des Leuchters",
+          "autor" : "Christoph Dittert",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "\"Mein Name ist Nayeli. Und ich bin ein Dieb!\" Der junge Mann, der bei den drei Detektiven auf dem Schrottplatz auftaucht, zieht einen antiken Kerzenhalter aus seinem Rucksack und erzählt dazu eine seltsame Geschichte. Doch wer ist der Fremde, der urplötzlich auftaucht und Nayeli dann in die Flucht schlägt? Unversehens geraten Justus, Bob und Peter in große Gefahr …",
+          "veröffentlichungsdatum" : "2014-02-21",
+          "kapitel" : [
+            {
+              "titel" : "Böse Macht im Grab",
+              "start" : 0,
+              "end" : 285107
+            },
+            {
+              "titel" : "Auf dem Geisterschiff",
+              "start" : 285107,
+              "end" : 629667
+            },
+            {
+              "titel" : "Freier Wille",
+              "start" : 629667,
+              "end" : 1409027
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Nayeli",
+              "sprecher" : "Stefan Brönneke"
+            },
+            {
+              "rolle" : "Barker",
+              "sprecher" : "Ben Hecker"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Off-Sprecherin",
+              "sprecher" : "Claudia Stocksieker"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/6/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/6/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 7,
+          "titel" : "Die verschwundene Torte",
+          "autor" : "André Marx",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "An Justus' Geburtstag muss der Erste Detektiv eine schwere Niederlage einstecken: Ausgerechnet seine Geburtstagstorte wurde über Nacht aus der Freiluftwerkstatt gestohlen! Doch wer kommt als Täter in Frage? Mit Hilfe einer Überwachungskamera sollte der Dieb doch zu identifizieren sein – oder etwa nicht?",
+          "veröffentlichungsdatum" : "2014-02-21",
+          "kapitel" : [
+            {
+              "titel" : "In Angst und Schrecken",
+              "start" : 0,
+              "end" : 367840
+            },
+            {
+              "titel" : "Gescanntes Areal",
+              "start" : 367840,
+              "end" : 528413
+            },
+            {
+              "titel" : "Des Rätsels Lösung",
+              "start" : 528413,
+              "end" : 1099640
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Ian Carew",
+              "sprecher" : "Sascha Draeger"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/7/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/7/ffmetadata.txt"
           }
         }
       ],
@@ -1487,6 +1356,128 @@
           "sprecher" : "Sascha Draeger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der siebte Gast – Inszenierung neuer Geschichten",
+              "start" : 0,
+              "end" : 439267
+            },
+            {
+              "titel" : "Der siebte Gast – Die Worte einer Lügenhexe",
+              "start" : 439267,
+              "end" : 774387
+            },
+            {
+              "titel" : "Der siebte Gast – Prinzessin in Champagnerlaune",
+              "start" : 774387,
+              "end" : 1596747
+            },
+            {
+              "titel" : "Bis um sieben zurück – Kopfschmerzen",
+              "start" : 1596747,
+              "end" : 2291680
+            },
+            {
+              "titel" : "Bis um sieben zurück – Erwischt!",
+              "start" : 2291680,
+              "end" : 2796560
+            },
+            {
+              "titel" : "Bis um sieben zurück – Bobby",
+              "start" : 2796560,
+              "end" : 3073920
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Bobs schwerste Stunde – Alles weg!",
+              "start" : 0,
+              "end" : 433867
+            },
+            {
+              "titel" : "Bobs schwerste Stunde – Gruselstimme",
+              "start" : 433867,
+              "end" : 973600
+            },
+            {
+              "titel" : "Bobs schwerste Stunde – Aufwendiges Vorhaben",
+              "start" : 973600,
+              "end" : 1574187
+            },
+            {
+              "titel" : "Die rote Sieben – Rien ne va plus",
+              "start" : 1574187,
+              "end" : 1869480
+            },
+            {
+              "titel" : "Die rote Sieben – Blutspuren",
+              "start" : 1869480,
+              "end" : 2303627
+            },
+            {
+              "titel" : "Die rote Sieben – Abgekartetes Spiel",
+              "start" : 2303627,
+              "end" : 2748267
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Schutzgeld – Überraschung!",
+              "start" : 0,
+              "end" : 277693
+            },
+            {
+              "titel" : "Schutzgeld – Arges Misstrauen",
+              "start" : 277693,
+              "end" : 941400
+            },
+            {
+              "titel" : "Schutzgeld – Sieben harte Stunden",
+              "start" : 941400,
+              "end" : 1389800
+            },
+            {
+              "titel" : "Die siebte Frau des Leuchters – Böse Macht im Grab",
+              "start" : 1389800,
+              "end" : 1674907
+            },
+            {
+              "titel" : "Die siebte Frau des Leuchters – Auf dem Geisterschiff",
+              "start" : 1674907,
+              "end" : 2019467
+            },
+            {
+              "titel" : "Die siebte Frau des Leuchters – Freier Wille",
+              "start" : 2019467,
+              "end" : 2798827
+            },
+            {
+              "titel" : "Die verschwundene Torte – In Angst und Schrecken",
+              "start" : 2798827,
+              "end" : 3166667
+            },
+            {
+              "titel" : "Die verschwundene Torte – Gescanntes Areal",
+              "start" : 3166667,
+              "end" : 3327240
+            },
+            {
+              "titel" : "Die verschwundene Torte – Des Rätsels Lösung",
+              "start" : 3327240,
+              "end" : 3898467
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/metadata.json",
         "cover" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/cover.png"
@@ -1495,494 +1486,394 @@
     {
       "teile" : [
         {
-          "teile" : [
-            {
-              "teilNummer" : 1,
-              "titel" : "Immer und immer wieder",
-              "autor" : "Hendrik Buchna",
-              "beschreibung" : "Peter ist ratlos: In wenigen Minuten wird die Zentrale zerstört werden, und er kann nichts dagegen tun! Erst ein Tipp vom Ersten Detektiv bringt ihn auf die richtige Spur – oder doch nicht?",
-              "kapitel" : [
-                {
-                  "titel" : "Sieben",
-                  "start" : 0,
-                  "end" : 172213
-                },
-                {
-                  "titel" : "Variationen",
-                  "start" : 172213,
-                  "end" : 590280
-                },
-                {
-                  "titel" : "Elf",
-                  "start" : 590280,
-                  "end" : 950800
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Hüne",
-                  "sprecher" : "Johannes Semm"
-                },
-                {
-                  "rolle" : "Marvin Gray",
-                  "sprecher" : "Horst Stark"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/1/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/1/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 2,
-              "titel" : "Der Raub der Zehntausend",
-              "autor" : "Marco Sonnleitner",
-              "beschreibung" : "Beim Ausliefern einer Standuhr geraten die drei Detektive mitten in einen Kriminalfall, der äußerst explosiv enden könnte …",
-              "kapitel" : [
-                {
-                  "titel" : "Der absolute Hammer",
-                  "start" : 0,
-                  "end" : 193827
-                },
-                {
-                  "titel" : "Die Botschaft",
-                  "start" : 193827,
-                  "end" : 823293
-                },
-                {
-                  "titel" : "Ablenkungsmanöver",
-                  "start" : 823293,
-                  "end" : 1198507
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Nancy McMonigal",
-                  "sprecher" : "Gerlinde Dillge"
-                },
-                {
-                  "rolle" : "Tom",
-                  "sprecher" : "Wolfgang Rositzka"
-                },
-                {
-                  "rolle" : "Rod",
-                  "sprecher" : "Herbert Tennigkeit"
-                },
-                {
-                  "rolle" : "Joe",
-                  "sprecher" : "Olaf Reichmann"
-                },
-                {
-                  "rolle" : "Ben",
-                  "sprecher" : "Stephan Chrzescinski"
-                },
-                {
-                  "rolle" : "Mariann",
-                  "sprecher" : "Simone Ritscher"
-                },
-                {
-                  "rolle" : "TV-Sprecher",
-                  "sprecher" : "Holger Wemhoff"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/2/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/2/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 3,
-              "titel" : "Der verschwundene Zeitgeist",
-              "autor" : "André Minninger",
-              "beschreibung" : "Wer hat die fehlenden Manuskriptseiten von Malcolm Fever gestohlen? Als sich die drei Detektive des Falls annehmen, machen sie die Bekanntschaft mit einer höchst sonderbaren Dame …",
-              "kapitel" : [
-                {
-                  "titel" : "Ein emotionales Gespräch",
-                  "start" : 0,
-                  "end" : 645586
-                },
-                {
-                  "titel" : "Eindeutiges Foto",
-                  "start" : 645586,
-                  "end" : 1502960
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Malcolm Fever",
-                  "sprecher" : "Tilo Schmitz"
-                },
-                {
-                  "rolle" : "Lucy Hopkins",
-                  "sprecher" : "Topsy Küppers"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/3/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/3/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 1,
+          "titel" : "Immer und immer wieder",
+          "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Peter ist ratlos: In wenigen Minuten wird die Zentrale zerstört werden, und er kann nichts dagegen tun! Erst ein Tipp vom Ersten Detektiv bringt ihn auf die richtige Spur – oder doch nicht?",
+          "veröffentlichungsdatum" : "2016-03-04",
           "kapitel" : [
             {
-              "titel" : "Immer und immer wieder – Sieben",
+              "titel" : "Sieben",
               "start" : 0,
               "end" : 172213
             },
             {
-              "titel" : "Immer und immer wieder – Variationen",
+              "titel" : "Variationen",
               "start" : 172213,
               "end" : 590280
             },
             {
-              "titel" : "Immer und immer wieder – Elf",
+              "titel" : "Elf",
               "start" : 590280,
               "end" : 950800
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
             },
             {
-              "titel" : "Der Raub der Zehntausend – Der absolute Hammer",
-              "start" : 950800,
-              "end" : 1144627
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Der Raub der Zehntausend – Die Botschaft",
-              "start" : 1144627,
-              "end" : 1774093
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Der Raub der Zehntausend – Ablenkungsmanöver",
-              "start" : 1774093,
-              "end" : 2149307
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
             },
             {
-              "titel" : "Der verschwundene Zeitgeist – Ein emotionales Gespräch",
-              "start" : 2149307,
-              "end" : 2794893
+              "rolle" : "Hüne",
+              "sprecher" : "Johannes Semm"
             },
             {
-              "titel" : "Der verschwundene Zeitgeist – Eindeutiges Foto",
-              "start" : 2794893,
-              "end" : 3652267
+              "rolle" : "Marvin Gray",
+              "sprecher" : "Horst Stark"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/1/ffmetadata.txt"
           }
         },
         {
-          "teile" : [
-            {
-              "teilNummer" : 4,
-              "titel" : "Leaving Nineteen Sixty-four",
-              "autor" : "Ben Nevis",
-              "beschreibung" : "Professor Selby hat die drei ??? auf eine Reise durch die Zeit geschickt – nun müssen sie ein Rätsel lösen, um zurückzukehren.",
-              "kapitel" : [
-                {
-                  "titel" : "Überraschung",
-                  "start" : 0,
-                  "end" : 477000
-                },
-                {
-                  "titel" : "Ein schlechter Scherz",
-                  "start" : 477000,
-                  "end" : 991520
-                },
-                {
-                  "titel" : "Ein Ass im Ärmel",
-                  "start" : 991520,
-                  "end" : 1748867
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Onkel Titus",
-                  "sprecher" : "Andreas E. Beurmann",
-                  "pseudonym" : "Hans Meinhardt"
-                },
-                {
-                  "rolle" : "Tante Mathilda",
-                  "sprecher" : "Karin Lieneweg"
-                },
-                {
-                  "rolle" : "Professor Selby",
-                  "sprecher" : "Claus Wilcke"
-                },
-                {
-                  "rolle" : "Oberpriesterin",
-                  "sprecher" : "Elga Schütz"
-                },
-                {
-                  "rolle" : "Kevin",
-                  "sprecher" : "Patrick Mölleken"
-                },
-                {
-                  "rolle" : "Mann in Kutte",
-                  "sprecher" : "Rüdiger Hellmann"
-                },
-                {
-                  "rolle" : "Radio",
-                  "sprecher" : "Wilhelm Wieben"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/4/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/4/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 5,
-              "titel" : "Rückwärtsgang",
-              "autor" : "André Marx",
-              "beschreibung" : "In diesem rätselhaften Fall scheint die Zeit aus den Fugen geraten zu sein – mal geht es vorwärts, dann wieder zurück!",
-              "kapitel" : [
-                {
-                  "titel" : "Jetzt",
-                  "start" : 0,
-                  "end" : 563586
-                },
-                {
-                  "titel" : "Die Aufzeichnung",
-                  "start" : 563586,
-                  "end" : 953986
-                },
-                {
-                  "titel" : "Vorwärts",
-                  "start" : 953986,
-                  "end" : 1136386
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Mr. Tilton",
-                  "sprecher" : "Christian Senger"
-                },
-                {
-                  "rolle" : "Mr. Walsh",
-                  "sprecher" : "Christian Rudolf"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/5/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/5/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 6,
-              "titel" : "Zeit der Opfer, Zeit der Wunder",
-              "autor" : "Christoph Dittert, Kari Erlhoff",
-              "beschreibung" : "Eigentlich geht es nur um ein Literaturprojekt für die Schule – doch mit den drei ??? wird auch das schnell zu einem Abenteuer …",
-              "kapitel" : [
-                {
-                  "titel" : "Die richtige Perspektive",
-                  "start" : 0,
-                  "end" : 524827
-                },
-                {
-                  "titel" : "Die nächste Stufe",
-                  "start" : 524827,
-                  "end" : 964467
-                },
-                {
-                  "titel" : "Einfach galaktisch!",
-                  "start" : 964467,
-                  "end" : 1413600
-                },
-                {
-                  "titel" : "Objekt der Begierde",
-                  "start" : 1413600,
-                  "end" : 1684120
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Thomas Fritsch"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Weise Frau",
-                  "sprecher" : "Dorothea Hagena"
-                },
-                {
-                  "rolle" : "Kelly",
-                  "sprecher" : "Juliane Szalay"
-                },
-                {
-                  "rolle" : "Patrick",
-                  "sprecher" : "Nicolas König"
-                },
-                {
-                  "rolle" : "Samuel",
-                  "sprecher" : "Johannes Semm"
-                },
-                {
-                  "rolle" : "Kenneth",
-                  "sprecher" : "Olaf Reichmann"
-                },
-                {
-                  "rolle" : "Liz Zapata",
-                  "sprecher" : "Merete Brettschneider"
-                },
-                {
-                  "rolle" : "Skinny Norris",
-                  "sprecher" : "Michael Harck"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/6/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/6/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 2,
+          "titel" : "Der Raub der Zehntausend",
+          "autor" : "Marco Sonnleitner",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Beim Ausliefern einer Standuhr geraten die drei Detektive mitten in einen Kriminalfall, der äußerst explosiv enden könnte …",
+          "veröffentlichungsdatum" : "2016-03-04",
           "kapitel" : [
             {
-              "titel" : "Leaving Nineteen Sixty-four – Überraschung",
+              "titel" : "Der absolute Hammer",
               "start" : 0,
-              "end" : 477000
+              "end" : 193827
             },
             {
-              "titel" : "Leaving Nineteen Sixty-four – Ein schlechter Scherz",
-              "start" : 477000,
-              "end" : 991520
+              "titel" : "Die Botschaft",
+              "start" : 193827,
+              "end" : 823293
             },
             {
-              "titel" : "Leaving Nineteen Sixty-four – Ein Ass im Ärmel",
-              "start" : 991520,
-              "end" : 1748867
+              "titel" : "Ablenkungsmanöver",
+              "start" : 823293,
+              "end" : 1198507
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
             },
             {
-              "titel" : "Rückwärtsgang – Jetzt",
-              "start" : 1748867,
-              "end" : 2312453
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Rückwärtsgang – Die Aufzeichnung",
-              "start" : 2312453,
-              "end" : 2702853
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Rückwärtsgang – Vorwärts",
-              "start" : 2702853,
-              "end" : 2885253
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
             },
             {
-              "titel" : "Zeit der Opfer, Zeit der Wunder – Die richtige Perspektive",
-              "start" : 2885253,
-              "end" : 3410080
+              "rolle" : "Nancy McMonigal",
+              "sprecher" : "Gerlinde Dillge"
             },
             {
-              "titel" : "Zeit der Opfer, Zeit der Wunder – Die nächste Stufe",
-              "start" : 3410080,
-              "end" : 3849720
+              "rolle" : "Tom",
+              "sprecher" : "Wolfgang Rositzka"
             },
             {
-              "titel" : "Zeit der Opfer, Zeit der Wunder – Einfach galaktisch!",
-              "start" : 3849720,
-              "end" : 4298853
+              "rolle" : "Rod",
+              "sprecher" : "Herbert Tennigkeit"
             },
             {
-              "titel" : "Zeit der Opfer, Zeit der Wunder – Objekt der Begierde",
-              "start" : 4298853,
-              "end" : 4569373
+              "rolle" : "Joe",
+              "sprecher" : "Olaf Reichmann"
+            },
+            {
+              "rolle" : "Ben",
+              "sprecher" : "Stephan Chrzescinski"
+            },
+            {
+              "rolle" : "Mariann",
+              "sprecher" : "Simone Ritscher"
+            },
+            {
+              "rolle" : "TV-Sprecher",
+              "sprecher" : "Holger Wemhoff"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/2/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 3,
+          "titel" : "Der verschwundene Zeitgeist",
+          "autor" : "André Minninger",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Wer hat die fehlenden Manuskriptseiten von Malcolm Fever gestohlen? Als sich die drei Detektive des Falls annehmen, machen sie die Bekanntschaft mit einer höchst sonderbaren Dame …",
+          "veröffentlichungsdatum" : "2016-03-04",
+          "kapitel" : [
+            {
+              "titel" : "Ein emotionales Gespräch",
+              "start" : 0,
+              "end" : 645586
+            },
+            {
+              "titel" : "Eindeutiges Foto",
+              "start" : 645586,
+              "end" : 1502960
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Malcolm Fever",
+              "sprecher" : "Tilo Schmitz"
+            },
+            {
+              "rolle" : "Lucy Hopkins",
+              "sprecher" : "Topsy Küppers"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/3/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/3/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 4,
+          "titel" : "Leaving Nineteen Sixty-four",
+          "autor" : "Ben Nevis",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Professor Selby hat die drei ??? auf eine Reise durch die Zeit geschickt – nun müssen sie ein Rätsel lösen, um zurückzukehren.",
+          "veröffentlichungsdatum" : "2016-03-04",
+          "kapitel" : [
+            {
+              "titel" : "Überraschung",
+              "start" : 0,
+              "end" : 477000
+            },
+            {
+              "titel" : "Ein schlechter Scherz",
+              "start" : 477000,
+              "end" : 991520
+            },
+            {
+              "titel" : "Ein Ass im Ärmel",
+              "start" : 991520,
+              "end" : 1748867
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Onkel Titus",
+              "sprecher" : "Andreas E. Beurmann",
+              "pseudonym" : "Hans Meinhardt"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Professor Selby",
+              "sprecher" : "Claus Wilcke"
+            },
+            {
+              "rolle" : "Oberpriesterin",
+              "sprecher" : "Elga Schütz"
+            },
+            {
+              "rolle" : "Kevin",
+              "sprecher" : "Patrick Mölleken"
+            },
+            {
+              "rolle" : "Mann in Kutte",
+              "sprecher" : "Rüdiger Hellmann"
+            },
+            {
+              "rolle" : "Radio",
+              "sprecher" : "Wilhelm Wieben"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/4/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/4/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 5,
+          "titel" : "Rückwärtsgang",
+          "autor" : "André Marx",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "In diesem rätselhaften Fall scheint die Zeit aus den Fugen geraten zu sein – mal geht es vorwärts, dann wieder zurück!",
+          "veröffentlichungsdatum" : "2016-03-04",
+          "kapitel" : [
+            {
+              "titel" : "Jetzt",
+              "start" : 0,
+              "end" : 563586
+            },
+            {
+              "titel" : "Die Aufzeichnung",
+              "start" : 563586,
+              "end" : 953986
+            },
+            {
+              "titel" : "Vorwärts",
+              "start" : 953986,
+              "end" : 1136386
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Mr. Tilton",
+              "sprecher" : "Christian Senger"
+            },
+            {
+              "rolle" : "Mr. Walsh",
+              "sprecher" : "Christian Rudolf"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/5/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/5/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 6,
+          "titel" : "Zeit der Opfer, Zeit der Wunder",
+          "autor" : "Christoph Dittert, Kari Erlhoff",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Eigentlich geht es nur um ein Literaturprojekt für die Schule – doch mit den drei ??? wird auch das schnell zu einem Abenteuer …",
+          "veröffentlichungsdatum" : "2016-03-04",
+          "kapitel" : [
+            {
+              "titel" : "Die richtige Perspektive",
+              "start" : 0,
+              "end" : 524827
+            },
+            {
+              "titel" : "Die nächste Stufe",
+              "start" : 524827,
+              "end" : 964467
+            },
+            {
+              "titel" : "Einfach galaktisch!",
+              "start" : 964467,
+              "end" : 1413600
+            },
+            {
+              "titel" : "Objekt der Begierde",
+              "start" : 1413600,
+              "end" : 1684120
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Thomas Fritsch"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Weise Frau",
+              "sprecher" : "Dorothea Hagena"
+            },
+            {
+              "rolle" : "Kelly",
+              "sprecher" : "Juliane Szalay"
+            },
+            {
+              "rolle" : "Patrick",
+              "sprecher" : "Nicolas König"
+            },
+            {
+              "rolle" : "Samuel",
+              "sprecher" : "Johannes Semm"
+            },
+            {
+              "rolle" : "Kenneth",
+              "sprecher" : "Olaf Reichmann"
+            },
+            {
+              "rolle" : "Liz Zapata",
+              "sprecher" : "Merete Brettschneider"
+            },
+            {
+              "rolle" : "Skinny Norris",
+              "sprecher" : "Michael Harck"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/6/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/6/ffmetadata.txt"
           }
         }
       ],
@@ -2118,6 +2009,108 @@
           "sprecher" : "Michael Harck"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Immer und immer wieder – Sieben",
+              "start" : 0,
+              "end" : 172213
+            },
+            {
+              "titel" : "Immer und immer wieder – Variationen",
+              "start" : 172213,
+              "end" : 590280
+            },
+            {
+              "titel" : "Immer und immer wieder – Elf",
+              "start" : 590280,
+              "end" : 950800
+            },
+            {
+              "titel" : "Der Raub der Zehntausend – Der absolute Hammer",
+              "start" : 950800,
+              "end" : 1144627
+            },
+            {
+              "titel" : "Der Raub der Zehntausend – Die Botschaft",
+              "start" : 1144627,
+              "end" : 1774093
+            },
+            {
+              "titel" : "Der Raub der Zehntausend – Ablenkungsmanöver",
+              "start" : 1774093,
+              "end" : 2149307
+            },
+            {
+              "titel" : "Der verschwundene Zeitgeist – Ein emotionales Gespräch",
+              "start" : 2149307,
+              "end" : 2794893
+            },
+            {
+              "titel" : "Der verschwundene Zeitgeist – Eindeutiges Foto",
+              "start" : 2794893,
+              "end" : 3652267
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Leaving Nineteen Sixty-four – Überraschung",
+              "start" : 0,
+              "end" : 477000
+            },
+            {
+              "titel" : "Leaving Nineteen Sixty-four – Ein schlechter Scherz",
+              "start" : 477000,
+              "end" : 991520
+            },
+            {
+              "titel" : "Leaving Nineteen Sixty-four – Ein Ass im Ärmel",
+              "start" : 991520,
+              "end" : 1748867
+            },
+            {
+              "titel" : "Rückwärtsgang – Jetzt",
+              "start" : 1748867,
+              "end" : 2312453
+            },
+            {
+              "titel" : "Rückwärtsgang – Die Aufzeichnung",
+              "start" : 2312453,
+              "end" : 2702853
+            },
+            {
+              "titel" : "Rückwärtsgang – Vorwärts",
+              "start" : 2702853,
+              "end" : 2885253
+            },
+            {
+              "titel" : "Zeit der Opfer, Zeit der Wunder – Die richtige Perspektive",
+              "start" : 2885253,
+              "end" : 3410080
+            },
+            {
+              "titel" : "Zeit der Opfer, Zeit der Wunder – Die nächste Stufe",
+              "start" : 3410080,
+              "end" : 3849720
+            },
+            {
+              "titel" : "Zeit der Opfer, Zeit der Wunder – Einfach galaktisch!",
+              "start" : 3849720,
+              "end" : 4298853
+            },
+            {
+              "titel" : "Zeit der Opfer, Zeit der Wunder – Objekt der Begierde",
+              "start" : 4298853,
+              "end" : 4569373
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/metadata.json",
         "cover" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/cover.png"
@@ -2126,510 +2119,399 @@
     {
       "teile" : [
         {
-          "teile" : [
-            {
-              "teilNummer" : 1,
-              "titel" : "Das schwarze Verlies",
-              "autor" : "Ben Nevis",
-              "beschreibung" : "Es ist dunkel. Mehr als dunkel. Schwarz. Peter erwacht und ist gefesselt! Wo befindet er sich? Ist alles nur ein Traum? Plötzlich vernimmt er ein seltsames Grunzen. Ein Kampfhund …? Dann kehren seine Erinnerungen zurück!",
-              "kapitel" : [
-                {
-                  "titel" : "Gefesselt",
-                  "start" : 0,
-                  "end" : 826640
-                },
-                {
-                  "titel" : "Betäubt",
-                  "start" : 826640,
-                  "end" : 1316773
-                },
-                {
-                  "titel" : "Verrostet",
-                  "start" : 1316773,
-                  "end" : 2240920
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/1/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 2,
-              "titel" : "Schwarze Seelen",
-              "autor" : "André Minninger",
-              "beschreibung" : "Die gegenseitigen Beschuldigungen der Zwillingsschwestern Helen und Ellen stellen die drei Detektive auf eine harte Zerreißprobe. Wird es ihnen dennoch gelingen, die wahre Täterin zu überführen?",
-              "kapitel" : [
-                {
-                  "titel" : "Ohne Gewissen",
-                  "start" : 0,
-                  "end" : 645160
-                },
-                {
-                  "titel" : "Ohne Rücksicht",
-                  "start" : 645160,
-                  "end" : 1349373
-                },
-                {
-                  "titel" : "Ohne Reue",
-                  "start" : 1349373,
-                  "end" : 1855920
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Axel Milberg"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Helen",
-                  "sprecher" : "Dorette Hugo",
-                  "pseudonym" : "Balancinha Blanc"
-                },
-                {
-                  "rolle" : "Ellen",
-                  "sprecher" : "Dorette Hugo"
-                },
-                {
-                  "rolle" : "Vater",
-                  "sprecher" : "Douglas Welbat"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/2/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 1,
+          "titel" : "Das schwarze Verlies",
+          "autor" : "Ben Nevis",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Es ist dunkel. Mehr als dunkel. Schwarz. Peter erwacht und ist gefesselt! Wo befindet er sich? Ist alles nur ein Traum? Plötzlich vernimmt er ein seltsames Grunzen. Ein Kampfhund …? Dann kehren seine Erinnerungen zurück!",
+          "veröffentlichungsdatum" : "2018-10-28",
           "kapitel" : [
             {
-              "titel" : "Das schwarze Verlies – Gefesselt",
+              "titel" : "Gefesselt",
               "start" : 0,
               "end" : 826640
             },
             {
-              "titel" : "Das schwarze Verlies – Betäubt",
+              "titel" : "Betäubt",
               "start" : 826640,
               "end" : 1316773
             },
             {
-              "titel" : "Das schwarze Verlies – Verrostet",
+              "titel" : "Verrostet",
               "start" : 1316773,
               "end" : 2240920
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Schwarze Seelen – Ohne Gewissen",
-              "start" : 2240920,
-              "end" : 2886080
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Schwarze Seelen – Ohne Rücksicht",
-              "start" : 2886080,
-              "end" : 3590293
-            },
-            {
-              "titel" : "Schwarze Seelen – Ohne Reue",
-              "start" : 3590293,
-              "end" : 4096840
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/1/ffmetadata.txt"
           }
         },
         {
-          "teile" : [
-            {
-              "teilNummer" : 3,
-              "titel" : "Ein schwarzer Tag für Mr. Kingstone",
-              "autor" : "Christoph Dittert",
-              "beschreibung" : "Ausgerechnet Skinny Norris beauftragt die drei Detektive mit einem neuen Fall: Wer erpresst Mr. Kingstone, den blinden Betreiber des Dunkelrestaurants in Rocky Beach? In totaler Finsternis ermitteln Justus, Peter und Bob, um dem skrupellosen Verbrecher auf die Schliche zu kommen. Doch wird ihre Falle auch zuschnappen?",
-              "kapitel" : [
-                {
-                  "titel" : "Unverschämter Kerl",
-                  "start" : 0,
-                  "end" : 526840
-                },
-                {
-                  "titel" : "Dunkelrestaurant",
-                  "start" : 526840,
-                  "end" : 1199413
-                },
-                {
-                  "titel" : "Kontaktschranke",
-                  "start" : 1199413,
-                  "end" : 1889653
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Axel Milberg"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Tante Mathilda",
-                  "sprecher" : "Karin Lieneweg"
-                },
-                {
-                  "rolle" : "Skinny Norris",
-                  "sprecher" : "Michael Harck"
-                },
-                {
-                  "rolle" : "Marc Kingstone",
-                  "sprecher" : "Rainer Brandt"
-                },
-                {
-                  "rolle" : "Aaron Kingstone",
-                  "sprecher" : "Tommi Piper"
-                },
-                {
-                  "rolle" : "Sarah",
-                  "sprecher" : "Christiane Leuchtmann"
-                },
-                {
-                  "rolle" : "Albert",
-                  "sprecher" : "Franzisko Löwe"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/3/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 4,
-              "titel" : "Wer hat Angst vorm Schwarzen Mann",
-              "autor" : "Marco Sonnleitner",
-              "beschreibung" : "In einem Kindergarten in Rocky Beach herrscht größte Besorgnis: Wurden die Kinder tatsächlich allesamt von einem unheimlichen \"Schwarzen Mann\" heimgesucht? Die Ermittlungen der drei ??? führen zum ominösen \"Herz von Afrika\" …",
-              "kapitel" : [
-                {
-                  "titel" : "Albtraum?",
-                  "start" : 0,
-                  "end" : 601054
-                },
-                {
-                  "titel" : "Das Herz von Afrika",
-                  "start" : 601054,
-                  "end" : 1250120
-                },
-                {
-                  "titel" : "Lasso-Künste",
-                  "start" : 1250120,
-                  "end" : 1767387
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Axel Milberg"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Kelly Madigan",
-                  "sprecher" : "Juliane Szalay"
-                },
-                {
-                  "rolle" : "Mrs. McGee",
-                  "sprecher" : "Alice Krimmel"
-                },
-                {
-                  "rolle" : "Toby",
-                  "sprecher" : "A. Stengelin"
-                },
-                {
-                  "rolle" : "Mrs. Wells",
-                  "sprecher" : "Heidi Schaffrath"
-                },
-                {
-                  "rolle" : "Junge",
-                  "sprecher" : "Linus Tauber"
-                },
-                {
-                  "rolle" : "Mädchen",
-                  "sprecher" : "Katinka Jaekel"
-                },
-                {
-                  "rolle" : "Ericsson",
-                  "sprecher" : "Detlef Tams"
-                },
-                {
-                  "rolle" : "Sprecher/Moderator",
-                  "sprecher" : "Oliver Böttcher"
-                },
-                {
-                  "rolle" : "Tarek Shabana",
-                  "sprecher" : "Werner Wilkening"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/4/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 2,
+          "titel" : "Schwarze Seelen",
+          "autor" : "André Minninger",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Die gegenseitigen Beschuldigungen der Zwillingsschwestern Helen und Ellen stellen die drei Detektive auf eine harte Zerreißprobe. Wird es ihnen dennoch gelingen, die wahre Täterin zu überführen?",
+          "veröffentlichungsdatum" : "2018-10-28",
           "kapitel" : [
             {
-              "titel" : "Ein schwarzer Tag für Mr. Kingstone – Unverschämter Kerl",
+              "titel" : "Ohne Gewissen",
               "start" : 0,
-              "end" : 526840
+              "end" : 645160
             },
             {
-              "titel" : "Ein schwarzer Tag für Mr. Kingstone – Dunkelrestaurant",
-              "start" : 526840,
-              "end" : 1199413
+              "titel" : "Ohne Rücksicht",
+              "start" : 645160,
+              "end" : 1349373
             },
             {
-              "titel" : "Ein schwarzer Tag für Mr. Kingstone – Kontaktschranke",
-              "start" : 1199413,
-              "end" : 1889653
+              "titel" : "Ohne Reue",
+              "start" : 1349373,
+              "end" : 1855920
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
             },
             {
-              "titel" : "Wer hat Angst vorm Schwarzen Mann – Albtraum?",
-              "start" : 1889653,
-              "end" : 2490707
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Wer hat Angst vorm Schwarzen Mann – Das Herz von Afrika",
-              "start" : 2490707,
-              "end" : 3139773
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Wer hat Angst vorm Schwarzen Mann – Lasso-Künste",
-              "start" : 3139773,
-              "end" : 3657040
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Helen",
+              "sprecher" : "Dorette Hugo",
+              "pseudonym" : "Balancinha Blanc"
+            },
+            {
+              "rolle" : "Ellen",
+              "sprecher" : "Dorette Hugo"
+            },
+            {
+              "rolle" : "Vater",
+              "sprecher" : "Douglas Welbat"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/2/ffmetadata.txt"
           }
         },
         {
-          "teile" : [
-            {
-              "teilNummer" : 5,
-              "titel" : "Die schwarze PhantOma",
-              "autor" : "Kari Erlhoff",
-              "beschreibung" : "Wer steckt hinter der unheimlichen Porschefahrerin, von der Justus beinahe überfahren wurde!? Auch Peter wird von ihr mit einem heftigen Fausthieb niedergestreckt! Wer ist die humpelnde Rentnerin, die als \"PhantOma\" in Rocky Beach ihr Unwesen treibt? An Verdächtigen mangelt es keineswegs …",
-              "kapitel" : [
-                {
-                  "titel" : "Wasserdichte Alibis",
-                  "start" : 0,
-                  "end" : 828067
-                },
-                {
-                  "titel" : "Kriminelle Abwege",
-                  "start" : 828067,
-                  "end" : 1373493
-                },
-                {
-                  "titel" : "Tägliches Training",
-                  "start" : 1373493,
-                  "end" : 2256800
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Axel Milberg"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Tasha",
-                  "sprecher" : "Victoria Zöller"
-                },
-                {
-                  "rolle" : "Domino Laverna",
-                  "sprecher" : "Sabine Hahn"
-                },
-                {
-                  "rolle" : "Biff Rodgers, Reporter",
-                  "sprecher" : "Daniel Schütter"
-                },
-                {
-                  "rolle" : "Lesley Dimple",
-                  "sprecher" : "Ann Montenbruck"
-                },
-                {
-                  "rolle" : "Zeus Zenon Johnson",
-                  "sprecher" : "Michael Prelle"
-                },
-                {
-                  "rolle" : "Computer",
-                  "sprecher" : "Peter Bayer"
-                },
-                {
-                  "rolle" : "Off-Sprecher",
-                  "sprecher" : "Frank Roder"
-                },
-                {
-                  "rolle" : "Sprecher",
-                  "sprecher" : "Andreas Birnbaum"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/5/ffmetadata.txt"
-              }
-            },
-            {
-              "teilNummer" : 6,
-              "titel" : "Das schwarze Nest",
-              "autor" : "Hendrik Buchna",
-              "beschreibung" : "Das Telefon klingelt nicht in der Zentrale der drei Detektive. Doch Justus hört es ganz deutlich. Leidet er unter Wahnvorstellungen?\nUnd auch Peter wird von argen Problemen geplagt: Er muss unbedingt das große Sackhüpfturnier gewinnen!\nBob wird endlich aus dem Krankenhaus entlassen und wundert sich über gar nichts mehr …",
-              "kapitel" : [
-                {
-                  "titel" : "Grabesstille",
-                  "start" : 0,
-                  "end" : 547413
-                },
-                {
-                  "titel" : "Demokratische Abstimmung",
-                  "start" : 547413,
-                  "end" : 1040413
-                },
-                {
-                  "titel" : "Fall gelöst",
-                  "start" : 1040413,
-                  "end" : 1718507
-                }
-              ],
-              "sprechrollen" : [
-                {
-                  "rolle" : "Erzähler",
-                  "sprecher" : "Axel Milberg"
-                },
-                {
-                  "rolle" : "Justus Jonas, Erster Detektiv",
-                  "sprecher" : "Oliver Rohrbeck"
-                },
-                {
-                  "rolle" : "Peter Shaw, Zweiter Detektiv",
-                  "sprecher" : "Jens Wawrczeck"
-                },
-                {
-                  "rolle" : "Bob Andrews, Recherchen und Archiv",
-                  "sprecher" : "Andreas Fröhlich"
-                },
-                {
-                  "rolle" : "Blacky",
-                  "sprecher" : "Heikedine Körting",
-                  "pseudonym" : "Pamela Punti"
-                },
-                {
-                  "rolle" : "Kassiererin",
-                  "sprecher" : "Angela Stresemann"
-                },
-                {
-                  "rolle" : "Inspektor Cotta",
-                  "sprecher" : "Holger Mahlich"
-                }
-              ],
-              "links" : {
-                "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/metadata.json",
-                "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/6/ffmetadata.txt"
-              }
-            }
-          ],
           "teilNummer" : 3,
+          "titel" : "Ein schwarzer Tag für Mr. Kingstone",
+          "autor" : "Christoph Dittert",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Ausgerechnet Skinny Norris beauftragt die drei Detektive mit einem neuen Fall: Wer erpresst Mr. Kingstone, den blinden Betreiber des Dunkelrestaurants in Rocky Beach? In totaler Finsternis ermitteln Justus, Peter und Bob, um dem skrupellosen Verbrecher auf die Schliche zu kommen. Doch wird ihre Falle auch zuschnappen?",
+          "veröffentlichungsdatum" : "2018-10-28",
           "kapitel" : [
             {
-              "titel" : "Die schwarze PhantOma – Wasserdichte Alibis",
+              "titel" : "Unverschämter Kerl",
               "start" : 0,
-              "end" : 828067
+              "end" : 526840
             },
             {
-              "titel" : "Die schwarze PhantOma – Kriminelle Abwege",
-              "start" : 828067,
-              "end" : 1373493
+              "titel" : "Dunkelrestaurant",
+              "start" : 526840,
+              "end" : 1199413
             },
             {
-              "titel" : "Die schwarze PhantOma – Tägliches Training",
-              "start" : 1373493,
-              "end" : 2256800
+              "titel" : "Kontaktschranke",
+              "start" : 1199413,
+              "end" : 1889653
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
             },
             {
-              "titel" : "Das schwarze Nest – Grabesstille",
-              "start" : 2256800,
-              "end" : 2804213
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
             },
             {
-              "titel" : "Das schwarze Nest – Demokratische Abstimmung",
-              "start" : 2804213,
-              "end" : 3297213
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
             },
             {
-              "titel" : "Das schwarze Nest – Fall gelöst",
-              "start" : 3297213,
-              "end" : 3975307
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tante Mathilda",
+              "sprecher" : "Karin Lieneweg"
+            },
+            {
+              "rolle" : "Skinny Norris",
+              "sprecher" : "Michael Harck"
+            },
+            {
+              "rolle" : "Marc Kingstone",
+              "sprecher" : "Rainer Brandt"
+            },
+            {
+              "rolle" : "Aaron Kingstone",
+              "sprecher" : "Tommi Piper"
+            },
+            {
+              "rolle" : "Sarah",
+              "sprecher" : "Christiane Leuchtmann"
+            },
+            {
+              "rolle" : "Albert",
+              "sprecher" : "Franzisko Löwe"
             }
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/3/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 4,
+          "titel" : "Wer hat Angst vorm Schwarzen Mann",
+          "autor" : "Marco Sonnleitner",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "In einem Kindergarten in Rocky Beach herrscht größte Besorgnis: Wurden die Kinder tatsächlich allesamt von einem unheimlichen \"Schwarzen Mann\" heimgesucht? Die Ermittlungen der drei ??? führen zum ominösen \"Herz von Afrika\" …",
+          "veröffentlichungsdatum" : "2018-10-28",
+          "kapitel" : [
+            {
+              "titel" : "Albtraum?",
+              "start" : 0,
+              "end" : 601054
+            },
+            {
+              "titel" : "Das Herz von Afrika",
+              "start" : 601054,
+              "end" : 1250120
+            },
+            {
+              "titel" : "Lasso-Künste",
+              "start" : 1250120,
+              "end" : 1767387
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Kelly Madigan",
+              "sprecher" : "Juliane Szalay"
+            },
+            {
+              "rolle" : "Mrs. McGee",
+              "sprecher" : "Alice Krimmel"
+            },
+            {
+              "rolle" : "Toby",
+              "sprecher" : "A. Stengelin"
+            },
+            {
+              "rolle" : "Mrs. Wells",
+              "sprecher" : "Heidi Schaffrath"
+            },
+            {
+              "rolle" : "Junge",
+              "sprecher" : "Linus Tauber"
+            },
+            {
+              "rolle" : "Mädchen",
+              "sprecher" : "Katinka Jaekel"
+            },
+            {
+              "rolle" : "Ericsson",
+              "sprecher" : "Detlef Tams"
+            },
+            {
+              "rolle" : "Sprecher/Moderator",
+              "sprecher" : "Oliver Böttcher"
+            },
+            {
+              "rolle" : "Tarek Shabana",
+              "sprecher" : "Werner Wilkening"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/4/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/4/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 5,
+          "titel" : "Die schwarze PhantOma",
+          "autor" : "Kari Erlhoff",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Wer steckt hinter der unheimlichen Porschefahrerin, von der Justus beinahe überfahren wurde!? Auch Peter wird von ihr mit einem heftigen Fausthieb niedergestreckt! Wer ist die humpelnde Rentnerin, die als \"PhantOma\" in Rocky Beach ihr Unwesen treibt? An Verdächtigen mangelt es keineswegs …",
+          "veröffentlichungsdatum" : "2018-10-28",
+          "kapitel" : [
+            {
+              "titel" : "Wasserdichte Alibis",
+              "start" : 0,
+              "end" : 828067
+            },
+            {
+              "titel" : "Kriminelle Abwege",
+              "start" : 828067,
+              "end" : 1373493
+            },
+            {
+              "titel" : "Tägliches Training",
+              "start" : 1373493,
+              "end" : 2256800
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Tasha",
+              "sprecher" : "Victoria Zöller"
+            },
+            {
+              "rolle" : "Domino Laverna",
+              "sprecher" : "Sabine Hahn"
+            },
+            {
+              "rolle" : "Biff Rodgers, Reporter",
+              "sprecher" : "Daniel Schütter"
+            },
+            {
+              "rolle" : "Lesley Dimple",
+              "sprecher" : "Ann Montenbruck"
+            },
+            {
+              "rolle" : "Zeus Zenon Johnson",
+              "sprecher" : "Michael Prelle"
+            },
+            {
+              "rolle" : "Computer",
+              "sprecher" : "Peter Bayer"
+            },
+            {
+              "rolle" : "Off-Sprecher",
+              "sprecher" : "Frank Roder"
+            },
+            {
+              "rolle" : "Sprecher",
+              "sprecher" : "Andreas Birnbaum"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/5/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/5/ffmetadata.txt"
+          }
+        },
+        {
+          "teilNummer" : 6,
+          "titel" : "Das schwarze Nest",
+          "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
+          "beschreibung" : "Das Telefon klingelt nicht in der Zentrale der drei Detektive. Doch Justus hört es ganz deutlich. Leidet er unter Wahnvorstellungen?\nUnd auch Peter wird von argen Problemen geplagt: Er muss unbedingt das große Sackhüpfturnier gewinnen!\nBob wird endlich aus dem Krankenhaus entlassen und wundert sich über gar nichts mehr …",
+          "veröffentlichungsdatum" : "2018-10-28",
+          "kapitel" : [
+            {
+              "titel" : "Grabesstille",
+              "start" : 0,
+              "end" : 547413
+            },
+            {
+              "titel" : "Demokratische Abstimmung",
+              "start" : 547413,
+              "end" : 1040413
+            },
+            {
+              "titel" : "Fall gelöst",
+              "start" : 1040413,
+              "end" : 1718507
+            }
+          ],
+          "sprechrollen" : [
+            {
+              "rolle" : "Erzähler",
+              "sprecher" : "Axel Milberg"
+            },
+            {
+              "rolle" : "Justus Jonas, Erster Detektiv",
+              "sprecher" : "Oliver Rohrbeck"
+            },
+            {
+              "rolle" : "Peter Shaw, Zweiter Detektiv",
+              "sprecher" : "Jens Wawrczeck"
+            },
+            {
+              "rolle" : "Bob Andrews, Recherchen und Archiv",
+              "sprecher" : "Andreas Fröhlich"
+            },
+            {
+              "rolle" : "Blacky",
+              "sprecher" : "Heikedine Körting",
+              "pseudonym" : "Pamela Punti"
+            },
+            {
+              "rolle" : "Kassiererin",
+              "sprecher" : "Angela Stresemann"
+            },
+            {
+              "rolle" : "Inspektor Cotta",
+              "sprecher" : "Holger Mahlich"
+            }
+          ],
+          "links" : {
+            "json" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/6/metadata.json",
+            "ffmetadata" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/6/ffmetadata.txt"
           }
         }
       ],
@@ -2772,6 +2654,113 @@
         {
           "rolle" : "Inspektor Cotta",
           "sprecher" : "Holger Mahlich"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das schwarze Verlies – Gefesselt",
+              "start" : 0,
+              "end" : 826640
+            },
+            {
+              "titel" : "Das schwarze Verlies – Betäubt",
+              "start" : 826640,
+              "end" : 1316773
+            },
+            {
+              "titel" : "Das schwarze Verlies – Verrostet",
+              "start" : 1316773,
+              "end" : 2240920
+            },
+            {
+              "titel" : "Schwarze Seelen – Ohne Gewissen",
+              "start" : 2240920,
+              "end" : 2886080
+            },
+            {
+              "titel" : "Schwarze Seelen – Ohne Rücksicht",
+              "start" : 2886080,
+              "end" : 3590293
+            },
+            {
+              "titel" : "Schwarze Seelen – Ohne Reue",
+              "start" : 3590293,
+              "end" : 4096840
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein schwarzer Tag für Mr. Kingstone – Unverschämter Kerl",
+              "start" : 0,
+              "end" : 526840
+            },
+            {
+              "titel" : "Ein schwarzer Tag für Mr. Kingstone – Dunkelrestaurant",
+              "start" : 526840,
+              "end" : 1199413
+            },
+            {
+              "titel" : "Ein schwarzer Tag für Mr. Kingstone – Kontaktschranke",
+              "start" : 1199413,
+              "end" : 1889653
+            },
+            {
+              "titel" : "Wer hat Angst vorm Schwarzen Mann – Albtraum?",
+              "start" : 1889653,
+              "end" : 2490707
+            },
+            {
+              "titel" : "Wer hat Angst vorm Schwarzen Mann – Das Herz von Afrika",
+              "start" : 2490707,
+              "end" : 3139773
+            },
+            {
+              "titel" : "Wer hat Angst vorm Schwarzen Mann – Lasso-Künste",
+              "start" : 3139773,
+              "end" : 3657040
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Die schwarze PhantOma – Wasserdichte Alibis",
+              "start" : 0,
+              "end" : 828067
+            },
+            {
+              "titel" : "Die schwarze PhantOma – Kriminelle Abwege",
+              "start" : 828067,
+              "end" : 1373493
+            },
+            {
+              "titel" : "Die schwarze PhantOma – Tägliches Training",
+              "start" : 1373493,
+              "end" : 2256800
+            },
+            {
+              "titel" : "Das schwarze Nest – Grabesstille",
+              "start" : 2256800,
+              "end" : 2804213
+            },
+            {
+              "titel" : "Das schwarze Nest – Demokratische Abstimmung",
+              "start" : 2804213,
+              "end" : 3297213
+            },
+            {
+              "titel" : "Das schwarze Nest – Fall gelöst",
+              "start" : 3297213,
+              "end" : 3975307
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt"
         }
       ],
       "links" : {

--- a/metadata/json/Serie.json
+++ b/metadata/json/Serie.json
@@ -101,6 +101,52 @@
           "sprecher" : "Andreas von der Meden"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Hilferuf",
+              "start" : 0,
+              "end" : 356947
+            },
+            {
+              "titel" : "Ein Papagei spricht Latein",
+              "start" : 356947,
+              "end" : 767720
+            },
+            {
+              "titel" : "Schneewittchen ist verschwunden",
+              "start" : 767720,
+              "end" : 1096187
+            },
+            {
+              "titel" : "Ein unverhoffter Besuch",
+              "start" : 1096187,
+              "end" : 1572827
+            },
+            {
+              "titel" : "Blackbeard, der Pirat",
+              "start" : 1572827,
+              "end" : 2032413
+            },
+            {
+              "titel" : "Die rätselhafte Botschaft",
+              "start" : 2032413,
+              "end" : 2459933
+            },
+            {
+              "titel" : "Von Steinen und Gebeinen",
+              "start" : 2459933,
+              "end" : 2761453
+            },
+            {
+              "titel" : "Blackbeard hat das letzte Wort",
+              "start" : 2761453,
+              "end" : 3144160
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/001/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/001/ffmetadata.txt",
@@ -219,6 +265,52 @@
           "sprecher" : "Katharina Brauren"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Seemannstruhe",
+              "start" : 0,
+              "end" : 262387
+            },
+            {
+              "titel" : "Das Wrack der \"Argyll Queen\"",
+              "start" : 262387,
+              "end" : 706387
+            },
+            {
+              "titel" : "Angriff!",
+              "start" : 706387,
+              "end" : 1062773
+            },
+            {
+              "titel" : "Die Goldgräberstadt",
+              "start" : 1062773,
+              "end" : 1348760
+            },
+            {
+              "titel" : "Beistand aus der Geisterwelt",
+              "start" : 1348760,
+              "end" : 1690440
+            },
+            {
+              "titel" : "Und wieder Java-Jim!",
+              "start" : 1690440,
+              "end" : 2051707
+            },
+            {
+              "titel" : "Der letzte Fingerzeig",
+              "start" : 2051707,
+              "end" : 2451120
+            },
+            {
+              "titel" : "Der Schatz der \"Argyll Queen\"",
+              "start" : 2451120,
+              "end" : 2738933
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/002/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/002/ffmetadata.txt",
@@ -331,6 +423,52 @@
         {
           "rolle" : "Polizist",
           "sprecher" : "Rolf Mamero"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Es spukt bei Mr. Prentice",
+              "start" : 0,
+              "end" : 267507
+            },
+            {
+              "titel" : "Die Paste mit der Zauberkraft",
+              "start" : 267507,
+              "end" : 573387
+            },
+            {
+              "titel" : "Verräterische Flecken",
+              "start" : 573387,
+              "end" : 1003627
+            },
+            {
+              "titel" : "Licht in der Kirche",
+              "start" : 1003627,
+              "end" : 1358413
+            },
+            {
+              "titel" : "Diagnose: Vergiftung",
+              "start" : 1358413,
+              "end" : 1817307
+            },
+            {
+              "titel" : "Es knallt!",
+              "start" : 1817307,
+              "end" : 2021613
+            },
+            {
+              "titel" : "Es brennt!",
+              "start" : 2021613,
+              "end" : 2425933
+            },
+            {
+              "titel" : "Ein perfektes Alibi",
+              "start" : 2425933,
+              "end" : 2748440
+            }
+          ]
         }
       ],
       "links" : {
@@ -459,6 +597,52 @@
           "sprecher" : "Gernot Endemann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Haltet den Dieb",
+              "start" : 0,
+              "end" : 373600
+            },
+            {
+              "titel" : "Peter beweist seinen Mut",
+              "start" : 373600,
+              "end" : 702387
+            },
+            {
+              "titel" : "Andy wundert sich",
+              "start" : 702387,
+              "end" : 1027800
+            },
+            {
+              "titel" : "Wer sucht eine schwarze Katze?",
+              "start" : 1027800,
+              "end" : 1329200
+            },
+            {
+              "titel" : "Der Mann mit der Tätowierung",
+              "start" : 1329200,
+              "end" : 1630253
+            },
+            {
+              "titel" : "In der Falle",
+              "start" : 1630253,
+              "end" : 2019613
+            },
+            {
+              "titel" : "Justus kombiniert",
+              "start" : 2019613,
+              "end" : 2320027
+            },
+            {
+              "titel" : "Der Räuber wird entlarvt",
+              "start" : 2320027,
+              "end" : 2662960
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/004/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/004/ffmetadata.txt",
@@ -570,10 +754,56 @@
           "sprecher" : "Gernot Endemann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Anruf für die drei ???",
+              "start" : 0,
+              "end" : 314733
+            },
+            {
+              "titel" : "Zu Hilfe!",
+              "start" : 314733,
+              "end" : 709453
+            },
+            {
+              "titel" : "Dreipunkt taucht auf",
+              "start" : 709453,
+              "end" : 1031453
+            },
+            {
+              "titel" : "Ein Herr mit schwarzem Schnurrbart",
+              "start" : 1031453,
+              "end" : 1480747
+            },
+            {
+              "titel" : "Bob hat eine Erleuchtung",
+              "start" : 1480747,
+              "end" : 1801347
+            },
+            {
+              "titel" : "Mädchenstimme am Telefon",
+              "start" : 1801347,
+              "end" : 2141040
+            },
+            {
+              "titel" : "Des Rätsels Lösung",
+              "start" : 2141040,
+              "end" : 2547213
+            },
+            {
+              "titel" : "Gebt mir das feurige Auge",
+              "start" : 2547213,
+              "end" : 2960987
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/005/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/005/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/005/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/005/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/005/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/f5/4e/46/f54e4607-2ea1-d765-632e-8a1723d4ba61/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152720if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/71/d2/32/0743213880525.jpg"
@@ -692,6 +922,52 @@
           "sprecher" : "Karl-Ulrich Meves"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Justus kauft einen Koffer",
+              "start" : 0,
+              "end" : 271253
+            },
+            {
+              "titel" : "Ein sonderbarer Besuch",
+              "start" : 271253,
+              "end" : 742653
+            },
+            {
+              "titel" : "Eine geheimnisvolle Botschaft",
+              "start" : 742653,
+              "end" : 1082693
+            },
+            {
+              "titel" : "Abschied von Sokrates",
+              "start" : 1082693,
+              "end" : 1362067
+            },
+            {
+              "titel" : "Warnung vom Polizeichef",
+              "start" : 1362067,
+              "end" : 1672467
+            },
+            {
+              "titel" : "Die drei ??? entdecken Spuren",
+              "start" : 1672467,
+              "end" : 2026640
+            },
+            {
+              "titel" : "Die Suchaktion beginnt",
+              "start" : 2026640,
+              "end" : 2423800
+            },
+            {
+              "titel" : "Wo ist das Geld?",
+              "start" : 2423800,
+              "end" : 2752640
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/006/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/006/ffmetadata.txt",
@@ -790,6 +1066,52 @@
         {
           "rolle" : "Telephonistin",
           "sprecher" : "Reinhilt Schneider"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Ungeheuer aus dem Meer",
+              "start" : 0,
+              "end" : 397493
+            },
+            {
+              "titel" : "Ein merkwürdiges Haus",
+              "start" : 397493,
+              "end" : 778800
+            },
+            {
+              "titel" : "Erste Spuren",
+              "start" : 778800,
+              "end" : 1086893
+            },
+            {
+              "titel" : "Gespenstische Botschaft am Telefon",
+              "start" : 1086893,
+              "end" : 1353707
+            },
+            {
+              "titel" : "Alte Chronik – neue Spur",
+              "start" : 1353707,
+              "end" : 1650093
+            },
+            {
+              "titel" : "Ein Witzbold und sein Werk",
+              "start" : 1650093,
+              "end" : 2096147
+            },
+            {
+              "titel" : "Die Drachenjagd beginnt",
+              "start" : 2096147,
+              "end" : 2466947
+            },
+            {
+              "titel" : "Das Geheimnis des alten Tunnels",
+              "start" : 2466947,
+              "end" : 2721773
+            }
+          ]
         }
       ],
       "links" : {
@@ -913,6 +1235,52 @@
           "sprecher" : "Peter Buchholz"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Schrei in der Nacht",
+              "start" : 0,
+              "end" : 334267
+            },
+            {
+              "titel" : "Die Geheimniskammer",
+              "start" : 334267,
+              "end" : 807813
+            },
+            {
+              "titel" : "Der Geist kehrt wieder",
+              "start" : 807813,
+              "end" : 1253213
+            },
+            {
+              "titel" : "Ein Pferd geht durch",
+              "start" : 1253213,
+              "end" : 1600080
+            },
+            {
+              "titel" : "Wohin mit den Geisterperlen?",
+              "start" : 1600080,
+              "end" : 1860920
+            },
+            {
+              "titel" : "Das Geheimnis der Geisterperlen",
+              "start" : 1860920,
+              "end" : 2460773
+            },
+            {
+              "titel" : "Justus findet eine Spur",
+              "start" : 2460773,
+              "end" : 2810333
+            },
+            {
+              "titel" : "Die rätselhafte 39",
+              "start" : 2810333,
+              "end" : 3203720
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/008/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/008/ffmetadata.txt",
@@ -1029,6 +1397,52 @@
         {
           "rolle" : "Kommissar Reynolds",
           "sprecher" : "Horst Frank"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine schwarze Gestalt",
+              "start" : 0,
+              "end" : 329240
+            },
+            {
+              "titel" : "Kundschaft auf dem Schrottplatz",
+              "start" : 329240,
+              "end" : 705533
+            },
+            {
+              "titel" : "Der Hinkende",
+              "start" : 705533,
+              "end" : 1105853
+            },
+            {
+              "titel" : "Gefangen!",
+              "start" : 1105853,
+              "end" : 1396213
+            },
+            {
+              "titel" : "Ein schwarzes Loch",
+              "start" : 1396213,
+              "end" : 1779253
+            },
+            {
+              "titel" : "Justus kombiniert",
+              "start" : 1779253,
+              "end" : 2396333
+            },
+            {
+              "titel" : "Zick oder Zack?",
+              "start" : 2396333,
+              "end" : 2590587
+            },
+            {
+              "titel" : "Justus bringt es an den Tag",
+              "start" : 2590587,
+              "end" : 2832680
+            }
+          ]
         }
       ],
       "links" : {
@@ -1148,6 +1562,52 @@
           "sprecher" : "Gernot Endemann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine Mumie flüstert",
+              "start" : 0,
+              "end" : 349240
+            },
+            {
+              "titel" : "Der Fluch des Ra-Orkon",
+              "start" : 349240,
+              "end" : 656547
+            },
+            {
+              "titel" : "Überall lauert Gefahr",
+              "start" : 656547,
+              "end" : 1042347
+            },
+            {
+              "titel" : "Eine gelungene Überraschung",
+              "start" : 1042347,
+              "end" : 1515027
+            },
+            {
+              "titel" : "Gefangen",
+              "start" : 1515027,
+              "end" : 1853280
+            },
+            {
+              "titel" : "Auf der Flucht",
+              "start" : 1853280,
+              "end" : 2163933
+            },
+            {
+              "titel" : "Viel zu viele Fragezeichen",
+              "start" : 2163933,
+              "end" : 2543333
+            },
+            {
+              "titel" : "Erstaunliches kommt an den Tag",
+              "start" : 2543333,
+              "end" : 3043693
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/010/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/010/ffmetadata.txt",
@@ -1243,10 +1703,56 @@
           "sprecher" : "Andreas von der Meden"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Man spricht vom Gespensterschloss",
+              "start" : 0,
+              "end" : 305493
+            },
+            {
+              "titel" : "Echo aus dem Jenseits",
+              "start" : 305493,
+              "end" : 666893
+            },
+            {
+              "titel" : "In der Falle!",
+              "start" : 666893,
+              "end" : 1071107
+            },
+            {
+              "titel" : "Der Mann mit der Narbe",
+              "start" : 1071107,
+              "end" : 1449360
+            },
+            {
+              "titel" : "Die Warnung der Zigeunerin",
+              "start" : 1449360,
+              "end" : 1776747
+            },
+            {
+              "titel" : "Das blaue Phantom",
+              "start" : 1776747,
+              "end" : 2224040
+            },
+            {
+              "titel" : "Im Verlies",
+              "start" : 2224040,
+              "end" : 2548187
+            },
+            {
+              "titel" : "Interview mit einem Gespenst",
+              "start" : 2548187,
+              "end" : 2894907
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/011/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/011/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/011/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/011/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/011/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/cd/c3/65/cdc36537-ec11-9175-81ba-869e45908266/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022658if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f6/90/5e/0743213881126.jpg"
@@ -1371,6 +1877,52 @@
           "sprecher" : "Lothar Zibell"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Schrei aus dem Wecker",
+              "start" : 0,
+              "end" : 340360
+            },
+            {
+              "titel" : "Das Zimmer der Uhren",
+              "start" : 340360,
+              "end" : 779387
+            },
+            {
+              "titel" : "Wer ist Rex?",
+              "start" : 779387,
+              "end" : 1168693
+            },
+            {
+              "titel" : "Rätsel über Rätsel",
+              "start" : 1168693,
+              "end" : 1780667
+            },
+            {
+              "titel" : "Der arme Gerald",
+              "start" : 1780667,
+              "end" : 2065293
+            },
+            {
+              "titel" : "Fragen ohne Antwort",
+              "start" : 2065293,
+              "end" : 2260053
+            },
+            {
+              "titel" : "Der Gegner hat die Oberhand",
+              "start" : 2260053,
+              "end" : 2513507
+            },
+            {
+              "titel" : "Überraschende Enthüllungen",
+              "start" : 2513507,
+              "end" : 2736347
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/012/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/012/ffmetadata.txt",
@@ -1491,6 +2043,52 @@
           "sprecher" : "Joachim Wolff"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Es lacht in der Nacht",
+              "start" : 0,
+              "end" : 318947
+            },
+            {
+              "titel" : "Überfall!",
+              "start" : 318947,
+              "end" : 638120
+            },
+            {
+              "titel" : "Eine aufregende Mitteilung",
+              "start" : 638120,
+              "end" : 966907
+            },
+            {
+              "titel" : "Nächtliche Gestalten",
+              "start" : 966907,
+              "end" : 1313267
+            },
+            {
+              "titel" : "Gefangen!",
+              "start" : 1313267,
+              "end" : 1621427
+            },
+            {
+              "titel" : "Justus geht ein Licht auf",
+              "start" : 1621427,
+              "end" : 1978587
+            },
+            {
+              "titel" : "Die Steilwand hinab",
+              "start" : 1978587,
+              "end" : 2346280
+            },
+            {
+              "titel" : "Der Schatz der Chumash",
+              "start" : 2346280,
+              "end" : 2640320
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/013/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/013/ffmetadata.txt",
@@ -1604,6 +2202,52 @@
         {
           "rolle" : "Lieferant",
           "sprecher" : "Franz-Josef Steffens"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein seltsamer Empfang",
+              "start" : 0,
+              "end" : 349613
+            },
+            {
+              "titel" : "Wer schleicht durch die Nacht?",
+              "start" : 349613,
+              "end" : 716013
+            },
+            {
+              "titel" : "Der Monsterberg",
+              "start" : 716013,
+              "end" : 1155747
+            },
+            {
+              "titel" : "Das wilde Tier aus dem Wald",
+              "start" : 1155747,
+              "end" : 1335227
+            },
+            {
+              "titel" : "Spur von nackten Sohlen",
+              "start" : 1335227,
+              "end" : 1741573
+            },
+            {
+              "titel" : "Justus blickt nicht mehr durch",
+              "start" : 1741573,
+              "end" : 1990573
+            },
+            {
+              "titel" : "Der Berg brennt!",
+              "start" : 1990573,
+              "end" : 2305467
+            },
+            {
+              "titel" : "Die Doppelgängerin",
+              "start" : 2305467,
+              "end" : 2550187
+            }
+          ]
         }
       ],
       "links" : {
@@ -1726,6 +2370,52 @@
           "sprecher" : "Joachim Wolff"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Fall im Löwenrevier",
+              "start" : 0,
+              "end" : 309587
+            },
+            {
+              "titel" : "Mit knapper Not entkommen",
+              "start" : 309587,
+              "end" : 611520
+            },
+            {
+              "titel" : "Immer Ärger mit George",
+              "start" : 611520,
+              "end" : 867800
+            },
+            {
+              "titel" : "Ein sturer Kunde mit Sonderwünschen",
+              "start" : 867800,
+              "end" : 1184587
+            },
+            {
+              "titel" : "Wirbel um einen Gorilla",
+              "start" : 1184587,
+              "end" : 1519467
+            },
+            {
+              "titel" : "Die verschlüsselte Botschaft",
+              "start" : 1519467,
+              "end" : 1746987
+            },
+            {
+              "titel" : "Eisenstäbe",
+              "start" : 1746987,
+              "end" : 2028987
+            },
+            {
+              "titel" : "Des Rätsels Lösung",
+              "start" : 2028987,
+              "end" : 2385253
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/015/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/015/ffmetadata.txt",
@@ -1832,6 +2522,52 @@
         {
           "rolle" : "Brotverkäufer",
           "sprecher" : "Harald Pages"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Haltet den Dieb!",
+              "start" : 0,
+              "end" : 387133
+            },
+            {
+              "titel" : "Chiavos Fluch",
+              "start" : 387133,
+              "end" : 639960
+            },
+            {
+              "titel" : "Justus wittert ein Geheimnis",
+              "start" : 639960,
+              "end" : 916000
+            },
+            {
+              "titel" : "Spuk im Spiegel",
+              "start" : 916000,
+              "end" : 1268573
+            },
+            {
+              "titel" : "Ein rätselhafter Brief",
+              "start" : 1268573,
+              "end" : 1570680
+            },
+            {
+              "titel" : "Verräterisches Glockenspiel",
+              "start" : 1570680,
+              "end" : 1927947
+            },
+            {
+              "titel" : "Wettlauf gegen die Uhr",
+              "start" : 1927947,
+              "end" : 2204560
+            },
+            {
+              "titel" : "Der Spiegel gibt sein Geheimnis preis",
+              "start" : 2204560,
+              "end" : 2551347
+            }
+          ]
         }
       ],
       "links" : {
@@ -1944,6 +2680,52 @@
         {
           "rolle" : "Kellnerin",
           "sprecher" : "Heidi Schaffrath"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Dingo Townes Aufforderung zum Wettstreit",
+              "start" : 0,
+              "end" : 436107
+            },
+            {
+              "titel" : "Wo der Windhund haust",
+              "start" : 436107,
+              "end" : 741333
+            },
+            {
+              "titel" : "Ein gefährlicher Bubenstreich",
+              "start" : 741333,
+              "end" : 1003880
+            },
+            {
+              "titel" : "Peter behält einen klaren Kopf",
+              "start" : 1003880,
+              "end" : 1259173
+            },
+            {
+              "titel" : "Der Alte aus dem Busch",
+              "start" : 1259173,
+              "end" : 1622200
+            },
+            {
+              "titel" : "Raus, wenn du kannst!",
+              "start" : 1622200,
+              "end" : 1981840
+            },
+            {
+              "titel" : "Noch ein Rätsel gelöst",
+              "start" : 1981840,
+              "end" : 2286467
+            },
+            {
+              "titel" : "Justus stellt eine Falle",
+              "start" : 2286467,
+              "end" : 2524840
+            }
+          ]
         }
       ],
       "links" : {
@@ -2065,6 +2847,52 @@
           "sprecher" : "Marianne Kehlau"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Unerwarteter Empfang",
+              "start" : 0,
+              "end" : 367720
+            },
+            {
+              "titel" : "Das Gespenst tritt auf",
+              "start" : 367720,
+              "end" : 694373
+            },
+            {
+              "titel" : "Endlich auf der Geisterinsel",
+              "start" : 694373,
+              "end" : 881747
+            },
+            {
+              "titel" : "Ein Totenschädel spricht",
+              "start" : 881747,
+              "end" : 1304760
+            },
+            {
+              "titel" : "Der erste Fund",
+              "start" : 1304760,
+              "end" : 1726600
+            },
+            {
+              "titel" : "Die Katastrophe",
+              "start" : 1726600,
+              "end" : 2005240
+            },
+            {
+              "titel" : "Eine aufregende Entdeckung",
+              "start" : 2005240,
+              "end" : 2340840
+            },
+            {
+              "titel" : "Rettung in letzter Minute",
+              "start" : 2340840,
+              "end" : 2606493
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/018/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/018/ffmetadata.txt",
@@ -2174,6 +3002,52 @@
         {
           "rolle" : "Taucher",
           "sprecher" : "Joachim Richert"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Im Tal der Wehklagen",
+              "start" : 0,
+              "end" : 264773
+            },
+            {
+              "titel" : "El Diablos Flucht",
+              "start" : 264773,
+              "end" : 737853
+            },
+            {
+              "titel" : "El Diablos Höhle",
+              "start" : 737853,
+              "end" : 1058320
+            },
+            {
+              "titel" : "Auf gefährlichem Weg",
+              "start" : 1058320,
+              "end" : 1335413
+            },
+            {
+              "titel" : "Jetzt wird ermittelt",
+              "start" : 1335413,
+              "end" : 1547973
+            },
+            {
+              "titel" : "Justus enthüllt einen Plan",
+              "start" : 1547973,
+              "end" : 1903240
+            },
+            {
+              "titel" : "Das blanke schwarze Wesen",
+              "start" : 1903240,
+              "end" : 2382093
+            },
+            {
+              "titel" : "Maske ab für El Diablo",
+              "start" : 2382093,
+              "end" : 2676573
+            }
+          ]
         }
       ],
       "links" : {
@@ -2289,6 +3163,52 @@
         {
           "rolle" : "Polizist",
           "sprecher" : "Hans Irle"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "»Der Potter« tritt auf – und wieder ab",
+              "start" : 0,
+              "end" : 460560
+            },
+            {
+              "titel" : "Zu viele Neue auf der Szene",
+              "start" : 460560,
+              "end" : 815293
+            },
+            {
+              "titel" : "Morton wird eingeschaltet",
+              "start" : 815293,
+              "end" : 1052973
+            },
+            {
+              "titel" : "Das Haus auf dem Hügel",
+              "start" : 1052973,
+              "end" : 1399293
+            },
+            {
+              "titel" : "Es spukt schon wieder",
+              "start" : 1399293,
+              "end" : 1731107
+            },
+            {
+              "titel" : "Fischt der feine Angler im Trüben?",
+              "start" : 1731107,
+              "end" : 1996360
+            },
+            {
+              "titel" : "Die Falle schnappt zu",
+              "start" : 1996360,
+              "end" : 2307520
+            },
+            {
+              "titel" : "Man wird handelseinig",
+              "start" : 2307520,
+              "end" : 2816907
+            }
+          ]
         }
       ],
       "links" : {
@@ -2411,6 +3331,52 @@
         {
           "rolle" : "Butler",
           "sprecher" : "Hans Daniel"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Puppe entflogen",
+              "start" : 0,
+              "end" : 304827
+            },
+            {
+              "titel" : "Die Falle schnappt zu",
+              "start" : 304827,
+              "end" : 550973
+            },
+            {
+              "titel" : "Der Dämon greift an!",
+              "start" : 550973,
+              "end" : 909173
+            },
+            {
+              "titel" : "Der schwarze Koffer",
+              "start" : 909173,
+              "end" : 1270027
+            },
+            {
+              "titel" : "Dem Schurken auf der Spur",
+              "start" : 1270027,
+              "end" : 1714560
+            },
+            {
+              "titel" : "Der tanzende Teufel schlägt zu!",
+              "start" : 1714560,
+              "end" : 2177067
+            },
+            {
+              "titel" : "Das Gesicht am Fenster",
+              "start" : 2177067,
+              "end" : 2372280
+            },
+            {
+              "titel" : "Maske ab für den Teufel!",
+              "start" : 2372280,
+              "end" : 2547813
+            }
+          ]
         }
       ],
       "links" : {
@@ -2539,6 +3505,52 @@
           "sprecher" : "Peter Kirchberger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Aufregung im Museum",
+              "start" : 0,
+              "end" : 252413
+            },
+            {
+              "titel" : "Spuk am Fenster",
+              "start" : 252413,
+              "end" : 562747
+            },
+            {
+              "titel" : "Von Gnomen und Zwergen",
+              "start" : 562747,
+              "end" : 943533
+            },
+            {
+              "titel" : "Ein unerwarteter Besuch",
+              "start" : 943533,
+              "end" : 1308347
+            },
+            {
+              "titel" : "Ein finsterer Plan wird enthüllt",
+              "start" : 1308347,
+              "end" : 1615907
+            },
+            {
+              "titel" : "Bob sucht seine Freunde",
+              "start" : 1615907,
+              "end" : 1922760
+            },
+            {
+              "titel" : "Die Spur verliert sich",
+              "start" : 1922760,
+              "end" : 2286347
+            },
+            {
+              "titel" : "Überraschungsangriff",
+              "start" : 2286347,
+              "end" : 2635960
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/022/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/022/ffmetadata.txt",
@@ -2662,6 +3674,52 @@
         {
           "rolle" : "Mr. Shaw",
           "sprecher" : "Franz-Josef Steffens"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Es geht hart auf hart",
+              "start" : 0,
+              "end" : 307133
+            },
+            {
+              "titel" : "Feuer!",
+              "start" : 307133,
+              "end" : 665760
+            },
+            {
+              "titel" : "Die Suche beginnt",
+              "start" : 665760,
+              "end" : 949947
+            },
+            {
+              "titel" : "Die alte Landkarte",
+              "start" : 949947,
+              "end" : 1275560
+            },
+            {
+              "titel" : "Der Sheriff waltet seines Amtes",
+              "start" : 1275560,
+              "end" : 1587587
+            },
+            {
+              "titel" : "Entdeckung in der Brandruine",
+              "start" : 1587587,
+              "end" : 1914053
+            },
+            {
+              "titel" : "Das Versteck",
+              "start" : 1914053,
+              "end" : 2245960
+            },
+            {
+              "titel" : "Das Schwert des Cortez",
+              "start" : 2245960,
+              "end" : 2565680
+            }
+          ]
         }
       ],
       "links" : {
@@ -2789,6 +3847,52 @@
           "sprecher" : "Andreas von der Meden"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Um Haaresbreite",
+              "start" : 0,
+              "end" : 371640
+            },
+            {
+              "titel" : "Die silberne Spinne",
+              "start" : 371640,
+              "end" : 669107
+            },
+            {
+              "titel" : "Lauter Verdächtige",
+              "start" : 669107,
+              "end" : 869293
+            },
+            {
+              "titel" : "Finstere Pläne",
+              "start" : 869293,
+              "end" : 1264667
+            },
+            {
+              "titel" : "Ein unverhoffter Fund",
+              "start" : 1264667,
+              "end" : 1549573
+            },
+            {
+              "titel" : "Bobs Gedächtnislücke",
+              "start" : 1549573,
+              "end" : 2035467
+            },
+            {
+              "titel" : "In die Kanäle",
+              "start" : 2035467,
+              "end" : 2333520
+            },
+            {
+              "titel" : "Die Magnus-Glocke",
+              "start" : 2333520,
+              "end" : 2537893
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/024/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/024/ffmetadata.txt",
@@ -2908,6 +4012,52 @@
           "sprecher" : "Wolfgang Kaven"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Mädchen auf der Schimmelstute",
+              "start" : 0,
+              "end" : 329573
+            },
+            {
+              "titel" : "Die singende Schlange",
+              "start" : 329573,
+              "end" : 685253
+            },
+            {
+              "titel" : "Das Haus am Torrente Canyon",
+              "start" : 685253,
+              "end" : 1089413
+            },
+            {
+              "titel" : "Ein Opfer der Schlange",
+              "start" : 1089413,
+              "end" : 1579707
+            },
+            {
+              "titel" : "Bentleys Geheimakten",
+              "start" : 1579707,
+              "end" : 1869867
+            },
+            {
+              "titel" : "Die Diamanten der Kaiserin",
+              "start" : 1869867,
+              "end" : 2104413
+            },
+            {
+              "titel" : "Dr. Shaitans Geister",
+              "start" : 2104413,
+              "end" : 2420880
+            },
+            {
+              "titel" : "Die Schlange bringt neues Unheil",
+              "start" : 2420880,
+              "end" : 2782427
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/025/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/025/ffmetadata.txt",
@@ -3013,6 +4163,52 @@
         {
           "rolle" : "Gasper",
           "sprecher" : "Rolf Mamero"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Einladung",
+              "start" : 0,
+              "end" : 317267
+            },
+            {
+              "titel" : "Schüsse im Dunkeln",
+              "start" : 317267,
+              "end" : 695920
+            },
+            {
+              "titel" : "Die Todesfalle!",
+              "start" : 695920,
+              "end" : 1133680
+            },
+            {
+              "titel" : "Da schleicht einer durch die Nacht",
+              "start" : 1133680,
+              "end" : 1310427
+            },
+            {
+              "titel" : "Glimmer oder Gold?",
+              "start" : 1310427,
+              "end" : 1531093
+            },
+            {
+              "titel" : "Mundraub",
+              "start" : 1531093,
+              "end" : 1795573
+            },
+            {
+              "titel" : "Der Wachhund, der nicht bellte",
+              "start" : 1795573,
+              "end" : 2214640
+            },
+            {
+              "titel" : "Wo ist die Beute?",
+              "start" : 2214640,
+              "end" : 2628080
+            }
+          ]
         }
       ],
       "links" : {
@@ -3125,6 +4321,52 @@
         {
           "rolle" : "Schrottplatzwart",
           "sprecher" : "Siegfried Wald"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Feuer!",
+              "start" : 0,
+              "end" : 404307
+            },
+            {
+              "titel" : "Ein Unglück kommt selten allein",
+              "start" : 404307,
+              "end" : 794467
+            },
+            {
+              "titel" : "Ist Hexerei im Spiel?",
+              "start" : 794467,
+              "end" : 1096667
+            },
+            {
+              "titel" : "Der magische Kreis",
+              "start" : 1096667,
+              "end" : 1555480
+            },
+            {
+              "titel" : "Endstation Kofferraum",
+              "start" : 1555480,
+              "end" : 1978227
+            },
+            {
+              "titel" : "Dornröschen",
+              "start" : 1978227,
+              "end" : 2297867
+            },
+            {
+              "titel" : "Eine Verschwörung",
+              "start" : 2297867,
+              "end" : 2662400
+            },
+            {
+              "titel" : "Party mit Überraschungseffekt",
+              "start" : 2662400,
+              "end" : 3108893
+            }
+          ]
         }
       ],
       "links" : {
@@ -3249,6 +4491,52 @@
           "sprecher" : "Hubert Mittendorf"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Menschenraub!",
+              "start" : 0,
+              "end" : 400267
+            },
+            {
+              "titel" : "Den Schurken auf der Spur",
+              "start" : 400267,
+              "end" : 663627
+            },
+            {
+              "titel" : "Entwischt!",
+              "start" : 663627,
+              "end" : 1077600
+            },
+            {
+              "titel" : "Freunde oder Feinde?",
+              "start" : 1077600,
+              "end" : 1440787
+            },
+            {
+              "titel" : "Djangas Stätte",
+              "start" : 1440787,
+              "end" : 1691213
+            },
+            {
+              "titel" : "Hier endet die Spur",
+              "start" : 1691213,
+              "end" : 2158347
+            },
+            {
+              "titel" : "Das Ebenbild",
+              "start" : 2158347,
+              "end" : 2588107
+            },
+            {
+              "titel" : "Der Gegner steht vor einem Problem",
+              "start" : 2588107,
+              "end" : 2875787
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/028/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/028/ffmetadata.txt",
@@ -3334,8 +4622,85 @@
           "end" : 2980667
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Titelsong",
+              "start" : 0,
+              "end" : 189893
+            },
+            {
+              "titel" : "Der heimliche Hehler",
+              "start" : 189893,
+              "end" : 374400
+            },
+            {
+              "titel" : "Tatort Zirkus",
+              "start" : 374400,
+              "end" : 540800
+            },
+            {
+              "titel" : "Geisterinsel",
+              "start" : 540800,
+              "end" : 656827
+            },
+            {
+              "titel" : "Musikpiraten",
+              "start" : 656827,
+              "end" : 859400
+            },
+            {
+              "titel" : "Schüsse aus dem Dunkel",
+              "start" : 859400,
+              "end" : 1060493
+            },
+            {
+              "titel" : "Drei ??? Rap",
+              "start" : 1060493,
+              "end" : 1395067
+            },
+            {
+              "titel" : "Der riskante Ritt",
+              "start" : 1395067,
+              "end" : 1641000
+            },
+            {
+              "titel" : "Der lachende Schatten",
+              "start" : 1641000,
+              "end" : 1776467
+            },
+            {
+              "titel" : "Stimmen aus dem Nichts",
+              "start" : 1776467,
+              "end" : 2115693
+            },
+            {
+              "titel" : "Die verschwundene Seglerin",
+              "start" : 2115693,
+              "end" : 2318027
+            },
+            {
+              "titel" : "Die bedrohte Ranch",
+              "start" : 2318027,
+              "end" : 2488627
+            },
+            {
+              "titel" : "Diamantenschmuggel",
+              "start" : 2488627,
+              "end" : 2695893
+            },
+            {
+              "titel" : "Titelsong",
+              "start" : 2695893,
+              "end" : 2980667
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/029/metadata.json",
+        "ffmetadata" : "http://dreimetadaten.de/data/Serie/029/ffmetadata.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/029/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music69/v4/db/7c/27/db7c27d4-f4e5-378a-188a-5ab6b5d17220/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023020if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/9f/12/d1/0743213882925.jpg"
@@ -3434,7 +4799,7 @@
         },
         {
           "rolle" : "Berg",
-          "sprecher" : "Andreas E. Beurmann / Wolfgang Draeger"
+          "sprecher" : "Andreas E. Beurmann, Wolfgang Draeger"
         },
         {
           "rolle" : "Yamura",
@@ -3447,6 +4812,52 @@
         {
           "rolle" : "Weston",
           "sprecher" : "Joachim Richert"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Rätselhafter Schwund",
+              "start" : 0,
+              "end" : 288453
+            },
+            {
+              "titel" : "Ein Schnüffler",
+              "start" : 288453,
+              "end" : 578347
+            },
+            {
+              "titel" : "Justus weiß eine Erklärung",
+              "start" : 578347,
+              "end" : 963613
+            },
+            {
+              "titel" : "Peter hat es erfasst",
+              "start" : 963613,
+              "end" : 1251253
+            },
+            {
+              "titel" : "Der Haifänger",
+              "start" : 1251253,
+              "end" : 1548573
+            },
+            {
+              "titel" : "Das Ungetüm aus dem Meer",
+              "start" : 1548573,
+              "end" : 1929387
+            },
+            {
+              "titel" : "Das Riff der Haie und sein Geheimnis",
+              "start" : 1929387,
+              "end" : 2294893
+            },
+            {
+              "titel" : "Qualm und List",
+              "start" : 2294893,
+              "end" : 2522293
+            }
+          ]
         }
       ],
       "links" : {
@@ -3570,6 +4981,52 @@
           "sprecher" : "Joachim Richert"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Blinder läuft davon",
+              "start" : 0,
+              "end" : 413907
+            },
+            {
+              "titel" : "Ein neuer Fall für die drei ???",
+              "start" : 413907,
+              "end" : 800533
+            },
+            {
+              "titel" : "Mr. Bonestells Bericht",
+              "start" : 800533,
+              "end" : 1205347
+            },
+            {
+              "titel" : "Neue Fährten",
+              "start" : 1205347,
+              "end" : 1483067
+            },
+            {
+              "titel" : "Die Terroristen",
+              "start" : 1483067,
+              "end" : 1816760
+            },
+            {
+              "titel" : "Die Warnung",
+              "start" : 1816760,
+              "end" : 2102840
+            },
+            {
+              "titel" : "Ernie macht Geschäfte",
+              "start" : 2102840,
+              "end" : 2558907
+            },
+            {
+              "titel" : "Ein Alptraum wird wahr!",
+              "start" : 2558907,
+              "end" : 2984573
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/031/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/031/ffmetadata.txt",
@@ -3685,6 +5142,52 @@
         {
           "rolle" : "Patrick",
           "sprecher" : "Joachim Richert"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Ameisenmensch",
+              "start" : 0,
+              "end" : 368307
+            },
+            {
+              "titel" : "Die verrückte Dame",
+              "start" : 368307,
+              "end" : 617733
+            },
+            {
+              "titel" : "Ein schlimmer Schock",
+              "start" : 617733,
+              "end" : 1006453
+            },
+            {
+              "titel" : "Der rätselhafte Späher",
+              "start" : 1006453,
+              "end" : 1321267
+            },
+            {
+              "titel" : "Die Vogelscheuche schlägt zu!",
+              "start" : 1321267,
+              "end" : 1762720
+            },
+            {
+              "titel" : "Eingesperrt!",
+              "start" : 1762720,
+              "end" : 2061227
+            },
+            {
+              "titel" : "Justus zieht seine Schlüsse",
+              "start" : 2061227,
+              "end" : 2397307
+            },
+            {
+              "titel" : "Die Überraschung zum Schluss",
+              "start" : 2397307,
+              "end" : 2652653
+            }
+          ]
         }
       ],
       "links" : {
@@ -3803,6 +5306,52 @@
           "sprecher" : "Horst Frank"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein reizbarer Herr",
+              "start" : 0,
+              "end" : 254627
+            },
+            {
+              "titel" : "Die Festung",
+              "start" : 254627,
+              "end" : 555320
+            },
+            {
+              "titel" : "Ausgang verboten",
+              "start" : 555320,
+              "end" : 850427
+            },
+            {
+              "titel" : "Invasion",
+              "start" : 850427,
+              "end" : 1309533
+            },
+            {
+              "titel" : "Ein unschuldiges Opfer",
+              "start" : 1309533,
+              "end" : 1562213
+            },
+            {
+              "titel" : "Es darf spioniert werden",
+              "start" : 1562213,
+              "end" : 1888827
+            },
+            {
+              "titel" : "Justus hat eine Erleuchtung",
+              "start" : 1888827,
+              "end" : 2224173
+            },
+            {
+              "titel" : "Geht die Welt unter?",
+              "start" : 2224173,
+              "end" : 2657067
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/033/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/033/ffmetadata.txt",
@@ -3900,6 +5449,52 @@
         {
           "rolle" : "Sam Davis",
           "sprecher" : "Utz Richter"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Banditen, Briganten und Seeräuber!",
+              "start" : 0,
+              "end" : 409747
+            },
+            {
+              "titel" : "Betrug!",
+              "start" : 409747,
+              "end" : 681173
+            },
+            {
+              "titel" : "Piratenüberfall!",
+              "start" : 681173,
+              "end" : 1038387
+            },
+            {
+              "titel" : "Nächtliche Pirsch",
+              "start" : 1038387,
+              "end" : 1303107
+            },
+            {
+              "titel" : "Prallvolle Säcke",
+              "start" : 1303107,
+              "end" : 1623267
+            },
+            {
+              "titel" : "Der Rote Pirat schlägt wieder zu",
+              "start" : 1623267,
+              "end" : 2029507
+            },
+            {
+              "titel" : "Gefangen",
+              "start" : 2029507,
+              "end" : 2370267
+            },
+            {
+              "titel" : "Nun wendet sich das Blatt",
+              "start" : 2370267,
+              "end" : 2640213
+            }
+          ]
         }
       ],
       "links" : {
@@ -4030,6 +5625,52 @@
           "sprecher" : "Edgar Bessen"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Unbekannte",
+              "start" : 0,
+              "end" : 312493
+            },
+            {
+              "titel" : "Böses Blut!",
+              "start" : 312493,
+              "end" : 748653
+            },
+            {
+              "titel" : "Besuch bei einem Toten",
+              "start" : 748653,
+              "end" : 1129800
+            },
+            {
+              "titel" : "Es tut sich was in Citrus Grove",
+              "start" : 1129800,
+              "end" : 1615347
+            },
+            {
+              "titel" : "Die Fußspur mit den vier Zehen",
+              "start" : 1615347,
+              "end" : 2007507
+            },
+            {
+              "titel" : "Noch ein Diebstahl",
+              "start" : 2007507,
+              "end" : 2463933
+            },
+            {
+              "titel" : "Fragen über Fragen",
+              "start" : 2463933,
+              "end" : 2815253
+            },
+            {
+              "titel" : "Tatmotiv: eine Million Dollar",
+              "start" : 2815253,
+              "end" : 3255933
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/035/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/035/ffmetadata.txt",
@@ -4127,6 +5768,52 @@
         {
           "rolle" : "Ocean-World-Mitarbeiter",
           "sprecher" : "Peter Lakenmacher, Christian Rode"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Lebensretter",
+              "start" : 0,
+              "end" : 374880
+            },
+            {
+              "titel" : "\"Ocean World\" – Die Welt des Ozeans",
+              "start" : 374880,
+              "end" : 720507
+            },
+            {
+              "titel" : "Jetzt aber los",
+              "start" : 720507,
+              "end" : 1043360
+            },
+            {
+              "titel" : "Der Mann mit dem eigenartigen rechten Auge",
+              "start" : 1043360,
+              "end" : 1445853
+            },
+            {
+              "titel" : "Die beiden langen Stangen",
+              "start" : 1445853,
+              "end" : 1826053
+            },
+            {
+              "titel" : "Die verlorene Fracht",
+              "start" : 1826053,
+              "end" : 2189133
+            },
+            {
+              "titel" : "Flukeys Lied",
+              "start" : 2189133,
+              "end" : 2524133
+            },
+            {
+              "titel" : "Was in der Kassette war",
+              "start" : 2524133,
+              "end" : 2896187
+            }
+          ]
         }
       ],
       "links" : {
@@ -4236,6 +5923,52 @@
           "sprecher" : "Günther Dockerill"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der kleine Ausreißer",
+              "start" : 0,
+              "end" : 548107
+            },
+            {
+              "titel" : "Es kommt ganz schlimm!",
+              "start" : 548107,
+              "end" : 984133
+            },
+            {
+              "titel" : "Böse Zungen",
+              "start" : 984133,
+              "end" : 1282507
+            },
+            {
+              "titel" : "Ein Dieb geht baden",
+              "start" : 1282507,
+              "end" : 1615600
+            },
+            {
+              "titel" : "Grauen unter Wasser!",
+              "start" : 1615600,
+              "end" : 2036120
+            },
+            {
+              "titel" : "Antworten werfen neue Fragen auf",
+              "start" : 2036120,
+              "end" : 2404280
+            },
+            {
+              "titel" : "Ein verborgener Schatz!",
+              "start" : 2404280,
+              "end" : 2763693
+            },
+            {
+              "titel" : "Justus entwickelt eine Theorie",
+              "start" : 2763693,
+              "end" : 3293027
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/037/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/037/ffmetadata.txt",
@@ -4335,6 +6068,52 @@
           "sprecher" : "Ingrid Andree"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine wandelnde Katastrophe",
+              "start" : 0,
+              "end" : 306440
+            },
+            {
+              "titel" : "Das Abenteuer beginnt",
+              "start" : 306440,
+              "end" : 635640
+            },
+            {
+              "titel" : "Feuer als Ablenkungsmanöver",
+              "start" : 635640,
+              "end" : 986160
+            },
+            {
+              "titel" : "Hier ist doch etwas faul",
+              "start" : 986160,
+              "end" : 1269787
+            },
+            {
+              "titel" : "Ein tollkühner Schachzug",
+              "start" : 1269787,
+              "end" : 1548760
+            },
+            {
+              "titel" : "Bob in der Klemme",
+              "start" : 1548760,
+              "end" : 2019613
+            },
+            {
+              "titel" : "Top Secret",
+              "start" : 2019613,
+              "end" : 2256893
+            },
+            {
+              "titel" : "Kein Ausweg für den Täter",
+              "start" : 2256893,
+              "end" : 2552053
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/038/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/038/ffmetadata.txt",
@@ -4420,6 +6199,52 @@
         {
           "rolle" : "Frisbee",
           "sprecher" : "Hans Paetsch"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Mann mit dem Zwinker-Tick",
+              "start" : 0,
+              "end" : 439920
+            },
+            {
+              "titel" : "Die Frau mit dem Vogel-Tick",
+              "start" : 439920,
+              "end" : 788440
+            },
+            {
+              "titel" : "Ein Mörder raubt Vögel",
+              "start" : 788440,
+              "end" : 1168840
+            },
+            {
+              "titel" : "Wo ist das Bindeglied?",
+              "start" : 1168840,
+              "end" : 1431160
+            },
+            {
+              "titel" : "Vergiftet?",
+              "start" : 1431160,
+              "end" : 1803747
+            },
+            {
+              "titel" : "Bewaffnete Aufsicht",
+              "start" : 1803747,
+              "end" : 2148827
+            },
+            {
+              "titel" : "Wer mit wem?",
+              "start" : 2148827,
+              "end" : 2537520
+            },
+            {
+              "titel" : "Hände hoch!",
+              "start" : 2537520,
+              "end" : 2873960
+            }
+          ]
         }
       ],
       "links" : {
@@ -4549,6 +6374,52 @@
           "sprecher" : "Lothar Grützner, Hans Hessling"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Zerbrochene Scheiben",
+              "start" : 0,
+              "end" : 335080
+            },
+            {
+              "titel" : "Justus entdeckt ein Schema",
+              "start" : 335080,
+              "end" : 644267
+            },
+            {
+              "titel" : "Anklage gegen die drei ???",
+              "start" : 644267,
+              "end" : 915480
+            },
+            {
+              "titel" : "Ein gestohlener Adler",
+              "start" : 915480,
+              "end" : 1411267
+            },
+            {
+              "titel" : "Der Täter, der nicht auffällt",
+              "start" : 1411267,
+              "end" : 1731587
+            },
+            {
+              "titel" : "Die nächste Telefonlawine rollt",
+              "start" : 1731587,
+              "end" : 2094680
+            },
+            {
+              "titel" : "Wer ist der Täter?",
+              "start" : 2094680,
+              "end" : 2402280
+            },
+            {
+              "titel" : "Ein Gewalttäter wird geschnappt",
+              "start" : 2402280,
+              "end" : 2821360
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/040/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/040/ffmetadata.txt",
@@ -4654,6 +6525,52 @@
         {
           "rolle" : "Kellner",
           "sprecher" : "Helmut Ahner"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Hilferuf",
+              "start" : 0,
+              "end" : 396627
+            },
+            {
+              "titel" : "Der Neffe und sein Anwalt",
+              "start" : 396627,
+              "end" : 867053
+            },
+            {
+              "titel" : "Gesucht: Ein verschollener Indianerstamm",
+              "start" : 867053,
+              "end" : 1296680
+            },
+            {
+              "titel" : "Peter findet den \"Tanzenden Saurier\"",
+              "start" : 1296680,
+              "end" : 1617853
+            },
+            {
+              "titel" : "Auf nach Comina!",
+              "start" : 1617853,
+              "end" : 1959653
+            },
+            {
+              "titel" : "Entdeckungen in der Höhle",
+              "start" : 1959653,
+              "end" : 2402427
+            },
+            {
+              "titel" : "Pamir, der Stammeshäuptling",
+              "start" : 2402427,
+              "end" : 2846920
+            },
+            {
+              "titel" : "Kommt das Erdbeben?",
+              "start" : 2846920,
+              "end" : 3214520
+            }
+          ]
         }
       ],
       "links" : {
@@ -4777,6 +6694,52 @@
         {
           "rolle" : "Rossings Assistentin",
           "sprecher" : "Claudia Schermutzki"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Können Totenköpfe weinen?",
+              "start" : 0,
+              "end" : 322667
+            },
+            {
+              "titel" : "Einbruch in die Villa Markels!",
+              "start" : 322667,
+              "end" : 729173
+            },
+            {
+              "titel" : "Ein Mann mit rotem Schnauzbart",
+              "start" : 729173,
+              "end" : 1131587
+            },
+            {
+              "titel" : "Panne beim Kunsthandel",
+              "start" : 1131587,
+              "end" : 1422933
+            },
+            {
+              "titel" : "Ein rätselhaftes Testament",
+              "start" : 1422933,
+              "end" : 1816467
+            },
+            {
+              "titel" : "Drei Arten, einen Sarg zu betrachten",
+              "start" : 1816467,
+              "end" : 2151027
+            },
+            {
+              "titel" : "Scherben bringen es an den Tag",
+              "start" : 2151027,
+              "end" : 2469773
+            },
+            {
+              "titel" : "Die allerletzte Hürde",
+              "start" : 2469773,
+              "end" : 2869227
+            }
+          ]
         }
       ],
       "links" : {
@@ -4910,6 +6873,52 @@
           "sprecher" : "Niki Nowotny"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Rätselhafter Fund",
+              "start" : 0,
+              "end" : 271987
+            },
+            {
+              "titel" : "Ein Werwolf in Hollywood",
+              "start" : 271987,
+              "end" : 641320
+            },
+            {
+              "titel" : "Eine neue Spur",
+              "start" : 641320,
+              "end" : 1068587
+            },
+            {
+              "titel" : "Draculas Rückkehr",
+              "start" : 1068587,
+              "end" : 1522880
+            },
+            {
+              "titel" : "Eine Dame verschwindet",
+              "start" : 1522880,
+              "end" : 1828680
+            },
+            {
+              "titel" : "Überfall!",
+              "start" : 1828680,
+              "end" : 2176107
+            },
+            {
+              "titel" : "Gefährlicher Absturz",
+              "start" : 2176107,
+              "end" : 2555973
+            },
+            {
+              "titel" : "Flucht ins Ungewisse",
+              "start" : 2555973,
+              "end" : 3050920
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/043/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/043/ffmetadata.txt",
@@ -5016,6 +7025,52 @@
         {
           "rolle" : "Gordon Harker",
           "sprecher" : "Stefan Brönneke"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Justus' geheime Vergangenheit",
+              "start" : 0,
+              "end" : 377787
+            },
+            {
+              "titel" : "Überraschung in Studio Neun",
+              "start" : 377787,
+              "end" : 763613
+            },
+            {
+              "titel" : "Fahndung hinter den Kulissen",
+              "start" : 763613,
+              "end" : 1081253
+            },
+            {
+              "titel" : "Quiz Nummer eins",
+              "start" : 1081253,
+              "end" : 1514413
+            },
+            {
+              "titel" : "Beschattungsmanöver in Hollywood",
+              "start" : 1514413,
+              "end" : 1883067
+            },
+            {
+              "titel" : "Der Wind bringt es an den Tag",
+              "start" : 1883067,
+              "end" : 2191960
+            },
+            {
+              "titel" : "Quiz Nummer zwei",
+              "start" : 2191960,
+              "end" : 2575160
+            },
+            {
+              "titel" : "Licht an – Ton ab – Kamera läuft!",
+              "start" : 2575160,
+              "end" : 3012147
+            }
+          ]
         }
       ],
       "links" : {
@@ -5130,6 +7185,52 @@
         {
           "rolle" : "Tante Mathilda",
           "sprecher" : "Ursula Vogel"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Von Wikingern und Indianern",
+              "start" : 0,
+              "end" : 363960
+            },
+            {
+              "titel" : "Unter Tränen",
+              "start" : 363960,
+              "end" : 780533
+            },
+            {
+              "titel" : "Tätowierte Jungfrau",
+              "start" : 780533,
+              "end" : 1099573
+            },
+            {
+              "titel" : "Kapitän aus grauer Vorzeit",
+              "start" : 1099573,
+              "end" : 1423587
+            },
+            {
+              "titel" : "Geistergestalten und Wölfe",
+              "start" : 1423587,
+              "end" : 1736333
+            },
+            {
+              "titel" : "Lichtsignale im Nebel",
+              "start" : 1736333,
+              "end" : 2050573
+            },
+            {
+              "titel" : "Zerfetzte Jacke",
+              "start" : 2050573,
+              "end" : 2424400
+            },
+            {
+              "titel" : "Eiskalter Betrug",
+              "start" : 2424400,
+              "end" : 2827347
+            }
+          ]
         }
       ],
       "links" : {
@@ -5247,6 +7348,52 @@
           "sprecher" : "Norbert Lange"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Millionär verschwindet",
+              "start" : 0,
+              "end" : 407480
+            },
+            {
+              "titel" : "Ende der Party",
+              "start" : 407480,
+              "end" : 694200
+            },
+            {
+              "titel" : "Gespeicherte Geheimdaten",
+              "start" : 694200,
+              "end" : 1110333
+            },
+            {
+              "titel" : "Die rätselhafte Botschaft",
+              "start" : 1110333,
+              "end" : 1443720
+            },
+            {
+              "titel" : "Das Buch des Bischofs",
+              "start" : 1443720,
+              "end" : 1736933
+            },
+            {
+              "titel" : "Justus hat eine Erleuchtung",
+              "start" : 1736933,
+              "end" : 2067707
+            },
+            {
+              "titel" : "Nicht umzubringen",
+              "start" : 2067707,
+              "end" : 2662787
+            },
+            {
+              "titel" : "Ein Geheimnis aus alter Zeit",
+              "start" : 2662787,
+              "end" : 2853253
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/046/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/046/ffmetadata.txt",
@@ -5352,6 +7499,52 @@
         {
           "rolle" : "Kranführer Dick",
           "sprecher" : "Ernst von Klipstein"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Albtraum",
+              "start" : 0,
+              "end" : 321613
+            },
+            {
+              "titel" : "Mr. Sweetness",
+              "start" : 321613,
+              "end" : 617587
+            },
+            {
+              "titel" : "Dr. Jonas am Apparat",
+              "start" : 617587,
+              "end" : 1098027
+            },
+            {
+              "titel" : "Mordanschlag",
+              "start" : 1098027,
+              "end" : 1415827
+            },
+            {
+              "titel" : "Zurückgekehrte Erinnerung",
+              "start" : 1415827,
+              "end" : 1732267
+            },
+            {
+              "titel" : "Endstation Schrottpresse",
+              "start" : 1732267,
+              "end" : 2208587
+            },
+            {
+              "titel" : "Gefährliche Marktforschung",
+              "start" : 2208587,
+              "end" : 2555440
+            },
+            {
+              "titel" : "Der große Preis",
+              "start" : 2555440,
+              "end" : 2842373
+            }
+          ]
         }
       ],
       "links" : {
@@ -5461,6 +7654,52 @@
           "sprecher" : "Manfred Liptow"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Über der Sierra Nevada",
+              "start" : 0,
+              "end" : 294067
+            },
+            {
+              "titel" : "Der gespenstische Waldläufer",
+              "start" : 294067,
+              "end" : 635667
+            },
+            {
+              "titel" : "Wer kann die Kranken heilen?",
+              "start" : 635667,
+              "end" : 1142653
+            },
+            {
+              "titel" : "Ein Traum und eine Botschaft",
+              "start" : 1142653,
+              "end" : 1431333
+            },
+            {
+              "titel" : "Die Wahnsinnsfahrt",
+              "start" : 1431333,
+              "end" : 1858533
+            },
+            {
+              "titel" : "Das Tal des Todes",
+              "start" : 1858533,
+              "end" : 2161400
+            },
+            {
+              "titel" : "Schmutzige Geschäfte",
+              "start" : 2161400,
+              "end" : 2521600
+            },
+            {
+              "titel" : "Das Ende für den Dämon",
+              "start" : 2521600,
+              "end" : 2878867
+            }
+          ]
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/048/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/048/ffmetadata.txt",
@@ -5565,10 +7804,56 @@
           "sprecher" : "Leonhard Mahlich"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Großer Qualm – kleines Feuer",
+              "start" : 0,
+              "end" : 363133
+            },
+            {
+              "titel" : "Spannendes aus der Szene",
+              "start" : 363133,
+              "end" : 667613
+            },
+            {
+              "titel" : "Kunst und Kommerz",
+              "start" : 667613,
+              "end" : 1086667
+            },
+            {
+              "titel" : "Das interstellare Interview",
+              "start" : 1086667,
+              "end" : 1333040
+            },
+            {
+              "titel" : "Getäuscht",
+              "start" : 1333040,
+              "end" : 1619493
+            },
+            {
+              "titel" : "Handzeichen",
+              "start" : 1619493,
+              "end" : 2033547
+            },
+            {
+              "titel" : "Schwarze Kunst im Keller",
+              "start" : 2033547,
+              "end" : 2418440
+            },
+            {
+              "titel" : "Hart erkämpfter Sieg",
+              "start" : 2418440,
+              "end" : 2670120
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/049/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/049/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/049/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/049/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/049/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/42/06/a6/4206a643-9994-b4a3-8bb1-05911a76dbed/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180157if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/44/f2/0f/0743213884929.jpg"
@@ -5669,10 +7954,56 @@
           "sprecher" : "Günter König"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Chaos in der Strandvilla",
+              "start" : 0,
+              "end" : 548960
+            },
+            {
+              "titel" : "Ein Unglück kommt selten allein",
+              "start" : 548960,
+              "end" : 947920
+            },
+            {
+              "titel" : "Stars mit und ohne Maske",
+              "start" : 947920,
+              "end" : 1336107
+            },
+            {
+              "titel" : "Rat vom großen Guru",
+              "start" : 1336107,
+              "end" : 1717547
+            },
+            {
+              "titel" : "Der Kerl mit dem Koffer",
+              "start" : 1717547,
+              "end" : 2171933
+            },
+            {
+              "titel" : "Nachteinsatz",
+              "start" : 2171933,
+              "end" : 2739760
+            },
+            {
+              "titel" : "Total vermasselt!",
+              "start" : 2739760,
+              "end" : 3043307
+            },
+            {
+              "titel" : "Ein Vampir kehrt zurück",
+              "start" : 3043307,
+              "end" : 3435173
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/050/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/050/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/050/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/050/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/050/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/3b/13/ce/3b13cee9-0f9c-66c0-c0b8-fff0d058bb66/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180141if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/71/8a/c7/0743213885025.jpg"
@@ -5761,10 +8092,56 @@
           "sprecher" : "Eckart Dux"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Teilnahme kostenlos",
+              "start" : 0,
+              "end" : 423747
+            },
+            {
+              "titel" : "Justus' Eroberung",
+              "start" : 423747,
+              "end" : 988093
+            },
+            {
+              "titel" : "Auf Blondie ist Verlass",
+              "start" : 988093,
+              "end" : 1322067
+            },
+            {
+              "titel" : "Wer ist hier der Boss?",
+              "start" : 1322067,
+              "end" : 1625933
+            },
+            {
+              "titel" : "Unverhoffter Besuch",
+              "start" : 1625933,
+              "end" : 2200907
+            },
+            {
+              "titel" : "Gefahr von allen Seiten",
+              "start" : 2200907,
+              "end" : 2671960
+            },
+            {
+              "titel" : "Verfrühter Triumph",
+              "start" : 2671960,
+              "end" : 2947467
+            },
+            {
+              "titel" : "Flüsse aus Feuer",
+              "start" : 2947467,
+              "end" : 3270107
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/051/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/051/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/051/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/051/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/051/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/1b/de/8a/1bde8a9a-6d18-6e8e-daca-86801874c325/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180155if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/37/1d/ab/0743213885124.jpg"
@@ -5885,10 +8262,56 @@
           "sprecher" : "Michael Quiatkowsky"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Hereingelegt!",
+              "start" : 0,
+              "end" : 415627
+            },
+            {
+              "titel" : "Bobs Entdeckung",
+              "start" : 415627,
+              "end" : 808667
+            },
+            {
+              "titel" : "Profi-Sound",
+              "start" : 808667,
+              "end" : 1425160
+            },
+            {
+              "titel" : "Im Tonstudio",
+              "start" : 1425160,
+              "end" : 1831267
+            },
+            {
+              "titel" : "Wer hat die Masterbänder?",
+              "start" : 1831267,
+              "end" : 2176867
+            },
+            {
+              "titel" : "Nicht ganz dicht",
+              "start" : 2176867,
+              "end" : 2574667
+            },
+            {
+              "titel" : "Drei plus vier",
+              "start" : 2574667,
+              "end" : 2921267
+            },
+            {
+              "titel" : "Endstation Chefetage",
+              "start" : 2921267,
+              "end" : 3267773
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/052/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/052/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/052/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/052/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/052/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/e9/0b/76/e90b769b-e62e-6704-ab3f-09de79e6ada2/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023023if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/1e/c4/9e/0743213885223.jpg"
@@ -5997,10 +8420,56 @@
           "sprecher" : "Michael Quiatkowsky"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Besuch aus New York",
+              "start" : 0,
+              "end" : 401867
+            },
+            {
+              "titel" : "Festgenommen!",
+              "start" : 401867,
+              "end" : 854520
+            },
+            {
+              "titel" : "Die Piranhas in Aktion",
+              "start" : 854520,
+              "end" : 1316040
+            },
+            {
+              "titel" : "Bandleader oder Bandenchef?",
+              "start" : 1316040,
+              "end" : 1587480
+            },
+            {
+              "titel" : "Gefährliche Begegnung",
+              "start" : 1587480,
+              "end" : 2078760
+            },
+            {
+              "titel" : "Wer wird hier beschattet?",
+              "start" : 2078760,
+              "end" : 2493467
+            },
+            {
+              "titel" : "Köderfalle Jaguar",
+              "start" : 2493467,
+              "end" : 2908813
+            },
+            {
+              "titel" : "Der Hai gibt auf",
+              "start" : 2908813,
+              "end" : 3203173
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/053/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/053/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/053/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/053/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/053/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/a0/77/57/a077578d-eb5e-2c15-9fe7-a4c2aff6bbc1/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180939if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/46/c3/c4/0743213885322.jpg"
@@ -6110,10 +8579,56 @@
           "sprecher" : "Henry König"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein denkenswerter Auftritt",
+              "start" : 0,
+              "end" : 390120
+            },
+            {
+              "titel" : "Gefahr im Verzug",
+              "start" : 390120,
+              "end" : 711920
+            },
+            {
+              "titel" : "Hinter den Kulissen",
+              "start" : 711920,
+              "end" : 954000
+            },
+            {
+              "titel" : "Geisterbeschwörung",
+              "start" : 954000,
+              "end" : 1520760
+            },
+            {
+              "titel" : "Eine klebrige Angelegenheit",
+              "start" : 1520760,
+              "end" : 1852587
+            },
+            {
+              "titel" : "Ausverkauft",
+              "start" : 1852587,
+              "end" : 2188827
+            },
+            {
+              "titel" : "Verfolgungsjagd",
+              "start" : 2188827,
+              "end" : 2724867
+            },
+            {
+              "titel" : "Autogrammjäger",
+              "start" : 2724867,
+              "end" : 3048040
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/054/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/054/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/054/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/054/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/054/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/aa/32/4e/aa324e0b-7353-6a32-9fba-1ae05bd79312/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230940if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/82/19/6a/0743213885421.jpg"
@@ -6226,10 +8741,56 @@
           "sprecher" : "Hans Clarin"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Durch die Hintertür",
+              "start" : 0,
+              "end" : 484507
+            },
+            {
+              "titel" : "Ganz cool",
+              "start" : 484507,
+              "end" : 903667
+            },
+            {
+              "titel" : "Ein Haufen Geld",
+              "start" : 903667,
+              "end" : 1198307
+            },
+            {
+              "titel" : "Eine Bombenparty",
+              "start" : 1198307,
+              "end" : 1812520
+            },
+            {
+              "titel" : "Verhörmethoden",
+              "start" : 1812520,
+              "end" : 2218707
+            },
+            {
+              "titel" : "Die Falle",
+              "start" : 2218707,
+              "end" : 2530613
+            },
+            {
+              "titel" : "Volltreffer",
+              "start" : 2530613,
+              "end" : 2795867
+            },
+            {
+              "titel" : "VIP",
+              "start" : 2795867,
+              "end" : 3056533
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/055/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/055/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/055/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/055/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/055/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/52/03/bf/5203bf9b-f1a0-b8d5-94ab-4ba2df90c4b0/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023028if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/33/69/b0/0743213885520.jpg"
@@ -6342,10 +8903,56 @@
           "sprecher" : "Douglas Welbat"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Chaos lässt grüßen",
+              "start" : 0,
+              "end" : 366920
+            },
+            {
+              "titel" : "Ein Monster kommt selten allein",
+              "start" : 366920,
+              "end" : 769293
+            },
+            {
+              "titel" : "Keine Gnade für den Fleck",
+              "start" : 769293,
+              "end" : 1097987
+            },
+            {
+              "titel" : "Raumschiff am Boden zerstört!",
+              "start" : 1097987,
+              "end" : 1460973
+            },
+            {
+              "titel" : "Stars zum Anfassen",
+              "start" : 1460973,
+              "end" : 1828253
+            },
+            {
+              "titel" : "Auf der Lauer",
+              "start" : 1828253,
+              "end" : 2143827
+            },
+            {
+              "titel" : "Nacht mit Fantasy",
+              "start" : 2143827,
+              "end" : 2501613
+            },
+            {
+              "titel" : "Wahnsinn hat Methode",
+              "start" : 2501613,
+              "end" : 2967587
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/056/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/056/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/056/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/056/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/056/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/ca/c6/22/cac62219-77cf-07e6-8f0f-cb51d6c47038/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045323if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/d2/70/fc/0743213885629.jpg"
@@ -6450,10 +9057,56 @@
           "sprecher" : "Thea Frank"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Absturz",
+              "start" : 0,
+              "end" : 364453
+            },
+            {
+              "titel" : "Eine Fee gibt Auskunft",
+              "start" : 364453,
+              "end" : 706507
+            },
+            {
+              "titel" : "Nächtlicher Einbruch",
+              "start" : 706507,
+              "end" : 977453
+            },
+            {
+              "titel" : "Die Schöne und der Verleger",
+              "start" : 977453,
+              "end" : 1302987
+            },
+            {
+              "titel" : "Planungsphase läuft",
+              "start" : 1302987,
+              "end" : 1599467
+            },
+            {
+              "titel" : "Ausgeräumt",
+              "start" : 1599467,
+              "end" : 2036267
+            },
+            {
+              "titel" : "Justus geht aufs Ganze",
+              "start" : 2036267,
+              "end" : 2314827
+            },
+            {
+              "titel" : "In der Klemme",
+              "start" : 2314827,
+              "end" : 2605187
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/057/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/057/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/057/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/057/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/057/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/22/f4/2e/22f42ec9-5f50-b15c-1e2c-c8614e062e9f/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153435if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f3/af/93/0743213885728.jpg"
@@ -6563,10 +9216,56 @@
           "sprecher" : "Rebecca Völz"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Kamelhaarmann tritt auf",
+              "start" : 0,
+              "end" : 448067
+            },
+            {
+              "titel" : "Bobs Alleingang",
+              "start" : 448067,
+              "end" : 739453
+            },
+            {
+              "titel" : "Ein Fiesling am Telefon",
+              "start" : 739453,
+              "end" : 1062853
+            },
+            {
+              "titel" : "Onkel Titus' großer Auftritt",
+              "start" : 1062853,
+              "end" : 1359627
+            },
+            {
+              "titel" : "Ein Engel mit Revolver",
+              "start" : 1359627,
+              "end" : 1663560
+            },
+            {
+              "titel" : "Die Dinge kommen ins Rollen",
+              "start" : 1663560,
+              "end" : 2106773
+            },
+            {
+              "titel" : "Familienkrieg",
+              "start" : 2106773,
+              "end" : 2379027
+            },
+            {
+              "titel" : "Das Geheimnis des gelben Gemäldes",
+              "start" : 2379027,
+              "end" : 2711893
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/058/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/058/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/058/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/058/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/058/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/1e/e8/56/1ee856ec-b33b-7b5e-ce59-f55ee0741436/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045321if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/03/52/8a/0743211851220.jpg"
@@ -6675,10 +9374,56 @@
           "sprecher" : "Michael Mechel"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine Stadt wird erpresst",
+              "start" : 0,
+              "end" : 267880
+            },
+            {
+              "titel" : "Auf Eis gelegt",
+              "start" : 267880,
+              "end" : 690600
+            },
+            {
+              "titel" : "Trotz Regen – kein Wasser",
+              "start" : 690600,
+              "end" : 999907
+            },
+            {
+              "titel" : "Flucht auf der Harley",
+              "start" : 999907,
+              "end" : 1328827
+            },
+            {
+              "titel" : "Anweisung vom Erpresser",
+              "start" : 1328827,
+              "end" : 1644293
+            },
+            {
+              "titel" : "Verbotener Handel",
+              "start" : 1644293,
+              "end" : 2044893
+            },
+            {
+              "titel" : "Auf Drogenentzug",
+              "start" : 2044893,
+              "end" : 2361133
+            },
+            {
+              "titel" : "Im Stich gelassen",
+              "start" : 2361133,
+              "end" : 2667307
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/059/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/059/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/059/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/059/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/059/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/6f/f4/79/6ff47958-586c-ebea-9cb7-a2a21468a1d0/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212358if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/13/bc/39/0743211851329.jpg"
@@ -6792,10 +9537,56 @@
           "pseudonym" : "Margot Linde"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Randale im Treibhaus",
+              "start" : 0,
+              "end" : 344320
+            },
+            {
+              "titel" : "Betrug in der Arena",
+              "start" : 344320,
+              "end" : 789440
+            },
+            {
+              "titel" : "Überfall auf Miss Sharp",
+              "start" : 789440,
+              "end" : 1121053
+            },
+            {
+              "titel" : "Verdächtiges Rendezvous",
+              "start" : 1121053,
+              "end" : 1458320
+            },
+            {
+              "titel" : "Tante Mathilda spielt Detektiv",
+              "start" : 1458320,
+              "end" : 1748120
+            },
+            {
+              "titel" : "Rauhe Schale, weicher Kern",
+              "start" : 1748120,
+              "end" : 2193827
+            },
+            {
+              "titel" : "Glenn packt aus",
+              "start" : 2193827,
+              "end" : 2541507
+            },
+            {
+              "titel" : "Tante Mathildas beste Freundin",
+              "start" : 2541507,
+              "end" : 2826880
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/060/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/060/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/060/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/060/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/060/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/a6/29/2b/a6292b27-fee9-d341-910e-7f7347e3a4dd/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135401if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/82/1f/5f/0743211851428.jpg"
@@ -6908,10 +9699,56 @@
           "sprecher" : "Hans Hessling"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein bombiges Richtfest",
+              "start" : 0,
+              "end" : 465853
+            },
+            {
+              "titel" : "Stümper am Werk",
+              "start" : 465853,
+              "end" : 1007520
+            },
+            {
+              "titel" : "Im Nacken kaltes Fleisch",
+              "start" : 1007520,
+              "end" : 1634640
+            },
+            {
+              "titel" : "Justus geht unter die Raucher",
+              "start" : 1634640,
+              "end" : 1967920
+            },
+            {
+              "titel" : "Flucht vor den Cops",
+              "start" : 1967920,
+              "end" : 2486920
+            },
+            {
+              "titel" : "Wen Asiens Herrscher nicht empfangen …",
+              "start" : 2486920,
+              "end" : 2834573
+            },
+            {
+              "titel" : "Von Kimble an Marple",
+              "start" : 2834573,
+              "end" : 3094480
+            },
+            {
+              "titel" : "Im Tigerkäfig",
+              "start" : 3094480,
+              "end" : 3569320
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/061/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/061/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/061/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/061/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/061/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/51/89/01/51890174-ada7-dd26-2a09-1fae93b9900d/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023025if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/fc/e7/d4/0743212358223.jpg"
@@ -7024,10 +9861,56 @@
           "sprecher" : "Willem Fricke"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Knobeln mit Folgen",
+              "start" : 0,
+              "end" : 297440
+            },
+            {
+              "titel" : "Amandas \"Old Star\"",
+              "start" : 297440,
+              "end" : 871373
+            },
+            {
+              "titel" : "Der Dieb schlägt wieder zu",
+              "start" : 871373,
+              "end" : 1448307
+            },
+            {
+              "titel" : "Amandas Geheimnis",
+              "start" : 1448307,
+              "end" : 1782720
+            },
+            {
+              "titel" : "Geister und Ganoven",
+              "start" : 1782720,
+              "end" : 2377627
+            },
+            {
+              "titel" : "Diebin in Aktion",
+              "start" : 2377627,
+              "end" : 2859707
+            },
+            {
+              "titel" : "Feuer",
+              "start" : 2859707,
+              "end" : 3265613
+            },
+            {
+              "titel" : "Zur Feier des Tages",
+              "start" : 3265613,
+              "end" : 3563227
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/062/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/062/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/062/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/062/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/062/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/8a/0c/d8/8a0cd85a-830a-47ff-58b3-afb4d07d5906/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152725if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/01/7d/4e/0743212358322.jpg"
@@ -7141,10 +10024,56 @@
           "sprecher" : "Astrid Kollex"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ballkünstler unter sich",
+              "start" : 0,
+              "end" : 412613
+            },
+            {
+              "titel" : "Explosive Nachrichten",
+              "start" : 412613,
+              "end" : 960400
+            },
+            {
+              "titel" : "Smell kauft Jimboy",
+              "start" : 960400,
+              "end" : 1348587
+            },
+            {
+              "titel" : "Eisiger Empfang in den Bergen",
+              "start" : 1348587,
+              "end" : 2023547
+            },
+            {
+              "titel" : "Foul auf Bestellung",
+              "start" : 2023547,
+              "end" : 2574587
+            },
+            {
+              "titel" : "Aktion Earphone",
+              "start" : 2574587,
+              "end" : 3069533
+            },
+            {
+              "titel" : "Ein riskanter Bluff",
+              "start" : 3069533,
+              "end" : 3325320
+            },
+            {
+              "titel" : "Cotta mischt mit",
+              "start" : 3325320,
+              "end" : 4014467
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/063/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/063/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/063/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/063/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/063/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/f3/26/93/f3269335-43f5-7026-235f-671d7a5cb163/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180936if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/a5/8c/89/0743212482225.jpg"
@@ -7258,10 +10187,56 @@
           "pseudonym" : "Norman Messer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Tante Mathilda ist verschwunden",
+              "start" : 0,
+              "end" : 663707
+            },
+            {
+              "titel" : "Rausschmiss der drei ???",
+              "start" : 663707,
+              "end" : 1289693
+            },
+            {
+              "titel" : "Kein Papierkorb für das Lösegeld",
+              "start" : 1289693,
+              "end" : 1893253
+            },
+            {
+              "titel" : "Drohung mit einem Ohr",
+              "start" : 1893253,
+              "end" : 2587613
+            },
+            {
+              "titel" : "In der Geisterstadt",
+              "start" : 2587613,
+              "end" : 3068627
+            },
+            {
+              "titel" : "Hinweis im Schnee",
+              "start" : 3068627,
+              "end" : 3293360
+            },
+            {
+              "titel" : "Doppeltes Spiel",
+              "start" : 3293360,
+              "end" : 3543280
+            },
+            {
+              "titel" : "High Noon",
+              "start" : 3543280,
+              "end" : 3969547
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/064/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/064/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/064/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/064/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/064/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/18/56/35/185635ed-e17c-b9a6-7276-5d63b67c8b62/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153420if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/91/33/36/0743212482324.jpg"
@@ -7382,10 +10357,56 @@
           "sprecher" : "Veronika Neugebauer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Gefangen!",
+              "start" : 0,
+              "end" : 358187
+            },
+            {
+              "titel" : "Die ewigen Jagdgründe",
+              "start" : 358187,
+              "end" : 882280
+            },
+            {
+              "titel" : "Beim Lügen ertappt",
+              "start" : 882280,
+              "end" : 1491027
+            },
+            {
+              "titel" : "Ungebetener Besuch",
+              "start" : 1491027,
+              "end" : 1786093
+            },
+            {
+              "titel" : "Schritte ins Nichts",
+              "start" : 1786093,
+              "end" : 2267360
+            },
+            {
+              "titel" : "Endstation Europa",
+              "start" : 2267360,
+              "end" : 2636493
+            },
+            {
+              "titel" : "Kommissar Zufall",
+              "start" : 2636493,
+              "end" : 2963173
+            },
+            {
+              "titel" : "Eiskalt erwischt",
+              "start" : 2963173,
+              "end" : 3579173
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/065/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/065/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/065/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/065/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/065/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/1a/1d/aa/1a1daabb-d03d-b221-8a11-21b72acb7f45/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135412if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/05/8b/b6/0743213131528.jpg"
@@ -7490,10 +10511,56 @@
           "sprecher" : "Luigi Pane"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Räuber in Rom",
+              "start" : 0,
+              "end" : 858480
+            },
+            {
+              "titel" : "Abgestürzt",
+              "start" : 858480,
+              "end" : 1204493
+            },
+            {
+              "titel" : "Ein Fotograph gibt sich verschwiegen",
+              "start" : 1204493,
+              "end" : 1593573
+            },
+            {
+              "titel" : "Fahndung nach Justus",
+              "start" : 1593573,
+              "end" : 2086493
+            },
+            {
+              "titel" : "Unerwartete Begegnung",
+              "start" : 2086493,
+              "end" : 2245947
+            },
+            {
+              "titel" : "Entführt",
+              "start" : 2245947,
+              "end" : 2705040
+            },
+            {
+              "titel" : "Die Beichte der Spinne",
+              "start" : 2705040,
+              "end" : 2995160
+            },
+            {
+              "titel" : "Der Mann im Schatten",
+              "start" : 2995160,
+              "end" : 3555013
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/066/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/066/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/066/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/066/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/066/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/3b/8d/c9/3b8dc904-52da-f3cd-d361-933b4dce7753/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135355if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/0e/01/10/0743213131627.jpg"
@@ -7602,10 +10669,56 @@
           "sprecher" : "Frank Meyer-Brockmann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Tödliche Gefahr",
+              "start" : 0,
+              "end" : 475547
+            },
+            {
+              "titel" : "Eine rätselhafte Tür",
+              "start" : 475547,
+              "end" : 876093
+            },
+            {
+              "titel" : "Rätsel auf dem Höhlengrund",
+              "start" : 876093,
+              "end" : 1332093
+            },
+            {
+              "titel" : "In der Hand der Räuber",
+              "start" : 1332093,
+              "end" : 1813307
+            },
+            {
+              "titel" : "Wie vom Erdboden verschluckt",
+              "start" : 1813307,
+              "end" : 2404093
+            },
+            {
+              "titel" : "Erpressung inklusive",
+              "start" : 2404093,
+              "end" : 2900173
+            },
+            {
+              "titel" : "Bruder Benedikt beichtet",
+              "start" : 2900173,
+              "end" : 3310747
+            },
+            {
+              "titel" : "Wiener Unterwelt",
+              "start" : 3310747,
+              "end" : 3799320
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/067/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/067/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/067/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/067/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/067/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/2a/de/b4/2adeb4d6-8000-9e52-bb64-ae4f0dcad8ec/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180145if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/94/fb/e4/0743213558325.jpg"
@@ -7694,10 +10807,56 @@
           "sprecher" : "Lutz Schnell"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Abgestürzt",
+              "start" : 0,
+              "end" : 496760
+            },
+            {
+              "titel" : "Überfall aus der Luft",
+              "start" : 496760,
+              "end" : 986600
+            },
+            {
+              "titel" : "Verschollen im Wallis",
+              "start" : 986600,
+              "end" : 1312760
+            },
+            {
+              "titel" : "Der letzte Erkundungsflug",
+              "start" : 1312760,
+              "end" : 1790093
+            },
+            {
+              "titel" : "Mitten im Spionage-Thriller",
+              "start" : 1790093,
+              "end" : 2477760
+            },
+            {
+              "titel" : "Jerzys Plan",
+              "start" : 2477760,
+              "end" : 2916680
+            },
+            {
+              "titel" : "Mit dem U-Boot in die Tiefe",
+              "start" : 2916680,
+              "end" : 3214720
+            },
+            {
+              "titel" : "Code 999",
+              "start" : 3214720,
+              "end" : 3581227
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/068/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/068/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/068/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/068/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/068/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/39/d8/5b/39d85baf-b146-6fb2-4c15-e80afaf87525/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212343if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/80/fc/8e/0743213558424.jpg"
@@ -7819,10 +10978,56 @@
           "sprecher" : "André Minninger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Angst im Nacken",
+              "start" : 0,
+              "end" : 415787
+            },
+            {
+              "titel" : "Ein Dummkopf hinterlässt Spuren",
+              "start" : 415787,
+              "end" : 985867
+            },
+            {
+              "titel" : "Die innere Stimme",
+              "start" : 985867,
+              "end" : 1620880
+            },
+            {
+              "titel" : "Ein Fall für Doktor Ferguson",
+              "start" : 1620880,
+              "end" : 2106587
+            },
+            {
+              "titel" : "Das Geheimnis der Glaskugel",
+              "start" : 2106587,
+              "end" : 2508280
+            },
+            {
+              "titel" : "Rendezvous mit den Entführern",
+              "start" : 2508280,
+              "end" : 3125667
+            },
+            {
+              "titel" : "Ein Plan gerät aus den Fugen",
+              "start" : 3125667,
+              "end" : 3484920
+            },
+            {
+              "titel" : "Erna Fiedlers Beichte",
+              "start" : 3484920,
+              "end" : 3942387
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/069/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/069/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/069/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/069/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/069/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/5e/46/2a/5e462af7-1f61-e3a4-3a6f-655b33a55482/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180143if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/a0/7b/77/0743213558523.jpg"
@@ -7935,10 +11140,56 @@
           "sprecher" : "Jona Mues"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Schuss!",
+              "start" : 0,
+              "end" : 729720
+            },
+            {
+              "titel" : "Sally Samson tobt",
+              "start" : 729720,
+              "end" : 1131773
+            },
+            {
+              "titel" : "Intrigen überall",
+              "start" : 1131773,
+              "end" : 1659947
+            },
+            {
+              "titel" : "Keine neue Spur",
+              "start" : 1659947,
+              "end" : 1978547
+            },
+            {
+              "titel" : "Justus Jonas jobt",
+              "start" : 1978547,
+              "end" : 2615013
+            },
+            {
+              "titel" : "Falsches Spiel",
+              "start" : 2615013,
+              "end" : 2926573
+            },
+            {
+              "titel" : "Eine böse Überraschung",
+              "start" : 2926573,
+              "end" : 3295413
+            },
+            {
+              "titel" : "Kurssturz",
+              "start" : 3295413,
+              "end" : 3784293
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/070/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/070/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/070/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/070/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/070/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/79/ca/7a/79ca7a9a-d60c-0ad2-2ce3-3958e43f83cc/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212340if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/d5/21/d3/0743213849423.jpg"
@@ -8064,10 +11315,56 @@
           "sprecher" : "Konstanze Ullmer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Onkel Titus sitzt in der Patsche",
+              "start" : 0,
+              "end" : 736827
+            },
+            {
+              "titel" : "Ein tragischer Segelunfall",
+              "start" : 736827,
+              "end" : 1304667
+            },
+            {
+              "titel" : "Im Reich der Mitte",
+              "start" : 1304667,
+              "end" : 1666187
+            },
+            {
+              "titel" : "1:0 für Santoria",
+              "start" : 1666187,
+              "end" : 1996960
+            },
+            {
+              "titel" : "Auf Leben und Tod",
+              "start" : 1996960,
+              "end" : 2409933
+            },
+            {
+              "titel" : "Lu Kwan schweigt",
+              "start" : 2409933,
+              "end" : 2928840
+            },
+            {
+              "titel" : "Bobs Theorie",
+              "start" : 2928840,
+              "end" : 3501547
+            },
+            {
+              "titel" : "Zweitausend $ zum Ersten",
+              "start" : 3501547,
+              "end" : 3994440
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/071/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/071/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/071/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/071/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/071/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/9d/97/2e/9d972eb9-f718-b639-4865-98057d99bb23/source",
         "cover_kosmos" : "http://web.archive.org/web/20220706182607if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/3c/1f/38/0743213849621.jpg"
@@ -8188,10 +11485,56 @@
           "sprecher" : "Susan Jarling"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Bauklötze beschlagnahmt",
+              "start" : 0,
+              "end" : 582867
+            },
+            {
+              "titel" : "Ein geheimnisvoller Tipp",
+              "start" : 582867,
+              "end" : 1202640
+            },
+            {
+              "titel" : "Verwüstung mit System",
+              "start" : 1202640,
+              "end" : 1564107
+            },
+            {
+              "titel" : "Fettige Marmeladengläser",
+              "start" : 1564107,
+              "end" : 1886947
+            },
+            {
+              "titel" : "Hester hofft auf Hilfe",
+              "start" : 1886947,
+              "end" : 2192213
+            },
+            {
+              "titel" : "Hakuna matata",
+              "start" : 2192213,
+              "end" : 2437733
+            },
+            {
+              "titel" : "Malcolm, der Rebell",
+              "start" : 2437733,
+              "end" : 3014147
+            },
+            {
+              "titel" : "Lauras letzte Chance",
+              "start" : 3014147,
+              "end" : 3477893
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/072/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/072/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/072/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/072/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/072/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/4a/0d/a0/4a0da044-0a16-4d61-5692-2891bc19dfb0/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153418if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/b5/eb/3c/0743213849720.jpg"
@@ -8296,10 +11639,56 @@
           "sprecher" : "Marianne Kehlau"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Doppelte Abfuhr",
+              "start" : 0,
+              "end" : 578787
+            },
+            {
+              "titel" : "Miss Madigans Medaillon",
+              "start" : 578787,
+              "end" : 998120
+            },
+            {
+              "titel" : "Hilferuf in der Nacht",
+              "start" : 998120,
+              "end" : 1676827
+            },
+            {
+              "titel" : "Poltergeister",
+              "start" : 1676827,
+              "end" : 1998627
+            },
+            {
+              "titel" : "Terror hinter verschlossener Tür",
+              "start" : 1998627,
+              "end" : 2831720
+            },
+            {
+              "titel" : "Schwebendes Geschirr",
+              "start" : 2831720,
+              "end" : 3177613
+            },
+            {
+              "titel" : "Der Geistesblitz",
+              "start" : 3177613,
+              "end" : 3602987
+            },
+            {
+              "titel" : "Ein alter Bekannter",
+              "start" : 3602987,
+              "end" : 3997320
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/073/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/073/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/073/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/073/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/073/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/09/a6/03/09a60380-38a0-05ce-3cd7-97a5f5047863/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045339if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/ea/56/0a/0743214284728.jpg"
@@ -8421,10 +11810,56 @@
           "sprecher" : "Moritz Gentsch"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine geheimnisvolle Erbschaft",
+              "start" : 0,
+              "end" : 581480
+            },
+            {
+              "titel" : "Gestohlene Informationen",
+              "start" : 581480,
+              "end" : 978013
+            },
+            {
+              "titel" : "Ein alter Trick",
+              "start" : 978013,
+              "end" : 1335027
+            },
+            {
+              "titel" : "Der undurchsichtige Mr. Whitehead",
+              "start" : 1335027,
+              "end" : 1989333
+            },
+            {
+              "titel" : "In der Höhle des Löwen",
+              "start" : 1989333,
+              "end" : 2450600
+            },
+            {
+              "titel" : "Das brennende Schwert",
+              "start" : 2450600,
+              "end" : 3003387
+            },
+            {
+              "titel" : "Wenn Tag und Nacht sich vereinen",
+              "start" : 3003387,
+              "end" : 3823227
+            },
+            {
+              "titel" : "Logische Schlussfolgerungen",
+              "start" : 3823227,
+              "end" : 4442107
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/074/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/074/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/074/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/074/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/074/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/28/94/73/2894733d-f9a7-3efa-53b9-81a3be32e857/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045313if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/42/ce/d1/0743214284827.jpg"
@@ -8525,10 +11960,56 @@
           "sprecher" : "Katja Stichel"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Atemlos",
+              "start" : 0,
+              "end" : 382227
+            },
+            {
+              "titel" : "Ein Vogel auf dem Drahtseil",
+              "start" : 382227,
+              "end" : 807587
+            },
+            {
+              "titel" : "Bodyguard",
+              "start" : 807587,
+              "end" : 1356627
+            },
+            {
+              "titel" : "Beethoven",
+              "start" : 1356627,
+              "end" : 1691960
+            },
+            {
+              "titel" : "Auf der Flucht",
+              "start" : 1691960,
+              "end" : 2113227
+            },
+            {
+              "titel" : "Menschen im Hotel",
+              "start" : 2113227,
+              "end" : 2552053
+            },
+            {
+              "titel" : "Fame",
+              "start" : 2552053,
+              "end" : 3020253
+            },
+            {
+              "titel" : "Die glorreichen Drei",
+              "start" : 3020253,
+              "end" : 3339600
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/075/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/075/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/075/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/075/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/075/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/2f/f0/41/2ff04107-2622-c542-c5c5-48e7b21ae213/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180134if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/23/27/c0/0743214284926.jpg"
@@ -8637,10 +12118,56 @@
           "sprecher" : "Thomas Schüler"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Schrei",
+              "start" : 0,
+              "end" : 662587
+            },
+            {
+              "titel" : "Eindeutige Abfuhr",
+              "start" : 662587,
+              "end" : 981400
+            },
+            {
+              "titel" : "Psychoanalysen",
+              "start" : 981400,
+              "end" : 1724707
+            },
+            {
+              "titel" : "Gespräch unter vier Augen",
+              "start" : 1724707,
+              "end" : 2232707
+            },
+            {
+              "titel" : "Dem Wahnsinn nahe",
+              "start" : 2232707,
+              "end" : 2906627
+            },
+            {
+              "titel" : "Tiefenhypnose",
+              "start" : 2906627,
+              "end" : 3305613
+            },
+            {
+              "titel" : "Der letzte Wille",
+              "start" : 3305613,
+              "end" : 3787227
+            },
+            {
+              "titel" : "Das geschenkte Leben",
+              "start" : 3787227,
+              "end" : 4184827
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/076/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/076/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/076/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/076/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/076/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/69/c1/0d/69c10d68-81ae-f0d8-7280-891636c946b1/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212319if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/06/64/bc/0743214285022.jpg"
@@ -8748,10 +12275,46 @@
           "pseudonym" : "Norman Messer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein dunkles Vorzeichen",
+              "start" : 0,
+              "end" : 602987
+            },
+            {
+              "titel" : "Karen hat viel zu erzählen",
+              "start" : 602987,
+              "end" : 1202320
+            },
+            {
+              "titel" : "Schock im Schnee",
+              "start" : 1202320,
+              "end" : 1779600
+            },
+            {
+              "titel" : "Neue Pläne",
+              "start" : 1779600,
+              "end" : 2417560
+            },
+            {
+              "titel" : "Observierung",
+              "start" : 2417560,
+              "end" : 3034920
+            },
+            {
+              "titel" : "Das Blatt wendet sich",
+              "start" : 3034920,
+              "end" : 3559333
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/077/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/077/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/077/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/077/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/077/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/3d/52/de/3d52de30-7d6c-87e7-d179-75b4693d12ad/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212308if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f7/48/75/0743215184027.jpg"
@@ -8855,10 +12418,46 @@
           "sprecher" : "Richard Ems"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Whisky für Justus",
+              "start" : 0,
+              "end" : 556600
+            },
+            {
+              "titel" : "Das leere Grab",
+              "start" : 556600,
+              "end" : 1121000
+            },
+            {
+              "titel" : "Begegnung im Dschungel",
+              "start" : 1121000,
+              "end" : 1676133
+            },
+            {
+              "titel" : "Der Lauscher im Schrank",
+              "start" : 1676133,
+              "end" : 2423920
+            },
+            {
+              "titel" : "Gefährliches Wissen",
+              "start" : 2423920,
+              "end" : 3095893
+            },
+            {
+              "titel" : "Urwaldjagd",
+              "start" : 3095893,
+              "end" : 3448987
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/078/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/078/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/078/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/078/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/078/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/6d/1f/8e/6d1f8e56-10c7-bbec-4137-261a8a08564c/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153405if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/b6/f9/32/0743215184126.jpg"
@@ -8978,10 +12577,56 @@
           "sprecher" : "Jens Herrndorff"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Dichter Nebel",
+              "start" : 0,
+              "end" : 609480
+            },
+            {
+              "titel" : "Studioluft",
+              "start" : 609480,
+              "end" : 1202053
+            },
+            {
+              "titel" : "Mythen und Rituale",
+              "start" : 1202053,
+              "end" : 1702747
+            },
+            {
+              "titel" : "Fotosession",
+              "start" : 1702747,
+              "end" : 2307147
+            },
+            {
+              "titel" : "Weichgekocht",
+              "start" : 2307147,
+              "end" : 2974147
+            },
+            {
+              "titel" : "70:30",
+              "start" : 2974147,
+              "end" : 3566467
+            },
+            {
+              "titel" : "In der Puppenwerkstatt",
+              "start" : 3566467,
+              "end" : 4095200
+            },
+            {
+              "titel" : "Showdown",
+              "start" : 4095200,
+              "end" : 4612307
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/079/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/079/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/079/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/079/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/079/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/64/00/05/640005b4-5953-5a61-7bed-bf890128b4d1/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045241if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/c7/0b/ef/0743215476122.jpg"
@@ -9057,10 +12702,46 @@
           "pseudonym" : "Igmar Frenzen"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Feuer am Himmel",
+              "start" : 0,
+              "end" : 542200
+            },
+            {
+              "titel" : "Das Orangental",
+              "start" : 542200,
+              "end" : 1202827
+            },
+            {
+              "titel" : "Cosma",
+              "start" : 1202827,
+              "end" : 1780293
+            },
+            {
+              "titel" : "Die Männer in Schwarz",
+              "start" : 1780293,
+              "end" : 2248373
+            },
+            {
+              "titel" : "Ein geheimnisvolles Päckchen",
+              "start" : 2248373,
+              "end" : 2948493
+            },
+            {
+              "titel" : "Die Maske fällt",
+              "start" : 2948493,
+              "end" : 3560667
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/080/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/080/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/080/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/080/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/080/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/4e/61/8d/4e618d22-8560-a589-0470-b558b1a152a0/source",
         "cover_kosmos" : "http://web.archive.org/web/20220104131538if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/09/85/d4/0743215476221.jpg"
@@ -9159,10 +12840,46 @@
           "sprecher" : "Heikedine Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein merkwürdiger Streich",
+              "start" : 0,
+              "end" : 495307
+            },
+            {
+              "titel" : "Verdeckte Fouls",
+              "start" : 495307,
+              "end" : 1040640
+            },
+            {
+              "titel" : "Der verschwundene Bruder",
+              "start" : 1040640,
+              "end" : 1485880
+            },
+            {
+              "titel" : "Kellys Entdeckung",
+              "start" : 1485880,
+              "end" : 2043000
+            },
+            {
+              "titel" : "Die Detektive gehen in die Offensive",
+              "start" : 2043000,
+              "end" : 2540480
+            },
+            {
+              "titel" : "Foules Spiel",
+              "start" : 2540480,
+              "end" : 2983827
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/081/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/081/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/081/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/081/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/081/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/ae/c5/9e/aec59ec2-7f1a-70f8-6f7d-9c2c0a11f067/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180128if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/a8/64/09/0743215476320.jpg"
@@ -9245,10 +12962,46 @@
           "sprecher" : "Werner Pohlenz"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Rad des Schicksals",
+              "start" : 0,
+              "end" : 606453
+            },
+            {
+              "titel" : "Der Gehängte",
+              "start" : 606453,
+              "end" : 1173240
+            },
+            {
+              "titel" : "Der Eremit",
+              "start" : 1173240,
+              "end" : 2099320
+            },
+            {
+              "titel" : "Der Magier",
+              "start" : 2099320,
+              "end" : 2855627
+            },
+            {
+              "titel" : "Der Tod",
+              "start" : 2855627,
+              "end" : 3486787
+            },
+            {
+              "titel" : "Das Gericht",
+              "start" : 3486787,
+              "end" : 4199867
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/082/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/082/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/082/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/082/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/082/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/dd/b1/8e/ddb18e64-6121-1cbc-dc61-057c37a6313a/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180132if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/87/c8/fa/0743215476429.jpg"
@@ -9339,10 +13092,46 @@
           "sprecher" : "Roland Becker"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die \"Wavedancer\"",
+              "start" : 0,
+              "end" : 588173
+            },
+            {
+              "titel" : "Peter über Bord",
+              "start" : 588173,
+              "end" : 1198933
+            },
+            {
+              "titel" : "Im Sturm",
+              "start" : 1198933,
+              "end" : 1780040
+            },
+            {
+              "titel" : "Meuterei",
+              "start" : 1780040,
+              "end" : 2312667
+            },
+            {
+              "titel" : "Das Wesen aus der Urzeit",
+              "start" : 2312667,
+              "end" : 2960080
+            },
+            {
+              "titel" : "In die Tiefe",
+              "start" : 2960080,
+              "end" : 3558427
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/083/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/083/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/083/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/083/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/083/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/44/fc/d7/44fcd768-ec87-136e-c774-1dfa37064746/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111022954if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/43/8d/81/0743215476528.jpg"
@@ -9425,10 +13214,46 @@
           "sprecher" : "Carola Lange"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Heimlichkeiten",
+              "start" : 0,
+              "end" : 579547
+            },
+            {
+              "titel" : "Musik des Teufels",
+              "start" : 579547,
+              "end" : 1260293
+            },
+            {
+              "titel" : "Ertappt",
+              "start" : 1260293,
+              "end" : 1800867
+            },
+            {
+              "titel" : "Peisinoes Gesang",
+              "start" : 1800867,
+              "end" : 2314800
+            },
+            {
+              "titel" : "Der Fluch der Teufelsgeige",
+              "start" : 2314800,
+              "end" : 2917507
+            },
+            {
+              "titel" : "Der fiedelnde Tod",
+              "start" : 2917507,
+              "end" : 3603107
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/084/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/084/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/084/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/084/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/084/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/9d/94/85/9d948543-4e64-202b-3008-38de66ff3513/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023018if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/d8/13/df/0743215974321.jpg"
@@ -9519,10 +13344,46 @@
           "sprecher" : "Ingrid Weiß"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Absender unbekannt",
+              "start" : 0,
+              "end" : 513733
+            },
+            {
+              "titel" : "Auf in die Wildnis",
+              "start" : 513733,
+              "end" : 932733
+            },
+            {
+              "titel" : "Die Botschaft des Königs",
+              "start" : 932733,
+              "end" : 1476733
+            },
+            {
+              "titel" : "Der schwarze Turm",
+              "start" : 1476733,
+              "end" : 2067720
+            },
+            {
+              "titel" : "Feuer",
+              "start" : 2067720,
+              "end" : 2797720
+            },
+            {
+              "titel" : "Auf heißer Spur",
+              "start" : 2797720,
+              "end" : 3562000
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/085/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/085/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/085/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/085/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/085/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/31/4b/84/314b8425-48ee-ff1e-0d9c-5e230c5f2203/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180916if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/9b/9d/e8/0743216568628.jpg"
@@ -9613,10 +13474,46 @@
           "sprecher" : "Michael Quiatkowsky"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "20:28 Uhr – Stromausfall",
+              "start" : 0,
+              "end" : 708707
+            },
+            {
+              "titel" : "21:01 Uhr – Erwischt",
+              "start" : 708707,
+              "end" : 1014947
+            },
+            {
+              "titel" : "21:47 Uhr – Lauschangriff",
+              "start" : 1014947,
+              "end" : 1727107
+            },
+            {
+              "titel" : "22:36 Uhr – Das Geheimnis des Nachtwächters",
+              "start" : 1727107,
+              "end" : 2250627
+            },
+            {
+              "titel" : "23:07 Uhr – Nichts als die Wahrheit",
+              "start" : 2250627,
+              "end" : 2726040
+            },
+            {
+              "titel" : "00:00 Uhr – Enthüllung um Mitternacht",
+              "start" : 2726040,
+              "end" : 3457213
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/086/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/086/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/086/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/086/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/086/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/4b/bf/24/4bbf241b-b0e4-cd3e-02bc-2095b94850ba/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153402if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/2d/6b/46/0743216568727.jpg"
@@ -9715,10 +13612,46 @@
           "sprecher" : "Kathi Robens"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Mann mit der Maske",
+              "start" : 0,
+              "end" : 422920
+            },
+            {
+              "titel" : "Falsche Schlüsse",
+              "start" : 422920,
+              "end" : 1107853
+            },
+            {
+              "titel" : "Das Duell",
+              "start" : 1107853,
+              "end" : 1646427
+            },
+            {
+              "titel" : "Unter Polizisten",
+              "start" : 1646427,
+              "end" : 2292627
+            },
+            {
+              "titel" : "Der dritte Brief",
+              "start" : 2292627,
+              "end" : 2795440
+            },
+            {
+              "titel" : "Der Wolf zeigt seine Krallen",
+              "start" : 2795440,
+              "end" : 3294627
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/087/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/087/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/087/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/087/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/087/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/5c/d7/fe/5cd7fee9-9b85-0b77-b92d-03aad42ac981/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230902if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/11/71/4b/0743216568826.jpg"
@@ -9837,10 +13770,46 @@
           "sprecher" : "Sascha Gutzeit"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Per E-Mail",
+              "start" : 0,
+              "end" : 609920
+            },
+            {
+              "titel" : "Intro",
+              "start" : 609920,
+              "end" : 1276160
+            },
+            {
+              "titel" : "Level 1",
+              "start" : 1276160,
+              "end" : 2047080
+            },
+            {
+              "titel" : "Level 2",
+              "start" : 2047080,
+              "end" : 2699867
+            },
+            {
+              "titel" : "Level 3",
+              "start" : 2699867,
+              "end" : 3638080
+            },
+            {
+              "titel" : "Level 4",
+              "start" : 3638080,
+              "end" : 4496507
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/088/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/088/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/088/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/088/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/088/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/e4/91/9f/e4919f43-b9d7-d99f-1c9b-c78bf62d4497/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145713if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/85/6a/cb/0743216568925.jpg"
@@ -9931,10 +13900,46 @@
           "sprecher" : "Uli Pleßmann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Sekundenschlaf",
+              "start" : 0,
+              "end" : 625347
+            },
+            {
+              "titel" : "Eine heiße Spur",
+              "start" : 625347,
+              "end" : 869453
+            },
+            {
+              "titel" : "20. April 1979",
+              "start" : 869453,
+              "end" : 1798200
+            },
+            {
+              "titel" : "Außer Kontrolle",
+              "start" : 1798200,
+              "end" : 2174227
+            },
+            {
+              "titel" : "Drogendeal",
+              "start" : 2174227,
+              "end" : 2764373
+            },
+            {
+              "titel" : "Operation Morton",
+              "start" : 2764373,
+              "end" : 3586347
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/089/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/089/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/089/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/089/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/089/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/50/ba/1f/50ba1ffa-3d1c-31e1-f840-0a10b01a7362/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111022953if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f1/4a/9b/0743217555429.jpg"
@@ -10009,10 +14014,46 @@
           "sprecher" : "Till Demtrøder"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Im Gruselkabinett",
+              "start" : 0,
+              "end" : 531893
+            },
+            {
+              "titel" : "Das verbrannte Grab",
+              "start" : 531893,
+              "end" : 1033320
+            },
+            {
+              "titel" : "Die vier Zeichen",
+              "start" : 1033320,
+              "end" : 1772520
+            },
+            {
+              "titel" : "Die Maske des Feuerteufels",
+              "start" : 1772520,
+              "end" : 2064853
+            },
+            {
+              "titel" : "Blutbad",
+              "start" : 2064853,
+              "end" : 2929427
+            },
+            {
+              "titel" : "Feuriges Finale",
+              "start" : 2929427,
+              "end" : 3532947
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/090/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/090/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/090/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/090/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/090/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/66/8e/fe/668efe18-4202-a163-dc5a-c11a951bc12e/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023016if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/ac/60/2d/0743217555528.jpg"
@@ -10091,10 +14132,46 @@
           "sprecher" : "Barbara Schipper"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Fragen Sie die Götter",
+              "start" : 0,
+              "end" : 535480
+            },
+            {
+              "titel" : "Im Labyrinth",
+              "start" : 535480,
+              "end" : 1273893
+            },
+            {
+              "titel" : "\"Utopia\"",
+              "start" : 1273893,
+              "end" : 1801853
+            },
+            {
+              "titel" : "Im Planetarium",
+              "start" : 1801853,
+              "end" : 2096373
+            },
+            {
+              "titel" : "Römisch-Griechisch",
+              "start" : 2096373,
+              "end" : 2905720
+            },
+            {
+              "titel" : "Die ganze Wahrheit",
+              "start" : 2905720,
+              "end" : 3597147
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/091/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/091/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/091/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/091/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/091/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/42/f8/da/42f8daf5-c652-9690-283f-2a0bad5da32d/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022653if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/43/20/e3/0743217797928.jpg"
@@ -10173,10 +14250,46 @@
           "sprecher" : "Hubertus Borck"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Zehn. Neun.",
+              "start" : 0,
+              "end" : 640173
+            },
+            {
+              "titel" : "Acht. Sieben.",
+              "start" : 640173,
+              "end" : 1195187
+            },
+            {
+              "titel" : "Sechs. Fünf.",
+              "start" : 1195187,
+              "end" : 1788000
+            },
+            {
+              "titel" : "Vier. Drei.",
+              "start" : 1788000,
+              "end" : 2680213
+            },
+            {
+              "titel" : "Zwei. Eins.",
+              "start" : 2680213,
+              "end" : 2972613
+            },
+            {
+              "titel" : "Null.",
+              "start" : 2972613,
+              "end" : 3569347
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/092/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/092/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/092/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/092/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/092/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/97/7a/72/977a7252-5a7b-bcc4-f625-f8250e9e64dc/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152708if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/78/af/a9/0743217877323.jpg"
@@ -10260,10 +14373,46 @@
           "sprecher" : "Anja Topf"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Bei Nacht und Nebel",
+              "start" : 0,
+              "end" : 738640
+            },
+            {
+              "titel" : "Jagd auf das Geisterschiff",
+              "start" : 738640,
+              "end" : 1160040
+            },
+            {
+              "titel" : "Duncan, der Finstere",
+              "start" : 1160040,
+              "end" : 1637547
+            },
+            {
+              "titel" : "Das Tagebuch des Tyrannen",
+              "start" : 1637547,
+              "end" : 2011853
+            },
+            {
+              "titel" : "Die Suche nach der Schatzkarte",
+              "start" : 2011853,
+              "end" : 2622520
+            },
+            {
+              "titel" : "In Luft aufgelöst",
+              "start" : 2622520,
+              "end" : 3592133
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/093/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/093/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/093/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/093/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/093/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/11/97/bc/1197bcaa-acfe-f2e0-b33d-f2e51edc3227/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212304if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/8b/0c/72/0743217877422.jpg"
@@ -10363,10 +14512,46 @@
           "sprecher" : "Hubertus Borck"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Im Reich der wilden Tiere",
+              "start" : 0,
+              "end" : 686640
+            },
+            {
+              "titel" : "Dunnerak",
+              "start" : 686640,
+              "end" : 1268320
+            },
+            {
+              "titel" : "Ein Schrei in der Nacht",
+              "start" : 1268320,
+              "end" : 1809000
+            },
+            {
+              "titel" : "Der leere Käfig",
+              "start" : 1809000,
+              "end" : 2496360
+            },
+            {
+              "titel" : "Das Geheimnis des Monsters",
+              "start" : 2496360,
+              "end" : 2727400
+            },
+            {
+              "titel" : "Affentheater",
+              "start" : 2727400,
+              "end" : 3262720
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/094/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/094/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/094/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/094/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/094/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/ae/89/08/ae8908c3-4e89-c243-71b4-130af87fa03f/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023014if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/c3/99/3a/0743217877521.jpg"
@@ -10453,10 +14638,46 @@
           "sprecher" : "Utz Richter"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die unsichtbare Botschaft",
+              "start" : 0,
+              "end" : 666293
+            },
+            {
+              "titel" : "Popol Vuh",
+              "start" : 666293,
+              "end" : 1131747
+            },
+            {
+              "titel" : "Die Telefon-Lawine",
+              "start" : 1131747,
+              "end" : 1802573
+            },
+            {
+              "titel" : "Observierung",
+              "start" : 1802573,
+              "end" : 2516373
+            },
+            {
+              "titel" : "Melody",
+              "start" : 2516373,
+              "end" : 2997640
+            },
+            {
+              "titel" : "Das Geheimnis des heiligen Buches",
+              "start" : 2997640,
+              "end" : 3603800
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/095/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/095/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/095/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/095/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/095/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/94/80/38/948038b7-c6ef-3bfa-5ef6-fd747c3db8dc/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180123if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/74/5f/77/0743218255427.jpg"
@@ -10561,10 +14782,56 @@
           "sprecher" : "Wolfgang Kaven"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein anonymer Anruf",
+              "start" : 0,
+              "end" : 300547
+            },
+            {
+              "titel" : "Angeklagt",
+              "start" : 300547,
+              "end" : 598627
+            },
+            {
+              "titel" : "Fahrerflucht",
+              "start" : 598627,
+              "end" : 1171720
+            },
+            {
+              "titel" : "Brandstiftung",
+              "start" : 1171720,
+              "end" : 1690280
+            },
+            {
+              "titel" : "Im Zeichen des Feuers",
+              "start" : 1690280,
+              "end" : 2093080
+            },
+            {
+              "titel" : "Auf heißer Spur",
+              "start" : 2093080,
+              "end" : 2369533
+            },
+            {
+              "titel" : "Ein Geschenk für Tante Mathilda",
+              "start" : 2369533,
+              "end" : 2892000
+            },
+            {
+              "titel" : "Enttarnt",
+              "start" : 2892000,
+              "end" : 3191000
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/096/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/096/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/096/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/096/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/096/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music122/v4/cf/d7/30/cfd73035-3983-1635-426a-1a2895b7bd17/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180130if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/1e/15/a4/0743218398124.jpg"
@@ -10658,10 +14925,56 @@
           "sprecher" : "Daniel Eggers"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Panik",
+              "start" : 0,
+              "end" : 521253
+            },
+            {
+              "titel" : "Albträume",
+              "start" : 521253,
+              "end" : 1129760
+            },
+            {
+              "titel" : "Parasiten",
+              "start" : 1129760,
+              "end" : 1661760
+            },
+            {
+              "titel" : "Blutsauger",
+              "start" : 1661760,
+              "end" : 2028907
+            },
+            {
+              "titel" : "Beklemmung",
+              "start" : 2028907,
+              "end" : 2467760
+            },
+            {
+              "titel" : "Zusammenführung",
+              "start" : 2467760,
+              "end" : 3075880
+            },
+            {
+              "titel" : "Abgründe",
+              "start" : 3075880,
+              "end" : 3776907
+            },
+            {
+              "titel" : "Erlösung",
+              "start" : 3776907,
+              "end" : 4066453
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/097/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/097/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/097/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/097/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/097/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/bd/6d/b7/bd6db73c-b169-fb62-c010-6e545cabdf98/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135347if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/30/71/c1/0743218398223.jpg"
@@ -10775,10 +15088,56 @@
           "pseudonym" : "Jakob Lichtblau"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Blackout",
+              "start" : 0,
+              "end" : 449000
+            },
+            {
+              "titel" : "Der Fluch des Adlers",
+              "start" : 449000,
+              "end" : 989973
+            },
+            {
+              "titel" : "Taylor kneift",
+              "start" : 989973,
+              "end" : 1481080
+            },
+            {
+              "titel" : "Der Albtraum beginnt",
+              "start" : 1481080,
+              "end" : 1943107
+            },
+            {
+              "titel" : "Das Tal des Schreckens",
+              "start" : 1943107,
+              "end" : 2365733
+            },
+            {
+              "titel" : "Im Dickicht des Waldes",
+              "start" : 2365733,
+              "end" : 2782520
+            },
+            {
+              "titel" : "Lauschangriff",
+              "start" : 2782520,
+              "end" : 3347573
+            },
+            {
+              "titel" : "Seitenwechsel",
+              "start" : 3347573,
+              "end" : 3772307
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/098/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/098/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/098/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/098/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/098/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/fc/08/1c/fc081ca3-c2e2-3fbf-f637-d4ff19536c91/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145711if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/17/73/b3/0743218398629.jpg"
@@ -10895,10 +15254,56 @@
           "sprecher" : "André Minninger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "\"Prime-Time\"",
+              "start" : 0,
+              "end" : 513747
+            },
+            {
+              "titel" : "Kälteschauer",
+              "start" : 513747,
+              "end" : 1123107
+            },
+            {
+              "titel" : "Rufmord",
+              "start" : 1123107,
+              "end" : 1524067
+            },
+            {
+              "titel" : "Reue",
+              "start" : 1524067,
+              "end" : 2089760
+            },
+            {
+              "titel" : "Ausgetrickst",
+              "start" : 2089760,
+              "end" : 2708040
+            },
+            {
+              "titel" : "Machtspiele",
+              "start" : 2708040,
+              "end" : 3361760
+            },
+            {
+              "titel" : "In der Gummizelle",
+              "start" : 3361760,
+              "end" : 4007707
+            },
+            {
+              "titel" : "Die Flügel der Nachtigall",
+              "start" : 4007707,
+              "end" : 4573053
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/099/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/099/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/099/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/099/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/099/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/c2/65/4f/c2654fb0-412d-e6a7-b355-9ca5be368a01/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180910if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/a7/26/99/0743218398728.jpg"
@@ -10911,7 +15316,10 @@
           "teilNummer" : 1,
           "buchstabe" : "A",
           "titel" : "Das Rätsel der Sphinx",
+          "autor" : "André Marx",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Ein seltsames Rätsel und ein unbekannter Anrufer. Die drei ??? haben alle Hände voll zu tun. Wer oder was verbirgt sich hinter dem geheimnisvollen Namen \"Sphinx\"? Alle Fäden laufen auf der \"Explorer\" zusammen, einem Schiff, auf dem der neueste Fall für Justus, Peter und Bob eine dramatische Wendung nimmt …",
+          "veröffentlichungsdatum" : "2001-10-15",
           "kapitel" : [
             {
               "titel" : "Botschaft von Geisterhand",
@@ -10988,15 +15396,17 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/1/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/100/1/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/100/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/100/1/ffmetadata.txt"
           }
         },
         {
           "teilNummer" : 2,
           "buchstabe" : "B",
           "titel" : "Das vergessene Volk",
+          "autor" : "André Marx",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Dichter Urwald, ein Vulkankrater und eine unbewohnte Insel.\nPeter Shaw – ganz auf sich allein gestellt – durchlebt im Dschungel einen wahren Albtraum. Wer ist das entstellte Narbengesicht, dem er urplötzlich in einer unterirdischen Höhle gegenüber steht?",
+          "veröffentlichungsdatum" : "2001-10-15",
           "kapitel" : [
             {
               "titel" : "Die Schattenmänner",
@@ -11093,15 +15503,17 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/2/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/100/2/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/100/2/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/100/2/ffmetadata.txt"
           }
         },
         {
           "teilNummer" : 3,
           "buchstabe" : "C",
           "titel" : "Der Fluch der Gräber",
+          "autor" : "André Marx",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Eine Bombendrohung, Raketenköpfe und den Tod vor Augen zu haben, bringen nicht nur den ängstlichen Zweiten Detektiv gehörig ins Schwitzen.\n\"Makatao\", die Toteninsel, entpuppt sich als eine gefährliche Falle.\nEin nervenaufreibender Wettlauf mit der Zeit beginnt …",
+          "veröffentlichungsdatum" : "2001-10-15",
           "kapitel" : [
             {
               "titel" : "Verdeckte Fouls",
@@ -11186,8 +15598,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/100/3/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/100/3/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/100/3/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/100/3/ffmetadata.txt"
           }
         }
       ],
@@ -11256,6 +15667,113 @@
         {
           "rolle" : "Anne",
           "sprecher" : "Corinna Wodrich"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Botschaft von Geisterhand",
+              "start" : 0,
+              "end" : 490480
+            },
+            {
+              "titel" : "Der verschwundene Schatz",
+              "start" : 490480,
+              "end" : 1098520
+            },
+            {
+              "titel" : "Die Geisterinsel",
+              "start" : 1098520,
+              "end" : 1580160
+            },
+            {
+              "titel" : "Der unsichtbare Gegner",
+              "start" : 1580160,
+              "end" : 2095880
+            },
+            {
+              "titel" : "Gefahr im Verzug",
+              "start" : 2095880,
+              "end" : 2660453
+            },
+            {
+              "titel" : "Das Geisterschiff",
+              "start" : 2660453,
+              "end" : 3204573
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Schattenmänner",
+              "start" : 0,
+              "end" : 500840
+            },
+            {
+              "titel" : "Der rasende Löwe",
+              "start" : 500840,
+              "end" : 1070627
+            },
+            {
+              "titel" : "Der Doppelgänger",
+              "start" : 1070627,
+              "end" : 1677840
+            },
+            {
+              "titel" : "Der magische Kreis",
+              "start" : 1677840,
+              "end" : 2187973
+            },
+            {
+              "titel" : "Das Narbengesicht",
+              "start" : 2187973,
+              "end" : 2922893
+            },
+            {
+              "titel" : "Nacht in Angst",
+              "start" : 2922893,
+              "end" : 3376800
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Verdeckte Fouls",
+              "start" : 0,
+              "end" : 618853
+            },
+            {
+              "titel" : "Die Rache des Tigers",
+              "start" : 618853,
+              "end" : 1016733
+            },
+            {
+              "titel" : "Die rätselhaften Bilder",
+              "start" : 1016733,
+              "end" : 1685640
+            },
+            {
+              "titel" : "Das Geheimnis der Särge",
+              "start" : 1685640,
+              "end" : 2235333
+            },
+            {
+              "titel" : "Dreckiger Deal",
+              "start" : 2235333,
+              "end" : 2721600
+            },
+            {
+              "titel" : "Tödliche Spur",
+              "start" : 2721600,
+              "end" : 3410493
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log3.txt"
         }
       ],
       "links" : {
@@ -11364,10 +15882,56 @@
           "sprecher" : "Thomas Schüler"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Stromstoß",
+              "start" : 0,
+              "end" : 582613
+            },
+            {
+              "titel" : "Der allerneueste Schrei",
+              "start" : 582613,
+              "end" : 863400
+            },
+            {
+              "titel" : "Teuflische SMS",
+              "start" : 863400,
+              "end" : 1400093
+            },
+            {
+              "titel" : "Blutige Finger",
+              "start" : 1400093,
+              "end" : 1887093
+            },
+            {
+              "titel" : "Abgrundtiefe Stimme",
+              "start" : 1887093,
+              "end" : 2394867
+            },
+            {
+              "titel" : "Verfluchtes Handy",
+              "start" : 2394867,
+              "end" : 2895893
+            },
+            {
+              "titel" : "Monique Carrera",
+              "start" : 2895893,
+              "end" : 3446040
+            },
+            {
+              "titel" : "Hokus-Pokus",
+              "start" : 3446040,
+              "end" : 4313453
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/101/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/101/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/101/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/101/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/101/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/54/e9/e3/54e9e3b2-375f-de3f-5c7e-fe78f2a4f92e/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135344if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/0b/06/ee/0743218754623.jpg"
@@ -11460,10 +16024,56 @@
           "sprecher" : "André Minninger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Eindringling",
+              "start" : 0,
+              "end" : 318373
+            },
+            {
+              "titel" : "Die ungleichen Brüder",
+              "start" : 318373,
+              "end" : 868720
+            },
+            {
+              "titel" : "Einbruch bei einem Dieb",
+              "start" : 868720,
+              "end" : 1336360
+            },
+            {
+              "titel" : "Hochwertige Ergebnisse",
+              "start" : 1336360,
+              "end" : 1781320
+            },
+            {
+              "titel" : "Der gestohlene Spiegel",
+              "start" : 1781320,
+              "end" : 2179773
+            },
+            {
+              "titel" : "Videorätsel",
+              "start" : 2179773,
+              "end" : 2504040
+            },
+            {
+              "titel" : "Verwirrspiel",
+              "start" : 2504040,
+              "end" : 3074253
+            },
+            {
+              "titel" : "Aller guten Dinge",
+              "start" : 3074253,
+              "end" : 3560680
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/102/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/102/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/102/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/102/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/102/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/24/59/77/245977db-e918-6b6a-7859-a46145ab9133/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023003if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/cf/bb/e3/0743218754722.jpg"
@@ -11565,10 +16175,56 @@
           "sprecher" : "Gerhart Hinze"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Brittany",
+              "start" : 0,
+              "end" : 427240
+            },
+            {
+              "titel" : "Grüße aus dem Jenseits",
+              "start" : 427240,
+              "end" : 1078653
+            },
+            {
+              "titel" : "Das Bilderrätsel",
+              "start" : 1078653,
+              "end" : 1538347
+            },
+            {
+              "titel" : "Alarm",
+              "start" : 1538347,
+              "end" : 1901600
+            },
+            {
+              "titel" : "Geistlicher Beistand",
+              "start" : 1901600,
+              "end" : 2807613
+            },
+            {
+              "titel" : "Abbild und Wirklichkeit",
+              "start" : 2807613,
+              "end" : 3028133
+            },
+            {
+              "titel" : "Abwärts",
+              "start" : 3028133,
+              "end" : 3430280
+            },
+            {
+              "titel" : "Klartext",
+              "start" : 3430280,
+              "end" : 3810187
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/103/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/103/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/103/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/103/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/103/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/24/05/89/24058925-dfab-6db6-4943-2dd961adb463/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111022950if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/b2/d0/f4/0743218754821.jpg"
@@ -11669,10 +16325,56 @@
           "sprecher" : "Karin Lieneweg"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Detektiv gesucht",
+              "start" : 0,
+              "end" : 745920
+            },
+            {
+              "titel" : "Gift per E-Mail",
+              "start" : 745920,
+              "end" : 1119947
+            },
+            {
+              "titel" : "Eine Qualle für Tom",
+              "start" : 1119947,
+              "end" : 1414453
+            },
+            {
+              "titel" : "Ein Fall für Dick Perry",
+              "start" : 1414453,
+              "end" : 1751627
+            },
+            {
+              "titel" : "Toms Rätsel",
+              "start" : 1751627,
+              "end" : 2416880
+            },
+            {
+              "titel" : "Pelagia noctiluca",
+              "start" : 2416880,
+              "end" : 2949333
+            },
+            {
+              "titel" : "Des Rätsels Lösung",
+              "start" : 2949333,
+              "end" : 3431733
+            },
+            {
+              "titel" : "Falsches Spiel",
+              "start" : 3431733,
+              "end" : 4138120
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/104/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/104/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/104/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/104/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/104/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/58/16/57/581657a6-edcf-0fb6-65a9-55872658347c/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153400if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/90/96/ce/0743218754920.jpg"
@@ -11769,10 +16471,56 @@
           "sprecher" : "Hartmut Kollakowsky"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ruhestörung",
+              "start" : 0,
+              "end" : 570107
+            },
+            {
+              "titel" : "Das Phantom vom Nebelberg",
+              "start" : 570107,
+              "end" : 1464027
+            },
+            {
+              "titel" : "Gruselgeschichten",
+              "start" : 1464027,
+              "end" : 1910827
+            },
+            {
+              "titel" : "Das Grauen schlägt zu",
+              "start" : 1910827,
+              "end" : 2183413
+            },
+            {
+              "titel" : "Gold",
+              "start" : 2183413,
+              "end" : 2913453
+            },
+            {
+              "titel" : "Das Herz des Berges",
+              "start" : 2913453,
+              "end" : 3285293
+            },
+            {
+              "titel" : "Die Stunde der Wahrheit",
+              "start" : 3285293,
+              "end" : 3864213
+            },
+            {
+              "titel" : "Weckruf",
+              "start" : 3864213,
+              "end" : 4545293
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/105/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/105/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/105/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/105/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/105/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/ba/05/89/ba058927-670b-4dc5-15a2-07f53046018f/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180120if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/ec/25/e0/0743218755026.jpg"
@@ -11899,10 +16647,56 @@
           "sprecher" : "Echt"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Saturday Night Fever",
+              "start" : 0,
+              "end" : 568547
+            },
+            {
+              "titel" : "Disco-Inferno",
+              "start" : 568547,
+              "end" : 1206787
+            },
+            {
+              "titel" : "Mit dem Teufel im Bunde",
+              "start" : 1206787,
+              "end" : 1534827
+            },
+            {
+              "titel" : "\"Devil-Dancer\"",
+              "start" : 1534827,
+              "end" : 2129680
+            },
+            {
+              "titel" : "Die Kutte des Satans",
+              "start" : 2129680,
+              "end" : 2486853
+            },
+            {
+              "titel" : "Massensuggestion",
+              "start" : 2486853,
+              "end" : 2950027
+            },
+            {
+              "titel" : "Die letzte Ruhestätte",
+              "start" : 2950027,
+              "end" : 3828987
+            },
+            {
+              "titel" : "Tödliches Abgas",
+              "start" : 3828987,
+              "end" : 4255213
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/106/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/106/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/106/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/106/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/106/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/88/20/9f/88209fb7-3552-bd4f-86b1-502f95110aa5/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152705if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/80/69/0f/0743219432520.jpg"
@@ -12007,10 +16801,56 @@
           "sprecher" : "Ingeburg Kanstein"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das geheimnisvolle Kästchen",
+              "start" : 0,
+              "end" : 661440
+            },
+            {
+              "titel" : "Der Messerwerfer",
+              "start" : 661440,
+              "end" : 1077000
+            },
+            {
+              "titel" : "Erwischt",
+              "start" : 1077000,
+              "end" : 1596280
+            },
+            {
+              "titel" : "Die Vision",
+              "start" : 1596280,
+              "end" : 2104453
+            },
+            {
+              "titel" : "Treffpunkt \"Bookstore\"",
+              "start" : 2104453,
+              "end" : 2403013
+            },
+            {
+              "titel" : "Wiedergeburt",
+              "start" : 2403013,
+              "end" : 2902787
+            },
+            {
+              "titel" : "Im buddhistischen Zentrum",
+              "start" : 2902787,
+              "end" : 3196947
+            },
+            {
+              "titel" : "Das Geheimnis des Kästchens",
+              "start" : 3196947,
+              "end" : 3850840
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/107/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/107/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/107/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/107/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/107/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/21/0d/ba/210dbaae-53f4-35b9-a6d4-d2f93ad9253d/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153356if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/3f/0d/e8/0743219432629.jpg"
@@ -12104,10 +16944,61 @@
           "sprecher" : "Hans Sievers"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die sieben Tore",
+              "start" : 0,
+              "end" : 539480
+            },
+            {
+              "titel" : "Ein seltsamer Zeitgenosse",
+              "start" : 539480,
+              "end" : 674560
+            },
+            {
+              "titel" : "Nächtliche Begegnung",
+              "start" : 674560,
+              "end" : 1356613
+            },
+            {
+              "titel" : "Der Brief",
+              "start" : 1356613,
+              "end" : 1731560
+            },
+            {
+              "titel" : "Rhetorische Meisterleistung",
+              "start" : 1731560,
+              "end" : 1882267
+            },
+            {
+              "titel" : "Labiler Zustand",
+              "start" : 1882267,
+              "end" : 2568960
+            },
+            {
+              "titel" : "Der heilige Skarabäus",
+              "start" : 2568960,
+              "end" : 3012053
+            },
+            {
+              "titel" : "Soo-Ann",
+              "start" : 3012053,
+              "end" : 3290867
+            },
+            {
+              "titel" : "Erinnerung",
+              "start" : 3290867,
+              "end" : 4004480
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/108/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/108/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/108/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/108/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/108/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/a0/a0/9b/a0a09bed-8652-3b39-03ce-479a4800718f/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145709if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/40/7b/74/0743219432728.jpg"
@@ -12216,10 +17107,56 @@
           "sprecher" : "Traudel Sperber"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "\"Wer knackt die Nuss?\"",
+              "start" : 0,
+              "end" : 843213
+            },
+            {
+              "titel" : "Auf Sendung",
+              "start" : 843213,
+              "end" : 1436867
+            },
+            {
+              "titel" : "24 Stunden Galgenfrist",
+              "start" : 1436867,
+              "end" : 1777947
+            },
+            {
+              "titel" : "Rätsel-Leichen",
+              "start" : 1777947,
+              "end" : 2206960
+            },
+            {
+              "titel" : "\"Jack, the Riddler\"",
+              "start" : 2206960,
+              "end" : 2617560
+            },
+            {
+              "titel" : "Namen und Symbole",
+              "start" : 2617560,
+              "end" : 2994160
+            },
+            {
+              "titel" : "Von den Toten auferstanden",
+              "start" : 2994160,
+              "end" : 3474133
+            },
+            {
+              "titel" : "Wer zuletzt lacht …",
+              "start" : 3474133,
+              "end" : 4027533
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/109/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/109/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/109/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/109/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/109/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/99/ef/53/99ef53fd-cac8-923d-5e58-a83e9cfed484/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022643if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f4/14/a3/0743219432827.jpg"
@@ -12332,10 +17269,56 @@
           "sprecher" : "Kristian Kretschmer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Monster im Park",
+              "start" : 0,
+              "end" : 406400
+            },
+            {
+              "titel" : "Lauft!",
+              "start" : 406400,
+              "end" : 1030573
+            },
+            {
+              "titel" : "Nicht von dieser Welt",
+              "start" : 1030573,
+              "end" : 1468880
+            },
+            {
+              "titel" : "Die Hypothese",
+              "start" : 1468880,
+              "end" : 2056173
+            },
+            {
+              "titel" : "Seuchenalarm",
+              "start" : 2056173,
+              "end" : 2541733
+            },
+            {
+              "titel" : "Justus lässt nicht locker",
+              "start" : 2541733,
+              "end" : 2689973
+            },
+            {
+              "titel" : "Kombinationsgabe",
+              "start" : 2689973,
+              "end" : 2891000
+            },
+            {
+              "titel" : "Im Tunnel",
+              "start" : 2891000,
+              "end" : 3310573
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/110/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/110/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/110/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/110/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/110/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music60/v4/f0/31/0c/f0310ce7-09a1-98b1-feb3-fc7a574e8921/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022655if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/7b/06/4a/0743219432926.jpg"
@@ -12486,10 +17469,86 @@
           "sprecher" : "Georg Marquard"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Geisterburg",
+              "start" : 0,
+              "end" : 259413
+            },
+            {
+              "titel" : "Überraschung im Zug",
+              "start" : 259413,
+              "end" : 414053
+            },
+            {
+              "titel" : "Starke Nerven",
+              "start" : 414053,
+              "end" : 589720
+            },
+            {
+              "titel" : "Der Wilderer",
+              "start" : 589720,
+              "end" : 729853
+            },
+            {
+              "titel" : "Der schwarze Vogel",
+              "start" : 729853,
+              "end" : 1133507
+            },
+            {
+              "titel" : "Teufelsbraten mit Soße",
+              "start" : 1133507,
+              "end" : 1395400
+            },
+            {
+              "titel" : "Das pure Entsetzen",
+              "start" : 1395400,
+              "end" : 2091120
+            },
+            {
+              "titel" : "Bis ins kleinste Detail",
+              "start" : 2091120,
+              "end" : 2180373
+            },
+            {
+              "titel" : "Wo ist Blackeye?",
+              "start" : 2180373,
+              "end" : 2422107
+            },
+            {
+              "titel" : "Gespensterjäger",
+              "start" : 2422107,
+              "end" : 2669653
+            },
+            {
+              "titel" : "Von der Außenwelt abgeschnitten",
+              "start" : 2669653,
+              "end" : 2878160
+            },
+            {
+              "titel" : "Der schwarze Henker",
+              "start" : 2878160,
+              "end" : 3128000
+            },
+            {
+              "titel" : "Sprung über den Abgrund",
+              "start" : 3128000,
+              "end" : 3614813
+            },
+            {
+              "titel" : "Gut gemacht, Justus Jonas!",
+              "start" : 3614813,
+              "end" : 3906600
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/111/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/111/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/111/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/111/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/111/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/68/f8/bf/68f8bf4d-440e-082f-765c-6126b54cc158/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230855if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/13/cb/05/0743219911124.jpg"
@@ -12611,10 +17670,81 @@
           "sprecher" : "Dennis Jensen"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Unternehmensphilosophie",
+              "start" : 0,
+              "end" : 164520
+            },
+            {
+              "titel" : "Ein Gaul namens \"Lady\"",
+              "start" : 164520,
+              "end" : 468947
+            },
+            {
+              "titel" : "Die erste Feder",
+              "start" : 468947,
+              "end" : 642880
+            },
+            {
+              "titel" : "Die zweite Feder",
+              "start" : 642880,
+              "end" : 727000
+            },
+            {
+              "titel" : "Ein Fachmann indianischer Kultur",
+              "start" : 727000,
+              "end" : 1263920
+            },
+            {
+              "titel" : "Schlucht der Dämonen",
+              "start" : 1263920,
+              "end" : 1415427
+            },
+            {
+              "titel" : "Die dritte Feder",
+              "start" : 1415427,
+              "end" : 1859680
+            },
+            {
+              "titel" : "Von Kakteen umgeben",
+              "start" : 1859680,
+              "end" : 1954040
+            },
+            {
+              "titel" : "Überfall",
+              "start" : 1954040,
+              "end" : 2216573
+            },
+            {
+              "titel" : "Kriegstrommeln",
+              "start" : 2216573,
+              "end" : 2514213
+            },
+            {
+              "titel" : "Justus flucht",
+              "start" : 2514213,
+              "end" : 2709840
+            },
+            {
+              "titel" : "Eine alte Indianer-Sage",
+              "start" : 2709840,
+              "end" : 2865147
+            },
+            {
+              "titel" : "Sturz in die Schlucht",
+              "start" : 2865147,
+              "end" : 3529667
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/112/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/112/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/112/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/112/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/112/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/c5/c7/eb/c5c7ebdf-62f4-219b-3fcc-2d3729727627/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111022959if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/9c/cf/07/0743219911223.jpg"
@@ -12741,10 +17871,86 @@
           "sprecher" : "Karin Lieneweg"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Luftangriff",
+              "start" : 0,
+              "end" : 265867
+            },
+            {
+              "titel" : "Von Drachen und Trollen",
+              "start" : 265867,
+              "end" : 428893
+            },
+            {
+              "titel" : "Blühende Fantasie",
+              "start" : 428893,
+              "end" : 819747
+            },
+            {
+              "titel" : "Das Reich der Elfenkönigin",
+              "start" : 819747,
+              "end" : 999320
+            },
+            {
+              "titel" : "Der Gerechte",
+              "start" : 999320,
+              "end" : 1596880
+            },
+            {
+              "titel" : "Nestor natabilis",
+              "start" : 1596880,
+              "end" : 1739880
+            },
+            {
+              "titel" : "Worum geht es?",
+              "start" : 1739880,
+              "end" : 1904040
+            },
+            {
+              "titel" : "Eine gewisse Ähnlichkeit",
+              "start" : 1904040,
+              "end" : 2115187
+            },
+            {
+              "titel" : "Ratlos",
+              "start" : 2115187,
+              "end" : 2226253
+            },
+            {
+              "titel" : "Geldgierige Neffen",
+              "start" : 2226253,
+              "end" : 2441773
+            },
+            {
+              "titel" : "Emilys Drache",
+              "start" : 2441773,
+              "end" : 2656627
+            },
+            {
+              "titel" : "Mit anderen Augen",
+              "start" : 2656627,
+              "end" : 3059320
+            },
+            {
+              "titel" : "Der verzauberte Schatz",
+              "start" : 3059320,
+              "end" : 3167240
+            },
+            {
+              "titel" : "Das Auge des Drachen",
+              "start" : 3167240,
+              "end" : 3607400
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/113/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/113/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/113/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/113/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/113/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music20/v4/6d/12/60/6d1260a4-3685-672c-10a8-f1c6e11e35ca/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180905if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f9/4c/e1/0743219911322.jpg"
@@ -12865,10 +18071,76 @@
           "sprecher" : "Christian Niehues"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Problem",
+              "start" : 0,
+              "end" : 234147
+            },
+            {
+              "titel" : "Besuch im Märchenschloss",
+              "start" : 234147,
+              "end" : 850707
+            },
+            {
+              "titel" : "Tante Mathildas Versprechen",
+              "start" : 850707,
+              "end" : 960493
+            },
+            {
+              "titel" : "Séance",
+              "start" : 960493,
+              "end" : 1315747
+            },
+            {
+              "titel" : "In Luft aufgelöst",
+              "start" : 1315747,
+              "end" : 1786267
+            },
+            {
+              "titel" : "Die Sache stinkt",
+              "start" : 1786267,
+              "end" : 2167507
+            },
+            {
+              "titel" : "Sodom und Gomorrha",
+              "start" : 2167507,
+              "end" : 2437107
+            },
+            {
+              "titel" : "Phantomstimmen",
+              "start" : 2437107,
+              "end" : 2707453
+            },
+            {
+              "titel" : "Und der Mörder ist …",
+              "start" : 2707453,
+              "end" : 2977680
+            },
+            {
+              "titel" : "Das Testament",
+              "start" : 2977680,
+              "end" : 3121520
+            },
+            {
+              "titel" : "Im Keller eines Fans",
+              "start" : 3121520,
+              "end" : 3431360
+            },
+            {
+              "titel" : "Cinderella",
+              "start" : 3431360,
+              "end" : 4150480
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/114/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/114/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/114/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/114/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/114/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/fd/c0/fb/fdc0fb3e-b9c4-c89c-646d-480d0d8a0f00/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023006if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/ac/2f/81/0743219911421.jpg"
@@ -13017,10 +18289,91 @@
           "sprecher" : "Victoria Trauttmansdorff"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein alter Bekannter",
+              "start" : 0,
+              "end" : 519307
+            },
+            {
+              "titel" : "Diebesgut",
+              "start" : 519307,
+              "end" : 680947
+            },
+            {
+              "titel" : "Ein paar Jahre auf dem Buckel",
+              "start" : 680947,
+              "end" : 772400
+            },
+            {
+              "titel" : "Entwischt",
+              "start" : 772400,
+              "end" : 971653
+            },
+            {
+              "titel" : "Kindheitsträume",
+              "start" : 971653,
+              "end" : 1080227
+            },
+            {
+              "titel" : "Zeichen und Symbole",
+              "start" : 1080227,
+              "end" : 1191613
+            },
+            {
+              "titel" : "Neugierige Rechtsanwältin",
+              "start" : 1191613,
+              "end" : 1272347
+            },
+            {
+              "titel" : "Wichtige Information",
+              "start" : 1272347,
+              "end" : 1367227
+            },
+            {
+              "titel" : "Das Gemälde mit dem Schiff",
+              "start" : 1367227,
+              "end" : 1459933
+            },
+            {
+              "titel" : "Schlüssel zur Herkunft",
+              "start" : 1459933,
+              "end" : 1875693
+            },
+            {
+              "titel" : "Der Gründer von \"Rothman-Oil\"",
+              "start" : 1875693,
+              "end" : 2695667
+            },
+            {
+              "titel" : "Herzanfall",
+              "start" : 2695667,
+              "end" : 3050160
+            },
+            {
+              "titel" : "Entscheidende Phase",
+              "start" : 3050160,
+              "end" : 3342893
+            },
+            {
+              "titel" : "Einbruch",
+              "start" : 3342893,
+              "end" : 3427853
+            },
+            {
+              "titel" : "Die letzte Fahrt der \"Gwendolyn\"",
+              "start" : 3427853,
+              "end" : 4200627
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/115/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/115/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/115/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/115/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/115/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music18/v4/ef/67/49/ef67493f-c2f5-1971-f9fe-0e8ed9b1c7b3/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180117if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/1b/61/c2/0743219911520.jpg"
@@ -13126,10 +18479,61 @@
           "sprecher" : "Anja Topf"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Schwierigkeiten",
+              "start" : 0,
+              "end" : 276147
+            },
+            {
+              "titel" : "Autounfall",
+              "start" : 276147,
+              "end" : 1555733
+            },
+            {
+              "titel" : "Ω, 4-14",
+              "start" : 1555733,
+              "end" : 1713280
+            },
+            {
+              "titel" : "Verschlüsselt",
+              "start" : 1713280,
+              "end" : 2007867
+            },
+            {
+              "titel" : "Abhauen!",
+              "start" : 2007867,
+              "end" : 2264573
+            },
+            {
+              "titel" : "\"Memory\"",
+              "start" : 2264573,
+              "end" : 2654533
+            },
+            {
+              "titel" : "Co.B.Ra",
+              "start" : 2654533,
+              "end" : 3219107
+            },
+            {
+              "titel" : "Babylonia",
+              "start" : 3219107,
+              "end" : 3541933
+            },
+            {
+              "titel" : "Rumpelstilzchenfaktor",
+              "start" : 3541933,
+              "end" : 3724893
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/116/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/116/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/116/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/116/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/116/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music42/v4/a6/65/01/a66501b9-5948-943a-34f4-191a44c23616/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045247if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/e1/32/78/0743219911629.jpg"
@@ -13254,10 +18658,71 @@
           "sprecher" : "Brigitte Böttrich"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Kommt ein Koffer geflogen …",
+              "start" : 0,
+              "end" : 632720
+            },
+            {
+              "titel" : "Feuer!",
+              "start" : 632720,
+              "end" : 836907
+            },
+            {
+              "titel" : "Hinterher!",
+              "start" : 836907,
+              "end" : 1171240
+            },
+            {
+              "titel" : "Kontrolle ist besser",
+              "start" : 1171240,
+              "end" : 1756587
+            },
+            {
+              "titel" : "Der Pakt",
+              "start" : 1756587,
+              "end" : 2356800
+            },
+            {
+              "titel" : "Operation Geldkoffer",
+              "start" : 2356800,
+              "end" : 2508120
+            },
+            {
+              "titel" : "Reisepläne",
+              "start" : 2508120,
+              "end" : 2601440
+            },
+            {
+              "titel" : "In der Klemme",
+              "start" : 2601440,
+              "end" : 3065427
+            },
+            {
+              "titel" : "Verschwunden",
+              "start" : 3065427,
+              "end" : 3196347
+            },
+            {
+              "titel" : "Falschgeld",
+              "start" : 3196347,
+              "end" : 3370160
+            },
+            {
+              "titel" : "Ein ehrlicher Staatsbürger",
+              "start" : 3370160,
+              "end" : 3640027
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/117/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/117/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/117/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/117/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/117/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/a7/8d/f7/a78df76d-dea3-81fe-a2c0-e8dc753f10ef/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180902if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/51/9b/21/0743219911728.jpg"
@@ -13399,10 +18864,81 @@
           "sprecher" : "Marion Klaus"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Erwischt",
+              "start" : 0,
+              "end" : 398720
+            },
+            {
+              "titel" : "Der Chef",
+              "start" : 398720,
+              "end" : 561960
+            },
+            {
+              "titel" : "Islamisches Heiligtum",
+              "start" : 561960,
+              "end" : 923227
+            },
+            {
+              "titel" : "Ein Pflegefall",
+              "start" : 923227,
+              "end" : 1103533
+            },
+            {
+              "titel" : "Im Geisterhaus",
+              "start" : 1103533,
+              "end" : 1317600
+            },
+            {
+              "titel" : "\"Fly\" – die Fliege",
+              "start" : 1317600,
+              "end" : 1535547
+            },
+            {
+              "titel" : "Die Maske des Steinzeitmenschen",
+              "start" : 1535547,
+              "end" : 1793400
+            },
+            {
+              "titel" : "Die einzig existierende Textvorlage",
+              "start" : 1793400,
+              "end" : 1961787
+            },
+            {
+              "titel" : "Feuer!",
+              "start" : 1961787,
+              "end" : 2283453
+            },
+            {
+              "titel" : "Ein wichtiges Detail",
+              "start" : 2283453,
+              "end" : 2712213
+            },
+            {
+              "titel" : "\"Dime ahora …\"",
+              "start" : 2712213,
+              "end" : 2881440
+            },
+            {
+              "titel" : "Pressemitteilung",
+              "start" : 2881440,
+              "end" : 2943840
+            },
+            {
+              "titel" : "Premiere",
+              "start" : 2943840,
+              "end" : 3996413
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/118/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/118/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/118/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/118/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/118/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/ed/ef/9f/edef9fb1-0ffa-9f9f-28e4-0431393c678a/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212316if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/ba/96/68/0743219911827.jpg"
@@ -13542,10 +19078,86 @@
           "sprecher" : "Frank Felicetti"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Wertvolle Sammlerstücke",
+              "start" : 0,
+              "end" : 196320
+            },
+            {
+              "titel" : "Ein original Mobimec",
+              "start" : 196320,
+              "end" : 595960
+            },
+            {
+              "titel" : "Drei fanatische Sammler",
+              "start" : 595960,
+              "end" : 780547
+            },
+            {
+              "titel" : "Schlupfkrabbler",
+              "start" : 780547,
+              "end" : 944600
+            },
+            {
+              "titel" : "Erdbebensicher",
+              "start" : 944600,
+              "end" : 1355960
+            },
+            {
+              "titel" : "Raus aus der Schusslinie",
+              "start" : 1355960,
+              "end" : 1519933
+            },
+            {
+              "titel" : "Was ist in der Kiste?",
+              "start" : 1519933,
+              "end" : 1659533
+            },
+            {
+              "titel" : "Der kreative Kopf der Firma",
+              "start" : 1659533,
+              "end" : 2277280
+            },
+            {
+              "titel" : "Roboter",
+              "start" : 2277280,
+              "end" : 2322213
+            },
+            {
+              "titel" : "Rohrpost der besonderen Art",
+              "start" : 2322213,
+              "end" : 2952840
+            },
+            {
+              "titel" : "Die Stadt der Engel",
+              "start" : 2952840,
+              "end" : 3109120
+            },
+            {
+              "titel" : "Im Dämmerlicht der Kirche",
+              "start" : 3109120,
+              "end" : 3313987
+            },
+            {
+              "titel" : "Zahlenrätsel",
+              "start" : 3313987,
+              "end" : 3558280
+            },
+            {
+              "titel" : "Kostenlose Werbung",
+              "start" : 3558280,
+              "end" : 4063440
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/119/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/119/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/119/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/119/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/119/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music22/v4/be/dc/91/bedc9105-adb8-ff7d-c96d-d3408a397569/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153352if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/39/28/e3/0743219911926.jpg"
@@ -13653,10 +19265,71 @@
           "sprecher" : "Alexander Müller"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Panik!",
+              "start" : 0,
+              "end" : 265680
+            },
+            {
+              "titel" : "Der Lebensretter",
+              "start" : 265680,
+              "end" : 547587
+            },
+            {
+              "titel" : "Mehrere Todesopfer",
+              "start" : 547587,
+              "end" : 917427
+            },
+            {
+              "titel" : "Im Tropeninstitut",
+              "start" : 917427,
+              "end" : 1488587
+            },
+            {
+              "titel" : "Deep Throat",
+              "start" : 1488587,
+              "end" : 1763173
+            },
+            {
+              "titel" : "Feueralarm",
+              "start" : 1763173,
+              "end" : 2156213
+            },
+            {
+              "titel" : "Von Gifttieren attackiert",
+              "start" : 2156213,
+              "end" : 2388360
+            },
+            {
+              "titel" : "Notruf",
+              "start" : 2388360,
+              "end" : 2828693
+            },
+            {
+              "titel" : "Die Lösung",
+              "start" : 2828693,
+              "end" : 2994813
+            },
+            {
+              "titel" : "Purer Sand",
+              "start" : 2994813,
+              "end" : 3251987
+            },
+            {
+              "titel" : "Einfache Logik",
+              "start" : 3251987,
+              "end" : 3528253
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/120/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/120/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/120/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/120/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/120/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/99/41/b1/9941b196-0ece-26a3-7b77-a9dbe07c05d2/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212314if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/36/89/5b/0743219912022.jpg"
@@ -13786,10 +19459,81 @@
           "sprecher" : "Michael Lott"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Fehlende Erinnerung",
+              "start" : 0,
+              "end" : 199973
+            },
+            {
+              "titel" : "Filmriss",
+              "start" : 199973,
+              "end" : 519067
+            },
+            {
+              "titel" : "Eins, Punkt, Fragezeichen",
+              "start" : 519067,
+              "end" : 760533
+            },
+            {
+              "titel" : "Hasta la vista!",
+              "start" : 760533,
+              "end" : 892200
+            },
+            {
+              "titel" : "Verdächtiges Individuum",
+              "start" : 892200,
+              "end" : 1075480
+            },
+            {
+              "titel" : "Fliegende Orangen",
+              "start" : 1075480,
+              "end" : 1332480
+            },
+            {
+              "titel" : "Absolute Dunkelheit",
+              "start" : 1332480,
+              "end" : 1518067
+            },
+            {
+              "titel" : "Gequirlter Blödsinn",
+              "start" : 1518067,
+              "end" : 1675573
+            },
+            {
+              "titel" : "Hilfeschrei",
+              "start" : 1675573,
+              "end" : 1833213
+            },
+            {
+              "titel" : "Amnesie",
+              "start" : 1833213,
+              "end" : 2312933
+            },
+            {
+              "titel" : "Überzeugende Schauspielkunst",
+              "start" : 2312933,
+              "end" : 2461267
+            },
+            {
+              "titel" : "Notbremse",
+              "start" : 2461267,
+              "end" : 3246733
+            },
+            {
+              "titel" : "In Deckung!",
+              "start" : 3246733,
+              "end" : 3762347
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/121/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/121/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/121/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/121/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/121/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/f8/2a/cc/f82acc38-a2c5-6dc7-c938-bd360a4d186f/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045239if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/9d/af/d9/0828766712124.jpg"
@@ -13903,10 +19647,61 @@
           "sprecher" : "Lou Wong"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Kein Platz mehr frei!",
+              "start" : 0,
+              "end" : 480747
+            },
+            {
+              "titel" : "Entgleist?",
+              "start" : 480747,
+              "end" : 1122253
+            },
+            {
+              "titel" : "Wertvolles Indiz",
+              "start" : 1122253,
+              "end" : 1727947
+            },
+            {
+              "titel" : "In der Sackgasse",
+              "start" : 1727947,
+              "end" : 2005133
+            },
+            {
+              "titel" : "Der \"Chinesentunnel\"",
+              "start" : 2005133,
+              "end" : 2511933
+            },
+            {
+              "titel" : "Durchleuchtete Puppen",
+              "start" : 2511933,
+              "end" : 2967387
+            },
+            {
+              "titel" : "Arg konstruiert",
+              "start" : 2967387,
+              "end" : 3091427
+            },
+            {
+              "titel" : "Hände hoch!",
+              "start" : 3091427,
+              "end" : 3413960
+            },
+            {
+              "titel" : "Gold!",
+              "start" : 3413960,
+              "end" : 3494760
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/122/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/122/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/122/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/122/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/122/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/72/b5/d1/72b5d183-da92-8f34-e181-4abd6a0d6f7c/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230912if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/8d/86/3f/0828766712223.jpg"
@@ -14014,10 +19809,71 @@
           "sprecher" : "Peter Heinrich Brix"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Abergläubische Großeltern",
+              "start" : 0,
+              "end" : 305107
+            },
+            {
+              "titel" : "Schock!",
+              "start" : 305107,
+              "end" : 851347
+            },
+            {
+              "titel" : "Totenuhr im Wohnzimmer",
+              "start" : 851347,
+              "end" : 1144893
+            },
+            {
+              "titel" : "Dunkler Punkt in der Vergangenheit",
+              "start" : 1144893,
+              "end" : 1515587
+            },
+            {
+              "titel" : "Herzanfall!",
+              "start" : 1515587,
+              "end" : 1826600
+            },
+            {
+              "titel" : "Verfluchte Grabkammer",
+              "start" : 1826600,
+              "end" : 2285080
+            },
+            {
+              "titel" : "Völlig desorientiert",
+              "start" : 2285080,
+              "end" : 2477853
+            },
+            {
+              "titel" : "In der Falle",
+              "start" : 2477853,
+              "end" : 2827893
+            },
+            {
+              "titel" : "Der Schreck in den Gliedern",
+              "start" : 2827893,
+              "end" : 3109800
+            },
+            {
+              "titel" : "Im Hexenkessel",
+              "start" : 3109800,
+              "end" : 3184333
+            },
+            {
+              "titel" : "Angst und Abscheu",
+              "start" : 3184333,
+              "end" : 3677213
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/123/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/123/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/123/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/123/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/123/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/4c/4b/56/4c4b56ab-d5a0-4eb8-bc41-0a319cde68ff/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135342if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/c8/50/c6/0828766712322.jpg"
@@ -14145,10 +20001,91 @@
           "sprecher" : "Patrick Bach"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Entführt!",
+              "start" : 0,
+              "end" : 579907
+            },
+            {
+              "titel" : "Eine Million Dollar",
+              "start" : 579907,
+              "end" : 977560
+            },
+            {
+              "titel" : "Nichts wie weg!",
+              "start" : 977560,
+              "end" : 1399053
+            },
+            {
+              "titel" : "Ein unwesentlicher Kollege",
+              "start" : 1399053,
+              "end" : 1677373
+            },
+            {
+              "titel" : "Auf den Fersen",
+              "start" : 1677373,
+              "end" : 1776213
+            },
+            {
+              "titel" : "Genialer Plan",
+              "start" : 1776213,
+              "end" : 1965400
+            },
+            {
+              "titel" : "Die Jagd beginnt",
+              "start" : 1965400,
+              "end" : 2111267
+            },
+            {
+              "titel" : "Wo ist der Entführer?",
+              "start" : 2111267,
+              "end" : 2214213
+            },
+            {
+              "titel" : "Gratulation!",
+              "start" : 2214213,
+              "end" : 2456800
+            },
+            {
+              "titel" : "Überfall",
+              "start" : 2456800,
+              "end" : 2641853
+            },
+            {
+              "titel" : "Nachtwanderung",
+              "start" : 2641853,
+              "end" : 2772547
+            },
+            {
+              "titel" : "Zerschmettert",
+              "start" : 2772547,
+              "end" : 3041227
+            },
+            {
+              "titel" : "Kleinholz",
+              "start" : 3041227,
+              "end" : 3299427
+            },
+            {
+              "titel" : "Minderjährig",
+              "start" : 3299427,
+              "end" : 3428760
+            },
+            {
+              "titel" : "Abschiedskonzert",
+              "start" : 3428760,
+              "end" : 3990920
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/124/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/124/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/124/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/124/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/124/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/7d/54/ac/7d54acbe-dcc6-b830-3acb-312674973b69/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212311if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/dd/b0/d9/0828766712421.jpg"
@@ -14161,7 +20098,10 @@
           "teilNummer" : 1,
           "buchstabe" : "A",
           "titel" : "Das Rätsel der Meister",
+          "autor" : "André Marx",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Justus, Peter und Bob sind alte Briefe des berühmten, verstorbenen Malers Jaccard zugespielt worden. Warum will jemand das Interesse der drei ??? auf das Gemälde \"Feuermond\" lenken, von dem in den Briefen die Rede ist? Und vor allen Dingen: Wer steckt dahinter? Als der international gesuchte Meisterdieb Victor Hugenay auftaucht, ist endgültig klar: Die drei ??? befinden sich wieder mitten in einem gefährlichen Abenteuer …",
+          "veröffentlichungsdatum" : "2008-10-10",
           "kapitel" : [
             {
               "titel" : "Flammen in der Nacht",
@@ -14277,15 +20217,17 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/1/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/125/1/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/125/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/125/1/ffmetadata.txt"
           }
         },
         {
           "teilNummer" : 2,
           "buchstabe" : "B",
           "titel" : "Der Pfad der Täuschung",
+          "autor" : "André Marx",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Welche Informationen hat der gesuchte Meisterdieb Victor Hugenay über das berühmte, verschollene Gemälde \"Feuermond\", hinter dem so viele her sind? Justus, Peter und Bob müssen haarscharf kombinieren. Unter Einsatz aller Kräfte treiben die drei ??? den Fall voran. Sogar die Zentrale, der betagte Wohnwagen, muss für einen atemberaubenden Einsatz auf kurvenreicher Straße herhalten …",
+          "veröffentlichungsdatum" : "2008-10-10",
           "kapitel" : [
             {
               "titel" : "Das Schweigen des Meisterdiebs",
@@ -14432,15 +20374,17 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/2/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/125/2/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/125/2/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/125/2/ffmetadata.txt"
           }
         },
         {
           "teilNummer" : 3,
           "buchstabe" : "C",
           "titel" : "Die Nacht der Schatten",
+          "autor" : "André Marx",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Auf einer kleinen Insel vor Rocky Beach treffen die drei ??? in nächtlicher Finsternis erneut auf den Meisterdieb Hugenay. Die Jagd nach \"Feuermond\" beginnt. Und schnell zeigt sich, dass es die drei Detektive mit mehr als einem Widersacher zu tun haben.\nWem wird es gelingen, das Gemälde zu finden und das große Geheimnis um \"Feuermond\" zu lüften?",
+          "veröffentlichungsdatum" : "2008-10-10",
           "kapitel" : [
             {
               "titel" : "Blanker Unsinn",
@@ -14597,8 +20541,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/125/3/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/125/3/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/125/3/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/125/3/ffmetadata.txt"
           }
         }
       ],
@@ -14713,6 +20656,233 @@
         {
           "rolle" : "Mr. Baker",
           "sprecher" : "Wolf Pahlke"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Flammen in der Nacht",
+              "start" : 0,
+              "end" : 687307
+            },
+            {
+              "titel" : "Jaccards Briefe",
+              "start" : 687307,
+              "end" : 1485080
+            },
+            {
+              "titel" : "Hinterher!",
+              "start" : 1485080,
+              "end" : 1615893
+            },
+            {
+              "titel" : "Das blanke Entsetzen",
+              "start" : 1615893,
+              "end" : 1856933
+            },
+            {
+              "titel" : "Juniordetektive auf der falschen Bahn",
+              "start" : 1856933,
+              "end" : 2204773
+            },
+            {
+              "titel" : "Recherchen",
+              "start" : 2204773,
+              "end" : 2472467
+            },
+            {
+              "titel" : "Fünf vor zwölf",
+              "start" : 2472467,
+              "end" : 2692880
+            },
+            {
+              "titel" : "Zwölf Uhr Mittags",
+              "start" : 2692880,
+              "end" : 2853760
+            },
+            {
+              "titel" : "Das Angebot",
+              "start" : 2853760,
+              "end" : 3382587
+            },
+            {
+              "titel" : "Präpariertes Päckchen",
+              "start" : 3382587,
+              "end" : 3455653
+            },
+            {
+              "titel" : "Entwischt!",
+              "start" : 3455653,
+              "end" : 4106587
+            },
+            {
+              "titel" : "\"Zwischen 1 und 2\"",
+              "start" : 4106587,
+              "end" : 4488347
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Schweigen des Meisterdiebs",
+              "start" : 0,
+              "end" : 347000
+            },
+            {
+              "titel" : "Überwacht",
+              "start" : 347000,
+              "end" : 489160
+            },
+            {
+              "titel" : "Hugenays Geschichte",
+              "start" : 489160,
+              "end" : 1005013
+            },
+            {
+              "titel" : "Erpressung",
+              "start" : 1005013,
+              "end" : 1399347
+            },
+            {
+              "titel" : "Keine Spur im Sand",
+              "start" : 1399347,
+              "end" : 1514147
+            },
+            {
+              "titel" : "Quitt",
+              "start" : 1514147,
+              "end" : 1656853
+            },
+            {
+              "titel" : "Erwischt!",
+              "start" : 1656853,
+              "end" : 1896333
+            },
+            {
+              "titel" : "Gratulation",
+              "start" : 1896333,
+              "end" : 2051707
+            },
+            {
+              "titel" : "Observation Kunstexpertin",
+              "start" : 2051707,
+              "end" : 2217267
+            },
+            {
+              "titel" : "Spitznamen",
+              "start" : 2217267,
+              "end" : 2503840
+            },
+            {
+              "titel" : "Der Weltenseher",
+              "start" : 2503840,
+              "end" : 2795253
+            },
+            {
+              "titel" : "Baupläne",
+              "start" : 2795253,
+              "end" : 3241027
+            },
+            {
+              "titel" : "Erdrutsch",
+              "start" : 3241027,
+              "end" : 3924080
+            },
+            {
+              "titel" : "\"Zwischen 11 und 12\"",
+              "start" : 3924080,
+              "end" : 4166213
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Blanker Unsinn",
+              "start" : 0,
+              "end" : 313253
+            },
+            {
+              "titel" : "Schock!",
+              "start" : 313253,
+              "end" : 390387
+            },
+            {
+              "titel" : "Stromausfall",
+              "start" : 390387,
+              "end" : 689387
+            },
+            {
+              "titel" : "Blick in die Zukunft",
+              "start" : 689387,
+              "end" : 842747
+            },
+            {
+              "titel" : "Menschenleer",
+              "start" : 842747,
+              "end" : 1016213
+            },
+            {
+              "titel" : "Skrupel",
+              "start" : 1016213,
+              "end" : 1174907
+            },
+            {
+              "titel" : "Verschlossen",
+              "start" : 1174907,
+              "end" : 1749053
+            },
+            {
+              "titel" : "Überraschung",
+              "start" : 1749053,
+              "end" : 1904560
+            },
+            {
+              "titel" : "Verbündet",
+              "start" : 1904560,
+              "end" : 2796187
+            },
+            {
+              "titel" : "Verhaftet",
+              "start" : 2796187,
+              "end" : 2927733
+            },
+            {
+              "titel" : "Die halbe Wahrheit",
+              "start" : 2927733,
+              "end" : 3227173
+            },
+            {
+              "titel" : "Eine letzte Bitte",
+              "start" : 3227173,
+              "end" : 3436853
+            },
+            {
+              "titel" : "Die ganze Wahrheit",
+              "start" : 3436853,
+              "end" : 3671587
+            },
+            {
+              "titel" : "Die Würde",
+              "start" : 3671587,
+              "end" : 3959280
+            },
+            {
+              "titel" : "Der Brief",
+              "start" : 3959280,
+              "end" : 4183213
+            },
+            {
+              "titel" : "\"Nach 15\"",
+              "start" : 4183213,
+              "end" : 4464547
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log3.txt"
         }
       ],
       "links" : {
@@ -14832,10 +21002,71 @@
           "sprecher" : "Heikedine Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Stuarts Geheimnis",
+              "start" : 0,
+              "end" : 556333
+            },
+            {
+              "titel" : "Hausdurchsuchung",
+              "start" : 556333,
+              "end" : 903907
+            },
+            {
+              "titel" : "Von der Kamera erfasst",
+              "start" : 903907,
+              "end" : 1231520
+            },
+            {
+              "titel" : "Abwechslung",
+              "start" : 1231520,
+              "end" : 1567253
+            },
+            {
+              "titel" : "Spuren",
+              "start" : 1567253,
+              "end" : 2013760
+            },
+            {
+              "titel" : "Beerdigt",
+              "start" : 2013760,
+              "end" : 2359960
+            },
+            {
+              "titel" : "Verschwunden!",
+              "start" : 2359960,
+              "end" : 2456067
+            },
+            {
+              "titel" : "Sonne und Mond",
+              "start" : 2456067,
+              "end" : 2776267
+            },
+            {
+              "titel" : "Wandelnde Leiche",
+              "start" : 2776267,
+              "end" : 3030267
+            },
+            {
+              "titel" : "Am Grunde böser Schreie",
+              "start" : 3030267,
+              "end" : 3609000
+            },
+            {
+              "titel" : "Licht an!",
+              "start" : 3609000,
+              "end" : 3992933
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/126/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/126/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/126/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/126/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/126/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/2b/2b/cb/2b2bcbba-c651-e4ef-5eaa-53b0be45a8d5/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230900if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/8a/db/29/0828766712629.jpg"
@@ -14968,10 +21199,76 @@
           "sprecher" : "Susanne von Loessl"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Held von Carino Beach",
+              "start" : 0,
+              "end" : 451547
+            },
+            {
+              "titel" : "Einbruch mit Folgen",
+              "start" : 451547,
+              "end" : 781787
+            },
+            {
+              "titel" : "Cotta ruft",
+              "start" : 781787,
+              "end" : 896107
+            },
+            {
+              "titel" : "Falsche Zeugenaussage",
+              "start" : 896107,
+              "end" : 1290547
+            },
+            {
+              "titel" : "Besuch im Museum",
+              "start" : 1290547,
+              "end" : 1727733
+            },
+            {
+              "titel" : "Logische Lücken",
+              "start" : 1727733,
+              "end" : 2033080
+            },
+            {
+              "titel" : "Drohanruf",
+              "start" : 2033080,
+              "end" : 2518800
+            },
+            {
+              "titel" : "Great Deliverance",
+              "start" : 2518800,
+              "end" : 2957653
+            },
+            {
+              "titel" : "Böser Fehler",
+              "start" : 2957653,
+              "end" : 3260253
+            },
+            {
+              "titel" : "Unerwartete Hilfe",
+              "start" : 3260253,
+              "end" : 3552773
+            },
+            {
+              "titel" : "Teersee",
+              "start" : 3552773,
+              "end" : 4099293
+            },
+            {
+              "titel" : "Ende und Aus",
+              "start" : 4099293,
+              "end" : 4390653
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/127/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/127/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/127/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/127/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/127/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/cb/2e/96/cb2e96a9-12ba-04d8-9961-5534a5c11e33/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023013if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/0c/b8/db/0828766712728.jpg"
@@ -15092,10 +21389,76 @@
           "sprecher" : "André Minninger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Geisterstunde",
+              "start" : 0,
+              "end" : 677293
+            },
+            {
+              "titel" : "Erste Ermittlungen",
+              "start" : 677293,
+              "end" : 1291720
+            },
+            {
+              "titel" : "KCY",
+              "start" : 1291720,
+              "end" : 1533000
+            },
+            {
+              "titel" : "Die Botschaft des Talismans",
+              "start" : 1533000,
+              "end" : 2113133
+            },
+            {
+              "titel" : "Hotel Pacific Pearl",
+              "start" : 2113133,
+              "end" : 2426520
+            },
+            {
+              "titel" : "Fragen und Fallen",
+              "start" : 2426520,
+              "end" : 2492693
+            },
+            {
+              "titel" : "In der Geisterstadt",
+              "start" : 2492693,
+              "end" : 3108387
+            },
+            {
+              "titel" : "Verstorben",
+              "start" : 3108387,
+              "end" : 3212107
+            },
+            {
+              "titel" : "Niedergeschlagen",
+              "start" : 3212107,
+              "end" : 3598320
+            },
+            {
+              "titel" : "Wilde Kirschen",
+              "start" : 3598320,
+              "end" : 3777413
+            },
+            {
+              "titel" : "Magnesiumblitz",
+              "start" : 3777413,
+              "end" : 4011133
+            },
+            {
+              "titel" : "Die Juwelen",
+              "start" : 4011133,
+              "end" : 4412907
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/128/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/128/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/128/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/128/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/128/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music22/v4/12/df/55/12df551b-eb50-2396-ec97-38bb5c3a49cc/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180909if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/91/3c/2e/0828766712827.jpg"
@@ -15269,10 +21632,101 @@
           "sprecher" : "Wolf Pahlke"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Verschwunden",
+              "start" : 0,
+              "end" : 244173
+            },
+            {
+              "titel" : "Das Rätsel der Sphinx",
+              "start" : 244173,
+              "end" : 933920
+            },
+            {
+              "titel" : "Widerstand zwecklos",
+              "start" : 933920,
+              "end" : 1119773
+            },
+            {
+              "titel" : "Kamele",
+              "start" : 1119773,
+              "end" : 1292387
+            },
+            {
+              "titel" : "In der Grabanlage",
+              "start" : 1292387,
+              "end" : 1551613
+            },
+            {
+              "titel" : "Handelseinig",
+              "start" : 1551613,
+              "end" : 1644307
+            },
+            {
+              "titel" : "Sonderbare Gravur",
+              "start" : 1644307,
+              "end" : 2129547
+            },
+            {
+              "titel" : "Verfolgt",
+              "start" : 2129547,
+              "end" : 2380267
+            },
+            {
+              "titel" : "Arabische Zeichen",
+              "start" : 2380267,
+              "end" : 2622853
+            },
+            {
+              "titel" : "Entführt",
+              "start" : 2622853,
+              "end" : 2793120
+            },
+            {
+              "titel" : "SMS aus dem Grab",
+              "start" : 2793120,
+              "end" : 2903520
+            },
+            {
+              "titel" : "Angriff",
+              "start" : 2903520,
+              "end" : 3115373
+            },
+            {
+              "titel" : "Die Königin der Weisheit",
+              "start" : 3115373,
+              "end" : 3554533
+            },
+            {
+              "titel" : "Verschleiert",
+              "start" : 3554533,
+              "end" : 3838733
+            },
+            {
+              "titel" : "Im Sendebereich",
+              "start" : 3838733,
+              "end" : 4066787
+            },
+            {
+              "titel" : "Betäubt",
+              "start" : 4066787,
+              "end" : 4501560
+            },
+            {
+              "titel" : "Letzte Fragen",
+              "start" : 4501560,
+              "end" : 4734387
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/129/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/129/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/129/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/129/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/129/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/cd/cc/1b/cdcc1bb9-6ff9-1d92-336d-6f96fa8ea925/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111023012if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/5f/3f/bb/0828766712926.jpg"
@@ -15426,10 +21880,96 @@
           "sprecher" : "Günther Flesch"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Vorsicht, zerbrechlich!",
+              "start" : 0,
+              "end" : 774640
+            },
+            {
+              "titel" : "Prinz Eisenherz",
+              "start" : 774640,
+              "end" : 1045613
+            },
+            {
+              "titel" : "Ein alter Bekannter",
+              "start" : 1045613,
+              "end" : 1284120
+            },
+            {
+              "titel" : "Endlich eine Spur",
+              "start" : 1284120,
+              "end" : 1505933
+            },
+            {
+              "titel" : "Einbruch",
+              "start" : 1505933,
+              "end" : 1884213
+            },
+            {
+              "titel" : "Aufdringlicher Kunde",
+              "start" : 1884213,
+              "end" : 2086280
+            },
+            {
+              "titel" : "20.000 Dollar",
+              "start" : 2086280,
+              "end" : 2276133
+            },
+            {
+              "titel" : "Schonfrist",
+              "start" : 2276133,
+              "end" : 2382920
+            },
+            {
+              "titel" : "Belauscht",
+              "start" : 2382920,
+              "end" : 2521333
+            },
+            {
+              "titel" : "Beweisfoto",
+              "start" : 2521333,
+              "end" : 2613907
+            },
+            {
+              "titel" : "Fehlende Informationen",
+              "start" : 2613907,
+              "end" : 2822907
+            },
+            {
+              "titel" : "In der Falle",
+              "start" : 2822907,
+              "end" : 2882627
+            },
+            {
+              "titel" : "Original und Fälschung",
+              "start" : 2882627,
+              "end" : 3050907
+            },
+            {
+              "titel" : "Die MVUM",
+              "start" : 3050907,
+              "end" : 3320200
+            },
+            {
+              "titel" : "Hellen oder Heather?",
+              "start" : 3320200,
+              "end" : 3503333
+            },
+            {
+              "titel" : "Scherben bringen Glück",
+              "start" : 3503333,
+              "end" : 4112560
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/130/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/130/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/130/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/130/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/130/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music41/v4/e0/03/7a/e0037a54-0f6e-c71b-0f6e-f0b2662d2b97/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022642if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/02/53/56/0828766713022.jpg"
@@ -15543,10 +22083,61 @@
           "sprecher" : "Roman Kretschmer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Marriott's Island",
+              "start" : 0,
+              "end" : 349787
+            },
+            {
+              "titel" : "Das Haus der Geister",
+              "start" : 349787,
+              "end" : 1003653
+            },
+            {
+              "titel" : "Der Mörder geht um",
+              "start" : 1003653,
+              "end" : 1564200
+            },
+            {
+              "titel" : "Das Fenster im Boden",
+              "start" : 1564200,
+              "end" : 2588227
+            },
+            {
+              "titel" : "Schritte in der Wand",
+              "start" : 2588227,
+              "end" : 2877213
+            },
+            {
+              "titel" : "Das Archiv",
+              "start" : 2877213,
+              "end" : 3237933
+            },
+            {
+              "titel" : "Es stinkt",
+              "start" : 3237933,
+              "end" : 3557200
+            },
+            {
+              "titel" : "Bericht aus der Hölle",
+              "start" : 3557200,
+              "end" : 3882493
+            },
+            {
+              "titel" : "Das Spiel ist aus",
+              "start" : 3882493,
+              "end" : 4242960
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/131/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/131/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/131/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/131/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/131/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/b1/bf/16/b1bf1613-b6e4-363f-9d68-56d2122f7ea1/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135346if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/64/e8/5f/0886974413127.jpg"
@@ -15672,10 +22263,61 @@
           "sprecher" : "Jürgen Holdorf"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine Dame verschwindet",
+              "start" : 0,
+              "end" : 424653
+            },
+            {
+              "titel" : "Andromeda",
+              "start" : 424653,
+              "end" : 710960
+            },
+            {
+              "titel" : "Kassiopeia",
+              "start" : 710960,
+              "end" : 954827
+            },
+            {
+              "titel" : "Spuk im Netz",
+              "start" : 954827,
+              "end" : 1251387
+            },
+            {
+              "titel" : "Professor Alkurah",
+              "start" : 1251387,
+              "end" : 1391307
+            },
+            {
+              "titel" : "Die weiße Frau",
+              "start" : 1391307,
+              "end" : 1905653
+            },
+            {
+              "titel" : "In Kepheus Haus",
+              "start" : 1905653,
+              "end" : 2581387
+            },
+            {
+              "titel" : "Ketus",
+              "start" : 2581387,
+              "end" : 3196627
+            },
+            {
+              "titel" : "Untergang",
+              "start" : 3196627,
+              "end" : 3799387
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/132/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/132/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/132/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/132/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/132/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/b5/e5/ce/b5e5ce53-7fa1-b591-2aea-f18f2f7228bb/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135341if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/c0/dc/6d/0886974413226.jpg"
@@ -15789,10 +22431,61 @@
           "sprecher" : "Bertram Hiese"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Hilfe, ein Zwerg!",
+              "start" : 0,
+              "end" : 314427
+            },
+            {
+              "titel" : "Das Grauen in der Tiefe",
+              "start" : 314427,
+              "end" : 662467
+            },
+            {
+              "titel" : "Das Versteck",
+              "start" : 662467,
+              "end" : 827360
+            },
+            {
+              "titel" : "Zwergenkunst",
+              "start" : 827360,
+              "end" : 971427
+            },
+            {
+              "titel" : "Ein Käfer wird misshandelt",
+              "start" : 971427,
+              "end" : 1158573
+            },
+            {
+              "titel" : "Flucht nach vorne!",
+              "start" : 1158573,
+              "end" : 1390053
+            },
+            {
+              "titel" : "Abwärts",
+              "start" : 1390053,
+              "end" : 2051440
+            },
+            {
+              "titel" : "Haifischfutter",
+              "start" : 2051440,
+              "end" : 2552107
+            },
+            {
+              "titel" : "Ein tierisches Geheimnis",
+              "start" : 2552107,
+              "end" : 3473893
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/133/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/133/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/133/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/133/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/133/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/bf/3d/32/bf3d3231-9cb7-a40a-1637-069eda7a1671/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230858if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/a4/ac/b6/0886974413325.jpg"
@@ -15918,10 +22611,81 @@
           "sprecher" : "Nicolas König"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Noch mal Glück gehabt!",
+              "start" : 0,
+              "end" : 276800
+            },
+            {
+              "titel" : "Angst",
+              "start" : 276800,
+              "end" : 849960
+            },
+            {
+              "titel" : "Beschattung",
+              "start" : 849960,
+              "end" : 1156707
+            },
+            {
+              "titel" : "Böser Geist",
+              "start" : 1156707,
+              "end" : 1448133
+            },
+            {
+              "titel" : "Verschüttet",
+              "start" : 1448133,
+              "end" : 1770587
+            },
+            {
+              "titel" : "Ordnung kehrt ein",
+              "start" : 1770587,
+              "end" : 2068627
+            },
+            {
+              "titel" : "Geschäftsgeheimnis",
+              "start" : 2068627,
+              "end" : 2193227
+            },
+            {
+              "titel" : "Neuer Entschluss",
+              "start" : 2193227,
+              "end" : 2280387
+            },
+            {
+              "titel" : "Fototrick",
+              "start" : 2280387,
+              "end" : 2601960
+            },
+            {
+              "titel" : "Es entwickelt sich",
+              "start" : 2601960,
+              "end" : 2757187
+            },
+            {
+              "titel" : "Der tote Mönch",
+              "start" : 2757187,
+              "end" : 3322453
+            },
+            {
+              "titel" : "Seltener Name",
+              "start" : 3322453,
+              "end" : 3627387
+            },
+            {
+              "titel" : "Letzte Ergebnisse",
+              "start" : 3627387,
+              "end" : 4029587
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/134/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/134/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/134/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/134/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/134/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music41/v4/e8/6f/51/e86f519b-d21e-46e4-bb8d-684f1b5de79b/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152702if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/4c/d6/c8/0886974413424.jpg"
@@ -16063,10 +22827,101 @@
           "sprecher" : "Konstanze Ullmer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Auf der Flucht",
+              "start" : 0,
+              "end" : 137213
+            },
+            {
+              "titel" : "Die rätselhaften Bilder",
+              "start" : 137213,
+              "end" : 558360
+            },
+            {
+              "titel" : "Der Schatz",
+              "start" : 558360,
+              "end" : 939400
+            },
+            {
+              "titel" : "Ort der Hinterlassenschaft",
+              "start" : 939400,
+              "end" : 1036853
+            },
+            {
+              "titel" : "Ein verlockendes Angebot",
+              "start" : 1036853,
+              "end" : 1223853
+            },
+            {
+              "titel" : "Entwischt",
+              "start" : 1223853,
+              "end" : 1413587
+            },
+            {
+              "titel" : "Enträtselt",
+              "start" : 1413587,
+              "end" : 1621613
+            },
+            {
+              "titel" : "Auf festem Boden",
+              "start" : 1621613,
+              "end" : 1816653
+            },
+            {
+              "titel" : "Das Wrack",
+              "start" : 1816653,
+              "end" : 1978587
+            },
+            {
+              "titel" : "Flackerndes Licht",
+              "start" : 1978587,
+              "end" : 2109520
+            },
+            {
+              "titel" : "Die drei Feuerlöscher",
+              "start" : 2109520,
+              "end" : 2635040
+            },
+            {
+              "titel" : "Am Ziel",
+              "start" : 2635040,
+              "end" : 2759453
+            },
+            {
+              "titel" : "Rettung!?",
+              "start" : 2759453,
+              "end" : 3063787
+            },
+            {
+              "titel" : "Schock in der Tiefe",
+              "start" : 3063787,
+              "end" : 3360347
+            },
+            {
+              "titel" : "Die Nerven liegen blank",
+              "start" : 3360347,
+              "end" : 3532707
+            },
+            {
+              "titel" : "Hände hoch!",
+              "start" : 3532707,
+              "end" : 4128267
+            },
+            {
+              "titel" : "Gratulation",
+              "start" : 4128267,
+              "end" : 4271013
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/135/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/135/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/135/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/135/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/135/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/c0/b5/9f/c0b59f61-926b-7f75-7017-f3686347df18/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145708if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/78/1a/a7/0886974413523.jpg"
@@ -16204,10 +23059,81 @@
           "sprecher" : "Rolf E. Schenker"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein neuer Fall",
+              "start" : 0,
+              "end" : 144133
+            },
+            {
+              "titel" : "Der Mann im Wasser",
+              "start" : 144133,
+              "end" : 602013
+            },
+            {
+              "titel" : "Ein Arzt muss her!",
+              "start" : 602013,
+              "end" : 741253
+            },
+            {
+              "titel" : "Heiße Dusche",
+              "start" : 741253,
+              "end" : 1198960
+            },
+            {
+              "titel" : "Das Phantom von Ridgelake",
+              "start" : 1198960,
+              "end" : 1449200
+            },
+            {
+              "titel" : "Auf der Lauer",
+              "start" : 1449200,
+              "end" : 1942893
+            },
+            {
+              "titel" : "Schlachtpläne",
+              "start" : 1942893,
+              "end" : 2328800
+            },
+            {
+              "titel" : "Hinab in die Tiefe",
+              "start" : 2328800,
+              "end" : 2546760
+            },
+            {
+              "titel" : "Luftnot",
+              "start" : 2546760,
+              "end" : 2664773
+            },
+            {
+              "titel" : "Tiefenrausch",
+              "start" : 2664773,
+              "end" : 3007947
+            },
+            {
+              "titel" : "Der letzte Wille",
+              "start" : 3007947,
+              "end" : 3417840
+            },
+            {
+              "titel" : "Cassandra",
+              "start" : 3417840,
+              "end" : 3947773
+            },
+            {
+              "titel" : "Abschied von Ridgelake",
+              "start" : 3947773,
+              "end" : 4117027
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/136/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/136/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/136/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/136/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/136/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/85/dc/a1/85dca1a3-0eb3-af01-a5a8-261360b89a84/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230854if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/2b/10/25/0886974413622.jpg"
@@ -16329,10 +23255,81 @@
           "sprecher" : "Tetje Mierendorf"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Buchstabensalat",
+              "start" : 0,
+              "end" : 451600
+            },
+            {
+              "titel" : "Scharlatan",
+              "start" : 451600,
+              "end" : 1026613
+            },
+            {
+              "titel" : "Ein seltsamer Fund",
+              "start" : 1026613,
+              "end" : 1512173
+            },
+            {
+              "titel" : "Klartext",
+              "start" : 1512173,
+              "end" : 1614960
+            },
+            {
+              "titel" : "Ein einfacher Auftrag",
+              "start" : 1614960,
+              "end" : 1858267
+            },
+            {
+              "titel" : "Absturz",
+              "start" : 1858267,
+              "end" : 2032200
+            },
+            {
+              "titel" : "Ein hübscher kleiner Einbruch",
+              "start" : 2032200,
+              "end" : 2394587
+            },
+            {
+              "titel" : "Aufklärung",
+              "start" : 2394587,
+              "end" : 2774720
+            },
+            {
+              "titel" : "Ausgeflogen",
+              "start" : 2774720,
+              "end" : 3268733
+            },
+            {
+              "titel" : "Gold?",
+              "start" : 3268733,
+              "end" : 3569160
+            },
+            {
+              "titel" : "Die Erde bebt",
+              "start" : 3569160,
+              "end" : 3953160
+            },
+            {
+              "titel" : "In der Todesfalle",
+              "start" : 3953160,
+              "end" : 4466947
+            },
+            {
+              "titel" : "Falsche Prognose",
+              "start" : 4466947,
+              "end" : 4653507
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/137/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/137/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/137/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/137/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/137/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music/v4/13/51/b2/1351b219-fd82-4245-14cd-2687bb8d380c/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152704if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/43/0a/0f/0886974413721.jpg"
@@ -16446,10 +23443,81 @@
           "sprecher" : "Burghart Klaußner"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Treibgut",
+              "start" : 0,
+              "end" : 274747
+            },
+            {
+              "titel" : "Pirate's Point",
+              "start" : 274747,
+              "end" : 404107
+            },
+            {
+              "titel" : "Die Wand",
+              "start" : 404107,
+              "end" : 637160
+            },
+            {
+              "titel" : "Der Gefangene",
+              "start" : 637160,
+              "end" : 1013693
+            },
+            {
+              "titel" : "King Kong und Freddy Krueger",
+              "start" : 1013693,
+              "end" : 1265867
+            },
+            {
+              "titel" : "Geheimbund",
+              "start" : 1265867,
+              "end" : 1416267
+            },
+            {
+              "titel" : "Die Löwenritter",
+              "start" : 1416267,
+              "end" : 2009027
+            },
+            {
+              "titel" : "Tatze und Schwert",
+              "start" : 2009027,
+              "end" : 2328880
+            },
+            {
+              "titel" : "Jagd auf Schuhe",
+              "start" : 2328880,
+              "end" : 2499840
+            },
+            {
+              "titel" : "Putzmann aus der Uni",
+              "start" : 2499840,
+              "end" : 2681427
+            },
+            {
+              "titel" : "Der Schlüssel",
+              "start" : 2681427,
+              "end" : 2873333
+            },
+            {
+              "titel" : "Zwischen Ameisen und Mistgabel",
+              "start" : 2873333,
+              "end" : 3093160
+            },
+            {
+              "titel" : "Die geheime Treppe",
+              "start" : 3093160,
+              "end" : 3987133
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/138/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/138/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/138/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/138/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/138/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/50/37/0b/50370b19-33ae-48fa-7f16-e9b76da09513/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180115if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/93/00/af/0886974413820.jpg"
@@ -16599,10 +23667,76 @@
           "sprecher" : "Sabine Hahn"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Zerstörte Kulissen",
+              "start" : 0,
+              "end" : 249707
+            },
+            {
+              "titel" : "Kulturprogramm",
+              "start" : 249707,
+              "end" : 421467
+            },
+            {
+              "titel" : "Das Stadttheater",
+              "start" : 421467,
+              "end" : 593213
+            },
+            {
+              "titel" : "Dunkelheit",
+              "start" : 593213,
+              "end" : 1149080
+            },
+            {
+              "titel" : "Gelogen",
+              "start" : 1149080,
+              "end" : 1482707
+            },
+            {
+              "titel" : "Nachts im Theater",
+              "start" : 1482707,
+              "end" : 1768627
+            },
+            {
+              "titel" : "Die Diva von Rocky Beach",
+              "start" : 1768627,
+              "end" : 2157973
+            },
+            {
+              "titel" : "Überraschung",
+              "start" : 2157973,
+              "end" : 2545453
+            },
+            {
+              "titel" : "Seemannsknoten",
+              "start" : 2545453,
+              "end" : 2937840
+            },
+            {
+              "titel" : "Nachtschicht",
+              "start" : 2937840,
+              "end" : 3172147
+            },
+            {
+              "titel" : "Abgereist",
+              "start" : 3172147,
+              "end" : 3248240
+            },
+            {
+              "titel" : "Manipulation",
+              "start" : 3248240,
+              "end" : 3860747
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/139/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/139/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/139/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/139/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/139/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/ef/72/07/ef720777-496f-3dae-33b6-b80beb656efe/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153359if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/ae/97/a2/0886974413929.jpg"
@@ -16726,10 +23860,71 @@
           "sprecher" : "Gerd Baltus"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Yonderwood",
+              "start" : 0,
+              "end" : 228680
+            },
+            {
+              "titel" : "Die Geisterstadt",
+              "start" : 228680,
+              "end" : 1245640
+            },
+            {
+              "titel" : "Vampirjäger",
+              "start" : 1245640,
+              "end" : 1323587
+            },
+            {
+              "titel" : "Bibelvers",
+              "start" : 1323587,
+              "end" : 1546867
+            },
+            {
+              "titel" : "Versammlung",
+              "start" : 1546867,
+              "end" : 1922880
+            },
+            {
+              "titel" : "Hilfe!",
+              "start" : 1922880,
+              "end" : 2182120
+            },
+            {
+              "titel" : "Durchsucht",
+              "start" : 2182120,
+              "end" : 2463187
+            },
+            {
+              "titel" : "Jenseits der Wälder",
+              "start" : 2463187,
+              "end" : 2862427
+            },
+            {
+              "titel" : "Nacht des Grauens",
+              "start" : 2862427,
+              "end" : 3917853
+            },
+            {
+              "titel" : "Überfall!",
+              "start" : 3917853,
+              "end" : 4087160
+            },
+            {
+              "titel" : "Der Schatz der Katze",
+              "start" : 4087160,
+              "end" : 4658533
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/140/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/140/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/140/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/140/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/140/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/fe/5e/33/fe5e33bf-593b-1cf7-10e3-4704e2048d60/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153351if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f5/38/bd/0886974414025.jpg"
@@ -16876,10 +24071,81 @@
           "sprecher" : "Olaf Kreutzenbeck"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "In die Höhe getrieben",
+              "start" : 0,
+              "end" : 515053
+            },
+            {
+              "titel" : "Mädchen für alles",
+              "start" : 515053,
+              "end" : 850187
+            },
+            {
+              "titel" : "Ein neuer Auftrag",
+              "start" : 850187,
+              "end" : 1073267
+            },
+            {
+              "titel" : "Stimmen",
+              "start" : 1073267,
+              "end" : 1393200
+            },
+            {
+              "titel" : "Pop-Art",
+              "start" : 1393200,
+              "end" : 1489160
+            },
+            {
+              "titel" : "Vertrocknete Blüte",
+              "start" : 1489160,
+              "end" : 1632027
+            },
+            {
+              "titel" : "Das Grauen in den Katakomben",
+              "start" : 1632027,
+              "end" : 1953987
+            },
+            {
+              "titel" : "Totengericht",
+              "start" : 1953987,
+              "end" : 2050547
+            },
+            {
+              "titel" : "Ägyptische Flüche",
+              "start" : 2050547,
+              "end" : 2163893
+            },
+            {
+              "titel" : "Durch die Blume",
+              "start" : 2163893,
+              "end" : 2317587
+            },
+            {
+              "titel" : "Fix und alle",
+              "start" : 2317587,
+              "end" : 2511587
+            },
+            {
+              "titel" : "Barocke Meisterwerke",
+              "start" : 2511587,
+              "end" : 3126160
+            },
+            {
+              "titel" : "Sprechende Pflanzen",
+              "start" : 3126160,
+              "end" : 3562347
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/141/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/141/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/141/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/141/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/141/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/0b/86/cf/0b86cfe8-1001-8e9d-8c92-95e041739eaf/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152703if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/42/c9/1e/0886978014122.jpg"
@@ -17033,10 +24299,81 @@
           "sprecher" : "Sascha Draeger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Liebe Hunde und böse Kekse",
+              "start" : 0,
+              "end" : 579040
+            },
+            {
+              "titel" : "Diebstahl",
+              "start" : 579040,
+              "end" : 787933
+            },
+            {
+              "titel" : "Pressekonferenz",
+              "start" : 787933,
+              "end" : 920560
+            },
+            {
+              "titel" : "Peter, der Hellseher",
+              "start" : 920560,
+              "end" : 1090960
+            },
+            {
+              "titel" : "Angst vor Gnomen",
+              "start" : 1090960,
+              "end" : 1238027
+            },
+            {
+              "titel" : "Nordlicht und Wölfe",
+              "start" : 1238027,
+              "end" : 1393373
+            },
+            {
+              "titel" : "Blut",
+              "start" : 1393373,
+              "end" : 1601413
+            },
+            {
+              "titel" : "Der pure Luxus",
+              "start" : 1601413,
+              "end" : 1787720
+            },
+            {
+              "titel" : "Geruchssinn",
+              "start" : 1787720,
+              "end" : 2041547
+            },
+            {
+              "titel" : "Bob wird überfahren",
+              "start" : 2041547,
+              "end" : 2342907
+            },
+            {
+              "titel" : "Alleingang",
+              "start" : 2342907,
+              "end" : 3069133
+            },
+            {
+              "titel" : "Fleckenteufel",
+              "start" : 3069133,
+              "end" : 3239613
+            },
+            {
+              "titel" : "Eine arktische Erinnerung",
+              "start" : 3239613,
+              "end" : 3437227
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/142/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/142/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/142/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/142/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/142/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/1d/5a/52/1d5a529e-e98e-88d1-b629-71e5ca78df23/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045238if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f5/65/15/0886978014221.jpg"
@@ -17156,10 +24493,71 @@
           "sprecher" : "Arndt Schmöle"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Nicht zu packen",
+              "start" : 0,
+              "end" : 193667
+            },
+            {
+              "titel" : "Onkel Tony",
+              "start" : 193667,
+              "end" : 572653
+            },
+            {
+              "titel" : "Ruby Tuesday",
+              "start" : 572653,
+              "end" : 813640
+            },
+            {
+              "titel" : "Babyface",
+              "start" : 813640,
+              "end" : 1536587
+            },
+            {
+              "titel" : "Schnitzeljagd",
+              "start" : 1536587,
+              "end" : 1716800
+            },
+            {
+              "titel" : "Atbash",
+              "start" : 1716800,
+              "end" : 2005333
+            },
+            {
+              "titel" : "Keine leichte Aufgabe",
+              "start" : 2005333,
+              "end" : 2195293
+            },
+            {
+              "titel" : "Rebus",
+              "start" : 2195293,
+              "end" : 2571693
+            },
+            {
+              "titel" : "Ivory",
+              "start" : 2571693,
+              "end" : 2783747
+            },
+            {
+              "titel" : "Im Elfenbeinturm",
+              "start" : 2783747,
+              "end" : 3156133
+            },
+            {
+              "titel" : "Bergamotte",
+              "start" : 3156133,
+              "end" : 3621920
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/143/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/143/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/143/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/143/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/143/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/fe/6f/74/fe6f7474-f6ac-95dc-4c9e-e3dd300b37da/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111022952if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/65/f5/81/0886978014320.jpg"
@@ -17290,10 +24688,81 @@
           "sprecher" : "Holger Löwenberg"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Albtraum",
+              "start" : 0,
+              "end" : 211747
+            },
+            {
+              "titel" : "Der Schatzsucher",
+              "start" : 211747,
+              "end" : 760587
+            },
+            {
+              "titel" : "Wasser und Erde",
+              "start" : 760587,
+              "end" : 1133573
+            },
+            {
+              "titel" : "Ein neuer Auftrag",
+              "start" : 1133573,
+              "end" : 1414960
+            },
+            {
+              "titel" : "Interview",
+              "start" : 1414960,
+              "end" : 1507267
+            },
+            {
+              "titel" : "Im Urlaub",
+              "start" : 1507267,
+              "end" : 1593493
+            },
+            {
+              "titel" : "Luft",
+              "start" : 1593493,
+              "end" : 2044560
+            },
+            {
+              "titel" : "Ein alter Vertrag",
+              "start" : 2044560,
+              "end" : 2212667
+            },
+            {
+              "titel" : "Überraschende Wendung",
+              "start" : 2212667,
+              "end" : 2403760
+            },
+            {
+              "titel" : "Es spukt",
+              "start" : 2403760,
+              "end" : 2511840
+            },
+            {
+              "titel" : "Sesam öffne dich",
+              "start" : 2511840,
+              "end" : 3121547
+            },
+            {
+              "titel" : "Unterirdisch",
+              "start" : 3121547,
+              "end" : 3889373
+            },
+            {
+              "titel" : "Geister",
+              "start" : 3889373,
+              "end" : 4256000
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/144/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/144/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/144/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/144/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/144/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/44/64/25/44642533-90d8-a699-839b-07518cc83a6d/source",
         "cover_kosmos" : "http://web.archive.org/web/20220104131536if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/b5/2f/31/0886978014429.jpg"
@@ -17418,10 +24887,76 @@
           "sprecher" : "Peter Buchholz"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Worum geht es?",
+              "start" : 0,
+              "end" : 138133
+            },
+            {
+              "titel" : "Verdeckte Ermittlungen",
+              "start" : 138133,
+              "end" : 456227
+            },
+            {
+              "titel" : "Sicher ist sicher",
+              "start" : 456227,
+              "end" : 707467
+            },
+            {
+              "titel" : "Ein Laden mit Schwertern",
+              "start" : 707467,
+              "end" : 900467
+            },
+            {
+              "titel" : "In Kontakt",
+              "start" : 900467,
+              "end" : 988333
+            },
+            {
+              "titel" : "Kalter Empfang",
+              "start" : 988333,
+              "end" : 1339040
+            },
+            {
+              "titel" : "Unerwünscht",
+              "start" : 1339040,
+              "end" : 1786600
+            },
+            {
+              "titel" : "Das Geheimnis im Turm",
+              "start" : 1786600,
+              "end" : 1966747
+            },
+            {
+              "titel" : "Am Abgrund",
+              "start" : 1966747,
+              "end" : 2114560
+            },
+            {
+              "titel" : "Die Botschaft des Meisters",
+              "start" : 2114560,
+              "end" : 2618800
+            },
+            {
+              "titel" : "Das goldene Schwert",
+              "start" : 2618800,
+              "end" : 3005440
+            },
+            {
+              "titel" : "Angst",
+              "start" : 3005440,
+              "end" : 3722547
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/145/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/145/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/145/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/145/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/145/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/1a/d7/e3/1ad7e31d-1aac-3bc6-c7eb-2a8b27612e77/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022652if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/c0/7e/6d/0886978014528.jpg"
@@ -17591,10 +25126,96 @@
           "sprecher" : "Robin Brosch"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine fiebrige Warnung",
+              "start" : 0,
+              "end" : 505680
+            },
+            {
+              "titel" : "Ein neuer Fall",
+              "start" : 505680,
+              "end" : 616427
+            },
+            {
+              "titel" : "Seltsamer Duft",
+              "start" : 616427,
+              "end" : 917307
+            },
+            {
+              "titel" : "Dem Spuk auf der Spur",
+              "start" : 917307,
+              "end" : 1173240
+            },
+            {
+              "titel" : "Gemeingefährlich",
+              "start" : 1173240,
+              "end" : 1434520
+            },
+            {
+              "titel" : "Sinnvolle Aufgabenteilung",
+              "start" : 1434520,
+              "end" : 1508213
+            },
+            {
+              "titel" : "Heimsuchung",
+              "start" : 1508213,
+              "end" : 1684080
+            },
+            {
+              "titel" : "Ziel verfehlt",
+              "start" : 1684080,
+              "end" : 1803800
+            },
+            {
+              "titel" : "Ein mysteriöser Montag",
+              "start" : 1803800,
+              "end" : 1982533
+            },
+            {
+              "titel" : "Angriff aus der Finsternis",
+              "start" : 1982533,
+              "end" : 2092040
+            },
+            {
+              "titel" : "Schicksalhafte Begegnung",
+              "start" : 2092040,
+              "end" : 2298653
+            },
+            {
+              "titel" : "Abschreckende Viecher",
+              "start" : 2298653,
+              "end" : 2474240
+            },
+            {
+              "titel" : "Ein Rätsel wird gelöst",
+              "start" : 2474240,
+              "end" : 2669080
+            },
+            {
+              "titel" : "Zwei Fragezeichen greifen ein",
+              "start" : 2669080,
+              "end" : 2933307
+            },
+            {
+              "titel" : "Alles oder nichts",
+              "start" : 2933307,
+              "end" : 3114227
+            },
+            {
+              "titel" : "Apfelkrise",
+              "start" : 3114227,
+              "end" : 3430360
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/146/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/146/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/146/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/146/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/146/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/71/a2/12/71a21215-41b6-b076-8853-c5363f7899e8/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180114if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/66/0b/d5/0886978014627.jpg"
@@ -17720,10 +25341,61 @@
           "sprecher" : "Tommaso Cacciapuoti"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Samuels Vermächtnis",
+              "start" : 0,
+              "end" : 883827
+            },
+            {
+              "titel" : "Im Grund des Feuers",
+              "start" : 883827,
+              "end" : 1123840
+            },
+            {
+              "titel" : "Vermummt",
+              "start" : 1123840,
+              "end" : 1493533
+            },
+            {
+              "titel" : "Wassergeist",
+              "start" : 1493533,
+              "end" : 1699147
+            },
+            {
+              "titel" : "Wo ist Bob?",
+              "start" : 1699147,
+              "end" : 1829547
+            },
+            {
+              "titel" : "Taylor & Co.",
+              "start" : 1829547,
+              "end" : 2257760
+            },
+            {
+              "titel" : "Rätselfieber",
+              "start" : 2257760,
+              "end" : 2767933
+            },
+            {
+              "titel" : "Ein alter Bekannter",
+              "start" : 2767933,
+              "end" : 3310373
+            },
+            {
+              "titel" : "Zwischentöne",
+              "start" : 3310373,
+              "end" : 3770533
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/147/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/147/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/147/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/147/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/147/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/e6/81/2a/e6812a57-2ae7-f2b1-efb4-cc5ef042ccfc/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022651if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/e5/6f/88/0886978014726.jpg"
@@ -17833,10 +25505,61 @@
           "sprecher" : "Gosta Liptow"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Verflucht",
+              "start" : 0,
+              "end" : 408987
+            },
+            {
+              "titel" : "Der gläserne Safe",
+              "start" : 408987,
+              "end" : 1683253
+            },
+            {
+              "titel" : "Neurotoxin",
+              "start" : 1683253,
+              "end" : 1922227
+            },
+            {
+              "titel" : "Ein mysteriöses Paket",
+              "start" : 1922227,
+              "end" : 2386280
+            },
+            {
+              "titel" : "Der Stern in der Dunkelheit",
+              "start" : 2386280,
+              "end" : 2623573
+            },
+            {
+              "titel" : "Feurige Flut",
+              "start" : 2623573,
+              "end" : 2869640
+            },
+            {
+              "titel" : "Kleines Rätsel",
+              "start" : 2869640,
+              "end" : 2971560
+            },
+            {
+              "titel" : "SOS",
+              "start" : 2971560,
+              "end" : 3844640
+            },
+            {
+              "titel" : "Zahltag",
+              "start" : 3844640,
+              "end" : 4011933
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/148/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/148/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/148/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/148/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/148/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/89/c6/08/89c60854-6977-ef69-4dfb-aa7fc365a9b5/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145706if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/61/f9/53/0886978014825.jpg"
@@ -17987,10 +25710,86 @@
           "sprecher" : "Frank Meyer-Brockmann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Vandalismus",
+              "start" : 0,
+              "end" : 387640
+            },
+            {
+              "titel" : "Terror in Seven Pines",
+              "start" : 387640,
+              "end" : 668600
+            },
+            {
+              "titel" : "Nein!",
+              "start" : 668600,
+              "end" : 747667
+            },
+            {
+              "titel" : "Nacht in Angst",
+              "start" : 747667,
+              "end" : 971480
+            },
+            {
+              "titel" : "Miss Biss",
+              "start" : 971480,
+              "end" : 1207773
+            },
+            {
+              "titel" : "Junge ohne Namen",
+              "start" : 1207773,
+              "end" : 1853787
+            },
+            {
+              "titel" : "Ein Baum in Nöten",
+              "start" : 1853787,
+              "end" : 2177787
+            },
+            {
+              "titel" : "Kein gutes Verhältnis",
+              "start" : 2177787,
+              "end" : 2273853
+            },
+            {
+              "titel" : "Auf Leben und Tod",
+              "start" : 2273853,
+              "end" : 2705707
+            },
+            {
+              "titel" : "Echte Kerle",
+              "start" : 2705707,
+              "end" : 2845787
+            },
+            {
+              "titel" : "Rachespiel",
+              "start" : 2845787,
+              "end" : 3017587
+            },
+            {
+              "titel" : "Bombenstimmung",
+              "start" : 3017587,
+              "end" : 3226547
+            },
+            {
+              "titel" : "Schutt und Asche",
+              "start" : 3226547,
+              "end" : 3539120
+            },
+            {
+              "titel" : "Happy Ending",
+              "start" : 3539120,
+              "end" : 3717773
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/149/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/149/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/149/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/149/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/149/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/89/fe/eb/89feeb6a-d74e-bf5d-c599-3cea28ef701b/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212304if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/de/5a/de/0886978014924.jpg"
@@ -18003,7 +25802,10 @@
           "teilNummer" : 1,
           "buchstabe" : "A",
           "titel" : "Rashuras Schatz",
+          "autor" : "Astrid Vollenbruch",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Die drei berühmten Detektive aus Rocky Beach müssen ein Rätsel lösen, das ihnen der schrullige Harry Shreber in seinem Testament hinterlassen hat. Schnell finden sie heraus, dass der erste Hinweis in einem schrottreifen Flugzeug in Shrebers Garten versteckt sein könnte. Die Suche nach Rashuras Schatz beginnt – aber Justus, Peter und Bob sind bei weitem nicht die Einzigen, die das Rätsel lösen wollen …",
+          "veröffentlichungsdatum" : "2011-11-11",
           "kapitel" : [
             {
               "titel" : "Eine rätselhafte Erbschaft",
@@ -18152,15 +25954,17 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/1/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/150/1/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/150/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/150/1/ffmetadata.txt"
           }
         },
         {
           "teilNummer" : 2,
           "buchstabe" : "B",
           "titel" : "Flammendes Wasser",
+          "autor" : "Astrid Vollenbruch",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Die Spur zu Rashuras Schatz führt die drei ??? hoch in die Berge, tief unter die Erde und hinaus auf die offene See. Aber mit jedem Hinweis wird alles nur noch geheimnisvoller – und gefährlicher! Ein Wettlauf mit der Zeit beginnt …",
+          "veröffentlichungsdatum" : "2011-11-11",
           "kapitel" : [
             {
               "titel" : "Fragezeichen",
@@ -18323,15 +26127,17 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/2/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/150/2/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/150/2/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/150/2/ffmetadata.txt"
           }
         },
         {
           "teilNummer" : 3,
           "buchstabe" : "C",
           "titel" : "Der brennende Kristall",
+          "autor" : "Astrid Vollenbruch",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Noch immer haben Justus, Peter und Bob das Rätsel aus dem Testament nicht lösen können. Welche Rolle spielen Moby Dick und der brennende Kristall? Die drei ??? begeben sich zur Geisterbucht, um das Geheimnis zu lüften. Doch sie sind nicht allein! Jeder pokert hoch in diesem Spiel, das nur einer gewinnen kann …",
+          "veröffentlichungsdatum" : "2011-11-11",
           "kapitel" : [
             {
               "titel" : "Blödmänner",
@@ -18469,8 +26275,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/150/3/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/150/3/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/150/3/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/150/3/ffmetadata.txt"
           }
         }
       ],
@@ -18611,6 +26416,228 @@
         {
           "rolle" : "Ruth",
           "sprecher" : "Gabriele Libbach"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine rätselhafte Erbschaft",
+              "start" : 0,
+              "end" : 524213
+            },
+            {
+              "titel" : "Persönliche Einschätzung",
+              "start" : 524213,
+              "end" : 771373
+            },
+            {
+              "titel" : "Das Haus des Sammlers",
+              "start" : 771373,
+              "end" : 1255853
+            },
+            {
+              "titel" : "Cochin Big Blind",
+              "start" : 1255853,
+              "end" : 1725040
+            },
+            {
+              "titel" : "Überfall",
+              "start" : 1725040,
+              "end" : 1844480
+            },
+            {
+              "titel" : "Verschlossen",
+              "start" : 1844480,
+              "end" : 1963693
+            },
+            {
+              "titel" : "Auf Draht",
+              "start" : 1963693,
+              "end" : 2098240
+            },
+            {
+              "titel" : "Der Flugzeugfan",
+              "start" : 2098240,
+              "end" : 2380493
+            },
+            {
+              "titel" : "Konkurrenz schläft nicht",
+              "start" : 2380493,
+              "end" : 2464707
+            },
+            {
+              "titel" : "Atemlos",
+              "start" : 2464707,
+              "end" : 2725533
+            },
+            {
+              "titel" : "Gerry",
+              "start" : 2725533,
+              "end" : 3283107
+            },
+            {
+              "titel" : "Verkauft",
+              "start" : 3283107,
+              "end" : 3494347
+            },
+            {
+              "titel" : "Der Uhrensammler",
+              "start" : 3494347,
+              "end" : 3782093
+            },
+            {
+              "titel" : "Ein Detektiv verschwindet",
+              "start" : 3782093,
+              "end" : 4055093
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Fragezeichen",
+              "start" : 0,
+              "end" : 140907
+            },
+            {
+              "titel" : "In Rashuras Hölle",
+              "start" : 140907,
+              "end" : 518107
+            },
+            {
+              "titel" : "Rettung",
+              "start" : 518107,
+              "end" : 716720
+            },
+            {
+              "titel" : "Wo ist Bob?",
+              "start" : 716720,
+              "end" : 975200
+            },
+            {
+              "titel" : "Heimlicher Fan",
+              "start" : 975200,
+              "end" : 1200120
+            },
+            {
+              "titel" : "Ein Hauch von Gift",
+              "start" : 1200120,
+              "end" : 1542440
+            },
+            {
+              "titel" : "Der Stern von Kerala",
+              "start" : 1542440,
+              "end" : 1910600
+            },
+            {
+              "titel" : "Eine wichtige Spur",
+              "start" : 1910600,
+              "end" : 2003600
+            },
+            {
+              "titel" : "Ein verdächtiger Polizist",
+              "start" : 2003600,
+              "end" : 2269573
+            },
+            {
+              "titel" : "Strandcafé Rocky Beach",
+              "start" : 2269573,
+              "end" : 2545627
+            },
+            {
+              "titel" : "Leviathan",
+              "start" : 2545627,
+              "end" : 2975827
+            },
+            {
+              "titel" : "Selbstmord",
+              "start" : 2975827,
+              "end" : 3128573
+            },
+            {
+              "titel" : "Hände hoch!",
+              "start" : 3128573,
+              "end" : 3275920
+            },
+            {
+              "titel" : "Ausbruch",
+              "start" : 3275920,
+              "end" : 3736453
+            },
+            {
+              "titel" : "Poker-Einsatz",
+              "start" : 3736453,
+              "end" : 3911413
+            },
+            {
+              "titel" : "Untergang",
+              "start" : 3911413,
+              "end" : 4100240
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Blödmänner",
+              "start" : 0,
+              "end" : 281320
+            },
+            {
+              "titel" : "Streit um eine Frau",
+              "start" : 281320,
+              "end" : 499720
+            },
+            {
+              "titel" : "Anudharas Fluch",
+              "start" : 499720,
+              "end" : 789240
+            },
+            {
+              "titel" : "Rachel's Delight",
+              "start" : 789240,
+              "end" : 1283040
+            },
+            {
+              "titel" : "Tauchgang in der Geisterbucht",
+              "start" : 1283040,
+              "end" : 1909547
+            },
+            {
+              "titel" : "Kennziffer",
+              "start" : 1909547,
+              "end" : 2095147
+            },
+            {
+              "titel" : "Familienangelegenheiten",
+              "start" : 2095147,
+              "end" : 2256840
+            },
+            {
+              "titel" : "Indisch",
+              "start" : 2256840,
+              "end" : 2769733
+            },
+            {
+              "titel" : "Eine Falle",
+              "start" : 2769733,
+              "end" : 2920173
+            },
+            {
+              "titel" : "Keine Tricks",
+              "start" : 2920173,
+              "end" : 3145560
+            },
+            {
+              "titel" : "Die letzte Tür",
+              "start" : 3145560,
+              "end" : 3763400
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log3.txt"
         }
       ],
       "links" : {
@@ -18791,10 +26818,96 @@
           "sprecher" : "Harald Dietl"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der schwarze Riese",
+              "start" : 0,
+              "end" : 326280
+            },
+            {
+              "titel" : "Goldie",
+              "start" : 326280,
+              "end" : 477053
+            },
+            {
+              "titel" : "Wertvolles Gemälde",
+              "start" : 477053,
+              "end" : 571573
+            },
+            {
+              "titel" : "Schmetterlingsflügel",
+              "start" : 571573,
+              "end" : 908893
+            },
+            {
+              "titel" : "Menschenkenntnis",
+              "start" : 908893,
+              "end" : 1006413
+            },
+            {
+              "titel" : "Schwarze Sonne",
+              "start" : 1006413,
+              "end" : 1227120
+            },
+            {
+              "titel" : "Pappnasen",
+              "start" : 1227120,
+              "end" : 1383027
+            },
+            {
+              "titel" : "Wer fürchtet sich vorm schwarzen Mann?",
+              "start" : 1383027,
+              "end" : 1570893
+            },
+            {
+              "titel" : "Weißer Spuk",
+              "start" : 1570893,
+              "end" : 2184987
+            },
+            {
+              "titel" : "Sommerblut",
+              "start" : 2184987,
+              "end" : 2434747
+            },
+            {
+              "titel" : "Blauer Baum",
+              "start" : 2434747,
+              "end" : 2567747
+            },
+            {
+              "titel" : "Grünes Huhn",
+              "start" : 2567747,
+              "end" : 2840067
+            },
+            {
+              "titel" : "Gelber Engel",
+              "start" : 2840067,
+              "end" : 3055893
+            },
+            {
+              "titel" : "Schwarz und weiß",
+              "start" : 3055893,
+              "end" : 3402080
+            },
+            {
+              "titel" : "Schuss ins Blaue",
+              "start" : 3402080,
+              "end" : 3717280
+            },
+            {
+              "titel" : "Rot ist die Liebe",
+              "start" : 3717280,
+              "end" : 3943307
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/151/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/151/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/151/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/151/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/151/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/7d/96/5d/7d965d85-08b0-7661-0a15-826d455e6923/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145710if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/be/cd/5a/0886979232129.jpg"
@@ -18947,10 +27060,76 @@
           "sprecher" : "Anton Sprick"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Auf der Flucht",
+              "start" : 0,
+              "end" : 508827
+            },
+            {
+              "titel" : "Erwischt",
+              "start" : 508827,
+              "end" : 708733
+            },
+            {
+              "titel" : "Gestohlene Kamera",
+              "start" : 708733,
+              "end" : 957680
+            },
+            {
+              "titel" : "Ein alter Fall",
+              "start" : 957680,
+              "end" : 1240053
+            },
+            {
+              "titel" : "Das Verhör",
+              "start" : 1240053,
+              "end" : 1685000
+            },
+            {
+              "titel" : "Niemandsland",
+              "start" : 1685000,
+              "end" : 2008773
+            },
+            {
+              "titel" : "Alles auf eine Karte",
+              "start" : 2008773,
+              "end" : 2365853
+            },
+            {
+              "titel" : "Verblüffung",
+              "start" : 2365853,
+              "end" : 2466347
+            },
+            {
+              "titel" : "Auf Hippie-Tour",
+              "start" : 2466347,
+              "end" : 2586800
+            },
+            {
+              "titel" : "Wiedersehen",
+              "start" : 2586800,
+              "end" : 2850880
+            },
+            {
+              "titel" : "Doppelagent",
+              "start" : 2850880,
+              "end" : 3027013
+            },
+            {
+              "titel" : "Fröhlich vereint",
+              "start" : 3027013,
+              "end" : 3374867
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/152/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/152/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/152/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/152/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/152/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music91/v4/17/66/cd/1766cd28-f935-f51e-c3a0-3d85edcc2555/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153402if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/65/42/16/0886979232228.jpg"
@@ -19094,10 +27273,71 @@
           "sprecher" : "Katinka Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Konferenzschaltung",
+              "start" : 0,
+              "end" : 431987
+            },
+            {
+              "titel" : "Pseudonyme",
+              "start" : 431987,
+              "end" : 692773
+            },
+            {
+              "titel" : "Schlechter Empfang",
+              "start" : 692773,
+              "end" : 979827
+            },
+            {
+              "titel" : "Genie-Streich",
+              "start" : 979827,
+              "end" : 1301000
+            },
+            {
+              "titel" : "Neues Rätsel",
+              "start" : 1301000,
+              "end" : 1477173
+            },
+            {
+              "titel" : "Homepage",
+              "start" : 1477173,
+              "end" : 1748720
+            },
+            {
+              "titel" : "50.000",
+              "start" : 1748720,
+              "end" : 1934987
+            },
+            {
+              "titel" : "Störung",
+              "start" : 1934987,
+              "end" : 2136827
+            },
+            {
+              "titel" : "Schuss",
+              "start" : 2136827,
+              "end" : 2471973
+            },
+            {
+              "titel" : "Griechische Tragödie",
+              "start" : 2471973,
+              "end" : 2858640
+            },
+            {
+              "titel" : "Kalte Dusche",
+              "start" : 2858640,
+              "end" : 3243960
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/153/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/153/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/153/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/153/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/153/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/47/de/60/47de6085-acdd-0cf4-2459-4aef848fdbc5/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045250if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/06/2e/16/0886979232327.jpg"
@@ -19268,10 +27508,81 @@
           "sprecher" : "Leonhard Mahlich"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der zweite Blutfleck",
+              "start" : 0,
+              "end" : 340773
+            },
+            {
+              "titel" : "Der vornehme Klient",
+              "start" : 340773,
+              "end" : 957333
+            },
+            {
+              "titel" : "Die drei Studenten",
+              "start" : 957333,
+              "end" : 1267933
+            },
+            {
+              "titel" : "Der blaue Karfunkel",
+              "start" : 1267933,
+              "end" : 1477560
+            },
+            {
+              "titel" : "Abgehört",
+              "start" : 1477560,
+              "end" : 1593800
+            },
+            {
+              "titel" : "Eine sichere Telefonzelle",
+              "start" : 1593800,
+              "end" : 1761707
+            },
+            {
+              "titel" : "Charles August Milverton",
+              "start" : 1761707,
+              "end" : 2243013
+            },
+            {
+              "titel" : "Das leere Haus",
+              "start" : 2243013,
+              "end" : 2392533
+            },
+            {
+              "titel" : "Eine Frage der Identität",
+              "start" : 2392533,
+              "end" : 2675667
+            },
+            {
+              "titel" : "Bingo!",
+              "start" : 2675667,
+              "end" : 2860093
+            },
+            {
+              "titel" : "Ein umwerfendes Buch",
+              "start" : 2860093,
+              "end" : 3207253
+            },
+            {
+              "titel" : "Der schwarze Peter",
+              "start" : 3207253,
+              "end" : 3475413
+            },
+            {
+              "titel" : "Das letzte Phantom",
+              "start" : 3475413,
+              "end" : 4238587
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/154/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/154/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/154/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/154/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/154/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/49/f1/6f/49f16f75-7f72-cb50-eecd-ad4436498728/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180919if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/d2/9a/16/0886979232426.jpg"
@@ -19424,10 +27735,96 @@
           "sprecher" : "Undine Ullmer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Kein Entkommen",
+              "start" : 0,
+              "end" : 369933
+            },
+            {
+              "titel" : "Düstere Legenden",
+              "start" : 369933,
+              "end" : 807520
+            },
+            {
+              "titel" : "Das Haus des Meisters",
+              "start" : 807520,
+              "end" : 1104333
+            },
+            {
+              "titel" : "Im Inneren des Herzens",
+              "start" : 1104333,
+              "end" : 1360867
+            },
+            {
+              "titel" : "Besessen",
+              "start" : 1360867,
+              "end" : 1745760
+            },
+            {
+              "titel" : "Filmriss",
+              "start" : 1745760,
+              "end" : 1791427
+            },
+            {
+              "titel" : "Leeres Fach",
+              "start" : 1791427,
+              "end" : 2063493
+            },
+            {
+              "titel" : "Belauscht",
+              "start" : 2063493,
+              "end" : 2176667
+            },
+            {
+              "titel" : "Die Informantin",
+              "start" : 2176667,
+              "end" : 2309467
+            },
+            {
+              "titel" : "Stromschlag",
+              "start" : 2309467,
+              "end" : 2424720
+            },
+            {
+              "titel" : "Der Meister der Recherche",
+              "start" : 2424720,
+              "end" : 2769827
+            },
+            {
+              "titel" : "Sohn des Königs",
+              "start" : 2769827,
+              "end" : 2842693
+            },
+            {
+              "titel" : "Panik",
+              "start" : 2842693,
+              "end" : 2990467
+            },
+            {
+              "titel" : "Die tote Lagune",
+              "start" : 2990467,
+              "end" : 3341347
+            },
+            {
+              "titel" : "CCK-4",
+              "start" : 3341347,
+              "end" : 3532573
+            },
+            {
+              "titel" : "Gefährliches Licht",
+              "start" : 3532573,
+              "end" : 4055280
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/155/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/155/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/155/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/155/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/155/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/0b/11/b0/0b11b09e-b129-c754-54c3-f402f09b2f02/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212303if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/46/e0/98/0886979232525.jpg"
@@ -19575,10 +27972,91 @@
           "sprecher" : "Oliver Mink"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Monster im Wald",
+              "start" : 0,
+              "end" : 282240
+            },
+            {
+              "titel" : "Schwierige Jungs",
+              "start" : 282240,
+              "end" : 457387
+            },
+            {
+              "titel" : "Der schwarze Ritter",
+              "start" : 457387,
+              "end" : 870160
+            },
+            {
+              "titel" : "Dragoncourt",
+              "start" : 870160,
+              "end" : 1056360
+            },
+            {
+              "titel" : "In der Falle",
+              "start" : 1056360,
+              "end" : 1171547
+            },
+            {
+              "titel" : "Im Land des Drachen",
+              "start" : 1171547,
+              "end" : 1676560
+            },
+            {
+              "titel" : "Zwei Welten",
+              "start" : 1676560,
+              "end" : 2117187
+            },
+            {
+              "titel" : "Ein alter Freund der Familie",
+              "start" : 2117187,
+              "end" : 2256827
+            },
+            {
+              "titel" : "Gimli und Guinevere",
+              "start" : 2256827,
+              "end" : 2832133
+            },
+            {
+              "titel" : "Ganoven",
+              "start" : 2832133,
+              "end" : 3130013
+            },
+            {
+              "titel" : "Am Abgrund",
+              "start" : 3130013,
+              "end" : 3485293
+            },
+            {
+              "titel" : "Die Höhle des Drachen",
+              "start" : 3485293,
+              "end" : 3683947
+            },
+            {
+              "titel" : "Guinevere",
+              "start" : 3683947,
+              "end" : 3854200
+            },
+            {
+              "titel" : "???",
+              "start" : 3854200,
+              "end" : 4168787
+            },
+            {
+              "titel" : "Die letzte Antwort",
+              "start" : 4168787,
+              "end" : 4331240
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/156/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/156/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/156/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/156/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/156/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/d3/04/70/d304706a-e440-a98e-b198-fb94c5be8527/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180113if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/be/a6/7c/0886979232624.jpg"
@@ -19712,10 +28190,76 @@
           "sprecher" : "Michael von Rospatt"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Riesen-Überraschung",
+              "start" : 0,
+              "end" : 210907
+            },
+            {
+              "titel" : "Die Hand des toten Mannes",
+              "start" : 210907,
+              "end" : 578680
+            },
+            {
+              "titel" : "Unerwarteter Besuch",
+              "start" : 578680,
+              "end" : 1291187
+            },
+            {
+              "titel" : "Der geheimnisvolle Mr. Newman",
+              "start" : 1291187,
+              "end" : 1877147
+            },
+            {
+              "titel" : "Uralter Trick",
+              "start" : 1877147,
+              "end" : 2020013
+            },
+            {
+              "titel" : "Schatten der Vergangenheit",
+              "start" : 2020013,
+              "end" : 2302480
+            },
+            {
+              "titel" : "Das Rätsel der Zehn",
+              "start" : 2302480,
+              "end" : 2494520
+            },
+            {
+              "titel" : "Sternensucher",
+              "start" : 2494520,
+              "end" : 2814227
+            },
+            {
+              "titel" : "Komplikationen",
+              "start" : 2814227,
+              "end" : 3052787
+            },
+            {
+              "titel" : "Im Zeichen der Schlangen",
+              "start" : 3052787,
+              "end" : 3689213
+            },
+            {
+              "titel" : "Fahrt ins Ungewisse",
+              "start" : 3689213,
+              "end" : 3950360
+            },
+            {
+              "titel" : "Showdown",
+              "start" : 3950360,
+              "end" : 4461093
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/157/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/157/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/157/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/157/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/157/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/28/c9/e5/28c9e542-efd4-0224-0714-07583b1136a1/source",
         "cover_kosmos" : "http://web.archive.org/web/20220104131534if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/e8/1f/c7/0886979232723.jpg"
@@ -19865,10 +28409,81 @@
           "sprecher" : "Jannik Endemann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ouvertüre",
+              "start" : 0,
+              "end" : 240800
+            },
+            {
+              "titel" : "Vorhang auf!",
+              "start" : 240800,
+              "end" : 388653
+            },
+            {
+              "titel" : "Hinter den Kulissen!",
+              "start" : 388653,
+              "end" : 794653
+            },
+            {
+              "titel" : "Zwischenspiel",
+              "start" : 794653,
+              "end" : 917080
+            },
+            {
+              "titel" : "Wesen im Dunkeln",
+              "start" : 917080,
+              "end" : 1256253
+            },
+            {
+              "titel" : "Detektive in Not",
+              "start" : 1256253,
+              "end" : 1412173
+            },
+            {
+              "titel" : "Teepause",
+              "start" : 1412173,
+              "end" : 1623400
+            },
+            {
+              "titel" : "Mistkerle",
+              "start" : 1623400,
+              "end" : 1780333
+            },
+            {
+              "titel" : "Inferno im Tempel",
+              "start" : 1780333,
+              "end" : 2261987
+            },
+            {
+              "titel" : "Blitz und Donner",
+              "start" : 2261987,
+              "end" : 2378587
+            },
+            {
+              "titel" : "Kaffee & Schokolade",
+              "start" : 2378587,
+              "end" : 2613133
+            },
+            {
+              "titel" : "Am Abgrund",
+              "start" : 2613133,
+              "end" : 2973933
+            },
+            {
+              "titel" : "Indizien",
+              "start" : 2973933,
+              "end" : 3396520
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/158/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/158/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/158/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/158/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/158/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/d5/8b/37/d58b3740-5414-043e-7a89-15fc43fbc024/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153350if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/77/57/f3/0886979232822.jpg"
@@ -19989,10 +28604,71 @@
           "sprecher" : "Gerhart Hinze"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Bauchangelegenheiten",
+              "start" : 0,
+              "end" : 277333
+            },
+            {
+              "titel" : "Spurensuche",
+              "start" : 277333,
+              "end" : 1083240
+            },
+            {
+              "titel" : "Nacht der Tiger",
+              "start" : 1083240,
+              "end" : 1490240
+            },
+            {
+              "titel" : "Unter Druck",
+              "start" : 1490240,
+              "end" : 1692067
+            },
+            {
+              "titel" : "Schwarze Stiere",
+              "start" : 1692067,
+              "end" : 1998333
+            },
+            {
+              "titel" : "Clever",
+              "start" : 1998333,
+              "end" : 2306307
+            },
+            {
+              "titel" : "In Teufels Küche – und Schrank",
+              "start" : 2306307,
+              "end" : 2583480
+            },
+            {
+              "titel" : "Mut zur Wahrheit",
+              "start" : 2583480,
+              "end" : 2852187
+            },
+            {
+              "titel" : "Schlagende Ziegen",
+              "start" : 2852187,
+              "end" : 3130987
+            },
+            {
+              "titel" : "Erstens kommt es anders …",
+              "start" : 3130987,
+              "end" : 3567227
+            },
+            {
+              "titel" : "… und zweitens als man denkt",
+              "start" : 3567227,
+              "end" : 3931427
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/159/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/159/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/159/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/159/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/159/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/76/95/67/76956777-0773-74b5-1ae9-880858e2c8c4/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145705if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/19/75/a0/0886979232921.jpg"
@@ -20114,10 +28790,61 @@
           "sprecher" : "Bertram Hiese"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Pergamentmacher",
+              "start" : 0,
+              "end" : 303573
+            },
+            {
+              "titel" : "Geschick und Verstand",
+              "start" : 303573,
+              "end" : 646293
+            },
+            {
+              "titel" : "Volltreffer!",
+              "start" : 646293,
+              "end" : 802640
+            },
+            {
+              "titel" : "Einbruch in die Suite",
+              "start" : 802640,
+              "end" : 1332533
+            },
+            {
+              "titel" : "Einstiche",
+              "start" : 1332533,
+              "end" : 1562627
+            },
+            {
+              "titel" : "Der Text über dem Text",
+              "start" : 1562627,
+              "end" : 2074107
+            },
+            {
+              "titel" : "Die erste Station",
+              "start" : 2074107,
+              "end" : 2533760
+            },
+            {
+              "titel" : "Gartenzaun",
+              "start" : 2533760,
+              "end" : 3210840
+            },
+            {
+              "titel" : "Die Gruft",
+              "start" : 3210840,
+              "end" : 3820387
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/160/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/160/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/160/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/160/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/160/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/02/d2/42/02d2428d-46c6-88ae-9840-bb6bac345d83/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180112if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/22/c2/6b/0886979233027.jpg"
@@ -20260,10 +28987,86 @@
           "sprecher" : "Lutz Harder"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Mord in Rocky Beach!",
+              "start" : 0,
+              "end" : 557640
+            },
+            {
+              "titel" : "Brock erinnert sich",
+              "start" : 557640,
+              "end" : 836560
+            },
+            {
+              "titel" : "Im Atelier des Malers",
+              "start" : 836560,
+              "end" : 1067427
+            },
+            {
+              "titel" : "Im Frauen-Club",
+              "start" : 1067427,
+              "end" : 1364853
+            },
+            {
+              "titel" : "Die Rückkehr des Zauberers",
+              "start" : 1364853,
+              "end" : 1486853
+            },
+            {
+              "titel" : "Gefragte Porrees",
+              "start" : 1486853,
+              "end" : 1730880
+            },
+            {
+              "titel" : "Ein Bild gibt Rätsel auf",
+              "start" : 1730880,
+              "end" : 1983360
+            },
+            {
+              "titel" : "Der Vampir",
+              "start" : 1983360,
+              "end" : 2235573
+            },
+            {
+              "titel" : "Das Verwirrspiel",
+              "start" : 2235573,
+              "end" : 2643587
+            },
+            {
+              "titel" : "Echtes Blut",
+              "start" : 2643587,
+              "end" : 2947973
+            },
+            {
+              "titel" : "Komplikationen",
+              "start" : 2947973,
+              "end" : 3260707
+            },
+            {
+              "titel" : "Ein alter Bekannter",
+              "start" : 3260707,
+              "end" : 3413813
+            },
+            {
+              "titel" : "Perfekte Tarnung",
+              "start" : 3413813,
+              "end" : 3825053
+            },
+            {
+              "titel" : "Ein Bild in Lebensgefahr",
+              "start" : 3825053,
+              "end" : 4238493
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/161/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/161/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/161/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/161/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/161/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/53/4b/01/534b0104-c102-b636-e09f-0f693c658a03/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022640if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/b8/5c/91/0887254003120.jpg"
@@ -20387,10 +29190,71 @@
           "sprecher" : "Gustav-Adolph Artz"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Warnung aus South Dakota",
+              "start" : 0,
+              "end" : 474747
+            },
+            {
+              "titel" : "Fort Stockburn",
+              "start" : 474747,
+              "end" : 663840
+            },
+            {
+              "titel" : "Phase 1",
+              "start" : 663840,
+              "end" : 954333
+            },
+            {
+              "titel" : "Fremde unerwünscht",
+              "start" : 954333,
+              "end" : 1567147
+            },
+            {
+              "titel" : "Phase 2",
+              "start" : 1567147,
+              "end" : 1771973
+            },
+            {
+              "titel" : "Dem Grauen auf der Spur",
+              "start" : 1771973,
+              "end" : 2055200
+            },
+            {
+              "titel" : "Schwierige Recherchen",
+              "start" : 2055200,
+              "end" : 2439800
+            },
+            {
+              "titel" : "Die große Bedrohung",
+              "start" : 2439800,
+              "end" : 2745893
+            },
+            {
+              "titel" : "Schatten der Vergangenheit",
+              "start" : 2745893,
+              "end" : 3128360
+            },
+            {
+              "titel" : "Furcht und Hoffnung",
+              "start" : 3128360,
+              "end" : 3613520
+            },
+            {
+              "titel" : "Der Nebel lichtet sich",
+              "start" : 3613520,
+              "end" : 4365707
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/162/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/162/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/162/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/162/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/162/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/a3/37/c9/a337c9f9-455b-d36a-5431-c336dd4a4552/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212302if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/70/82/91/0887254003229.jpg"
@@ -20486,10 +29350,71 @@
           "sprecher" : "Holger Mahlich"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Begegnung im Nebel",
+              "start" : 0,
+              "end" : 519093
+            },
+            {
+              "titel" : "Hässliche Fratze",
+              "start" : 519093,
+              "end" : 1034760
+            },
+            {
+              "titel" : "Ein üblicher Klassiker",
+              "start" : 1034760,
+              "end" : 1225760
+            },
+            {
+              "titel" : "Steinschlag",
+              "start" : 1225760,
+              "end" : 1582640
+            },
+            {
+              "titel" : "Harte Rätselnuss",
+              "start" : 1582640,
+              "end" : 1885467
+            },
+            {
+              "titel" : "Katzenmaske",
+              "start" : 1885467,
+              "end" : 2052000
+            },
+            {
+              "titel" : "Glatt gelogen",
+              "start" : 2052000,
+              "end" : 2626187
+            },
+            {
+              "titel" : "Die Gleichung geht auf",
+              "start" : 2626187,
+              "end" : 3009160
+            },
+            {
+              "titel" : "Platt",
+              "start" : 3009160,
+              "end" : 3373267
+            },
+            {
+              "titel" : "Auf der Flucht",
+              "start" : 3373267,
+              "end" : 4264013
+            },
+            {
+              "titel" : "Ein Rätsel aus der Kindheit",
+              "start" : 4264013,
+              "end" : 4468413
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/163/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/163/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/163/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/163/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/163/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/64/c5/5b/64c55bab-6657-1761-b0e0-775082869537/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152701if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/bd/16/24/0887254003328.jpg"
@@ -20614,10 +29539,66 @@
           "sprecher" : "Carsten Kausse"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Hooked Nose",
+              "start" : 0,
+              "end" : 432240
+            },
+            {
+              "titel" : "Alles schwarz",
+              "start" : 432240,
+              "end" : 872667
+            },
+            {
+              "titel" : "Wuhukini",
+              "start" : 872667,
+              "end" : 1086947
+            },
+            {
+              "titel" : "Pakt mit dem Teufel",
+              "start" : 1086947,
+              "end" : 1256627
+            },
+            {
+              "titel" : "Eine goldene Nase",
+              "start" : 1256627,
+              "end" : 1630533
+            },
+            {
+              "titel" : "Erinnerungslücken",
+              "start" : 1630533,
+              "end" : 2115453
+            },
+            {
+              "titel" : "Dunkle Stimmen",
+              "start" : 2115453,
+              "end" : 2399320
+            },
+            {
+              "titel" : "Der Tanz beginnt",
+              "start" : 2399320,
+              "end" : 2701827
+            },
+            {
+              "titel" : "Taub und blind",
+              "start" : 2701827,
+              "end" : 3813960
+            },
+            {
+              "titel" : "Ein würdiger Nachfolger",
+              "start" : 3813960,
+              "end" : 4125760
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/164/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/164/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/164/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/164/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/164/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/33/9d/82/339d82ac-5442-604b-98b5-8c9d7ebc130e/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180110if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/0c/4a/4b/0887254003427.jpg"
@@ -20749,10 +29730,71 @@
           "sprecher" : "Daniel Welbat"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Zwischen Himmel und Erde",
+              "start" : 0,
+              "end" : 337187
+            },
+            {
+              "titel" : "Das Tal der Unfälle",
+              "start" : 337187,
+              "end" : 477067
+            },
+            {
+              "titel" : "Im Schatten der Berge",
+              "start" : 477067,
+              "end" : 901987
+            },
+            {
+              "titel" : "\"Jene, die töten\"",
+              "start" : 901987,
+              "end" : 1260480
+            },
+            {
+              "titel" : "Getroffen!",
+              "start" : 1260480,
+              "end" : 1465107
+            },
+            {
+              "titel" : "Schlaflos im Yosemite Valley",
+              "start" : 1465107,
+              "end" : 1687787
+            },
+            {
+              "titel" : "Ein rätselhafter Anruf",
+              "start" : 1687787,
+              "end" : 2022933
+            },
+            {
+              "titel" : "Der Wahrheit auf der Spur",
+              "start" : 2022933,
+              "end" : 2244893
+            },
+            {
+              "titel" : "Ein grauenhafter Fund",
+              "start" : 2244893,
+              "end" : 3537587
+            },
+            {
+              "titel" : "In Lebensgefahr",
+              "start" : 3537587,
+              "end" : 3803453
+            },
+            {
+              "titel" : "Betrug am Berg",
+              "start" : 3803453,
+              "end" : 4217360
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/165/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/165/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/165/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/165/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/165/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/e3/44/2b/e3442bfa-54ba-5906-6898-5b2054c2ca12/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022638if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/c7/9d/13/0887254003526.jpg"
@@ -20850,10 +29892,61 @@
           "sprecher" : "Elga Schütz"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Nachricht aus dem Grab",
+              "start" : 0,
+              "end" : 711907
+            },
+            {
+              "titel" : "Es brennt",
+              "start" : 711907,
+              "end" : 1016347
+            },
+            {
+              "titel" : "Geisterschwaden",
+              "start" : 1016347,
+              "end" : 1492533
+            },
+            {
+              "titel" : "Eine gewisse Ähnlichkeit",
+              "start" : 1492533,
+              "end" : 1655520
+            },
+            {
+              "titel" : "Der Stadtforscher",
+              "start" : 1655520,
+              "end" : 2391173
+            },
+            {
+              "titel" : "Die Falle schnappt zu",
+              "start" : 2391173,
+              "end" : 2633853
+            },
+            {
+              "titel" : "In die Tiefe",
+              "start" : 2633853,
+              "end" : 3208480
+            },
+            {
+              "titel" : "Katastrophe in der Dunkelheit",
+              "start" : 3208480,
+              "end" : 3791347
+            },
+            {
+              "titel" : "Was damals in der Finsternis geschah",
+              "start" : 3791347,
+              "end" : 4063013
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/166/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/166/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/166/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/166/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/166/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/f0/6b/f7/f06bf784-4780-e1b4-f78d-290902f3e662/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111022949if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/5d/d0/58/0887254003625.jpg"
@@ -21022,10 +30115,91 @@
           "pseudonym" : "Bruno Ploeger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Hilferuf von King Kongs Insel",
+              "start" : 0,
+              "end" : 354080
+            },
+            {
+              "titel" : "Das Kino erwacht",
+              "start" : 354080,
+              "end" : 541387
+            },
+            {
+              "titel" : "Im Feindgebiet",
+              "start" : 541387,
+              "end" : 685787
+            },
+            {
+              "titel" : "Giraffen und Regenschirme",
+              "start" : 685787,
+              "end" : 1003093
+            },
+            {
+              "titel" : "Böses Spiel",
+              "start" : 1003093,
+              "end" : 1186907
+            },
+            {
+              "titel" : "Diebstahl",
+              "start" : 1186907,
+              "end" : 1501267
+            },
+            {
+              "titel" : "Tat oder Wahrheit?",
+              "start" : 1501267,
+              "end" : 1702587
+            },
+            {
+              "titel" : "Ein Monster kehrt zurück",
+              "start" : 1702587,
+              "end" : 1943293
+            },
+            {
+              "titel" : "1000NBRANDB282286",
+              "start" : 1943293,
+              "end" : 2071773
+            },
+            {
+              "titel" : "Der Dschungel des Mantikors",
+              "start" : 2071773,
+              "end" : 2476840
+            },
+            {
+              "titel" : "Tarzan in Gefahr",
+              "start" : 2476840,
+              "end" : 2662053
+            },
+            {
+              "titel" : "Gabbos Geheimnis",
+              "start" : 2662053,
+              "end" : 3273040
+            },
+            {
+              "titel" : "Das blaue Biest",
+              "start" : 3273040,
+              "end" : 3714080
+            },
+            {
+              "titel" : "Die Zeit läuft ab",
+              "start" : 3714080,
+              "end" : 4043320
+            },
+            {
+              "titel" : "Showdown",
+              "start" : 4043320,
+              "end" : 4324213
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/167/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/167/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/167/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/167/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/167/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music111/v4/a4/04/2b/a4042bde-8b6f-01fc-8679-b78c2e45942d/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145704if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/16/03/20/0887254003724.jpg"
@@ -21168,10 +30342,66 @@
           "sprecher" : "Andreas Becker"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Prinzessin",
+              "start" : 0,
+              "end" : 744000
+            },
+            {
+              "titel" : "Cotta ist bedient",
+              "start" : 744000,
+              "end" : 1089880
+            },
+            {
+              "titel" : "Die erste Spur",
+              "start" : 1089880,
+              "end" : 1366093
+            },
+            {
+              "titel" : "Merkwürdiger Fluchtweg",
+              "start" : 1366093,
+              "end" : 2202823
+            },
+            {
+              "titel" : "Auf dem Holzweg",
+              "start" : 2202823,
+              "end" : 2715917
+            },
+            {
+              "titel" : "Eine unglaubliche Entdeckung",
+              "start" : 2715917,
+              "end" : 3083317
+            },
+            {
+              "titel" : "Der Deal",
+              "start" : 3083317,
+              "end" : 3649810
+            },
+            {
+              "titel" : "Bis zum letzten Atemzug",
+              "start" : 3649810,
+              "end" : 3994983
+            },
+            {
+              "titel" : "Rache aus dem Grab",
+              "start" : 3994983,
+              "end" : 4287383
+            },
+            {
+              "titel" : "Justus ist nicht nett",
+              "start" : 4287383,
+              "end" : 4675973
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/168/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/168/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/168/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/168/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/168/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/61/82/67/618267e9-4aba-d583-b86d-2fdfd8606d35/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230853if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/95/b5/7f/0887254003823.jpg"
@@ -21303,10 +30533,66 @@
           "sprecher" : "Holger Mahlich"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Unterm Hammer",
+              "start" : 0,
+              "end" : 527773
+            },
+            {
+              "titel" : "Fahrerflucht",
+              "start" : 527773,
+              "end" : 897787
+            },
+            {
+              "titel" : "Krankenbesuch",
+              "start" : 897787,
+              "end" : 1208453
+            },
+            {
+              "titel" : "Zwillinge hinter dem Fliegengitter",
+              "start" : 1208453,
+              "end" : 1677960
+            },
+            {
+              "titel" : "Sam Chiccarelli",
+              "start" : 1677960,
+              "end" : 1943080
+            },
+            {
+              "titel" : "Analysen",
+              "start" : 1943080,
+              "end" : 2269173
+            },
+            {
+              "titel" : "Der verschwundene Großmeister",
+              "start" : 2269173,
+              "end" : 2756547
+            },
+            {
+              "titel" : "Mrs. Hammontrees Geheimnis",
+              "start" : 2756547,
+              "end" : 3527960
+            },
+            {
+              "titel" : "Wer ist wer?",
+              "start" : 3527960,
+              "end" : 4155387
+            },
+            {
+              "titel" : "Die Lansky-Eröffnung",
+              "start" : 4155387,
+              "end" : 4910587
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/169/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/169/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/169/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/169/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/169/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/42/03/51/420351cc-053e-af53-d65a-35e3fe43e78c/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153347if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/7a/b3/5c/0887254003922.jpg"
@@ -21458,10 +30744,71 @@
           "sprecher" : "Maria Baptista"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Spiel beginnt",
+              "start" : 0,
+              "end" : 740400
+            },
+            {
+              "titel" : "Verbotene Recherchen",
+              "start" : 740400,
+              "end" : 971173
+            },
+            {
+              "titel" : "Shackles & Chains",
+              "start" : 971173,
+              "end" : 1356493
+            },
+            {
+              "titel" : "NVSR und Regentanz",
+              "start" : 1356493,
+              "end" : 1687827
+            },
+            {
+              "titel" : "Verfolgt?",
+              "start" : 1687827,
+              "end" : 1793987
+            },
+            {
+              "titel" : "Nachtwache",
+              "start" : 1793987,
+              "end" : 2409333
+            },
+            {
+              "titel" : "Boblos in der Wüste",
+              "start" : 2409333,
+              "end" : 2969373
+            },
+            {
+              "titel" : "Black & White",
+              "start" : 2969373,
+              "end" : 3567120
+            },
+            {
+              "titel" : "Verkleidet",
+              "start" : 3567120,
+              "end" : 4277413
+            },
+            {
+              "titel" : "Im Namen des Gesetzes",
+              "start" : 4277413,
+              "end" : 4636707
+            },
+            {
+              "titel" : "Geheimnisse",
+              "start" : 4636707,
+              "end" : 4816533
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/170/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/170/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/170/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/170/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/170/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/92/7c/70/927c7044-8078-6a25-4d74-65f0018fda86/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111212301if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/16/33/f0/0887254004028.jpg"
@@ -21612,10 +30959,66 @@
           "sprecher" : "Toru Takahashi"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Mann im Meer",
+              "start" : 0,
+              "end" : 221320
+            },
+            {
+              "titel" : "Der Schrecken der sieben Meere",
+              "start" : 221320,
+              "end" : 1045053
+            },
+            {
+              "titel" : "Jimmy Blue Eye",
+              "start" : 1045053,
+              "end" : 1306560
+            },
+            {
+              "titel" : "Das Schicksal der Kassiopeia",
+              "start" : 1306560,
+              "end" : 1877720
+            },
+            {
+              "titel" : "Irrungen und Wirrungen",
+              "start" : 1877720,
+              "end" : 2146853
+            },
+            {
+              "titel" : "Das Grauen im Nebel",
+              "start" : 2146853,
+              "end" : 2490933
+            },
+            {
+              "titel" : "Abrahams Geheimnis",
+              "start" : 2490933,
+              "end" : 2769427
+            },
+            {
+              "titel" : "Schreiende Schatten",
+              "start" : 2769427,
+              "end" : 3215067
+            },
+            {
+              "titel" : "Bodycheck",
+              "start" : 3215067,
+              "end" : 3607467
+            },
+            {
+              "titel" : "Tod im Spiegel",
+              "start" : 3607467,
+              "end" : 4040853
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/171/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/171/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/171/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/171/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/171/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/0a/af/6d/0aaf6d4b-9bd2-2cdb-34f4-e25e3f42d67a/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115045237if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/a1/45/0d/0888430092921.jpg"
@@ -21743,10 +31146,71 @@
           "sprecher" : "Frank Thannhäuser"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Giftiges Geheimnis",
+              "start" : 0,
+              "end" : 517893
+            },
+            {
+              "titel" : "Eisenmann",
+              "start" : 517893,
+              "end" : 750520
+            },
+            {
+              "titel" : "Ein toter Vogel",
+              "start" : 750520,
+              "end" : 1555160
+            },
+            {
+              "titel" : "Kundschaft",
+              "start" : 1555160,
+              "end" : 1786840
+            },
+            {
+              "titel" : "Unter Verdacht",
+              "start" : 1786840,
+              "end" : 2064840
+            },
+            {
+              "titel" : "Gsch-Gsch!",
+              "start" : 2064840,
+              "end" : 2345920
+            },
+            {
+              "titel" : "Filmreife Flucht",
+              "start" : 2345920,
+              "end" : 2657213
+            },
+            {
+              "titel" : "Ein seltsamer Irrtum",
+              "start" : 2657213,
+              "end" : 2886973
+            },
+            {
+              "titel" : "Fragen über Fragen",
+              "start" : 2886973,
+              "end" : 3353173
+            },
+            {
+              "titel" : "Nacht im Bunker",
+              "start" : 3353173,
+              "end" : 4237453
+            },
+            {
+              "titel" : "Die letzten Fragen",
+              "start" : 4237453,
+              "end" : 4375213
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/172/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/172/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/172/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/172/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/172/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music122/v4/cc/65/a6/cc65a6f0-817b-1df8-21b3-82e33ccaa0d1/source",
         "cover_kosmos" : "http://web.archive.org/web/20220114180109if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/fa/cb/c4/0888430093027.jpg"
@@ -21865,10 +31329,66 @@
           "sprecher" : "Lutz Mackensy"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der einzige Zeuge",
+              "start" : 0,
+              "end" : 197480
+            },
+            {
+              "titel" : "Das Dunkelhaus",
+              "start" : 197480,
+              "end" : 588307
+            },
+            {
+              "titel" : "Bei Tageslicht",
+              "start" : 588307,
+              "end" : 1443960
+            },
+            {
+              "titel" : "In der Dämmerung",
+              "start" : 1443960,
+              "end" : 1644800
+            },
+            {
+              "titel" : "Monsternacht",
+              "start" : 1644800,
+              "end" : 2412000
+            },
+            {
+              "titel" : "Im Kleiderschrank",
+              "start" : 2412000,
+              "end" : 2609013
+            },
+            {
+              "titel" : "Die Trinität der Geist-Vögel",
+              "start" : 2609013,
+              "end" : 3006667
+            },
+            {
+              "titel" : "Der Fluch des Harpuniers",
+              "start" : 3006667,
+              "end" : 3340213
+            },
+            {
+              "titel" : "Hinterhalt",
+              "start" : 3340213,
+              "end" : 3654787
+            },
+            {
+              "titel" : "Die große Versammlung",
+              "start" : 3654787,
+              "end" : 4225213
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/173/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/173/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/173/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/173/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/173/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music122/v4/2b/a1/4d/2ba14d6b-6af1-15a0-d11f-c86a18e840e4/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153346if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/82/39/c1/0888430093126.jpg"
@@ -21978,10 +31498,61 @@
           "sprecher" : "Martin Brücker"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Wesen im Wald",
+              "start" : 0,
+              "end" : 378187
+            },
+            {
+              "titel" : "Das Tagebuch des Priesters",
+              "start" : 378187,
+              "end" : 915787
+            },
+            {
+              "titel" : "Hintergründe",
+              "start" : 915787,
+              "end" : 1254333
+            },
+            {
+              "titel" : "Der Geruch des Todes",
+              "start" : 1254333,
+              "end" : 1889827
+            },
+            {
+              "titel" : "Freunde in der Not",
+              "start" : 1889827,
+              "end" : 2257507
+            },
+            {
+              "titel" : "In Deckung!",
+              "start" : 2257507,
+              "end" : 2390667
+            },
+            {
+              "titel" : "Allergie",
+              "start" : 2390667,
+              "end" : 2871120
+            },
+            {
+              "titel" : "Sachen von heutzutage",
+              "start" : 2871120,
+              "end" : 3486680
+            },
+            {
+              "titel" : "Geld verdirbt den Charakter",
+              "start" : 3486680,
+              "end" : 3800827
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/174/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/174/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/174/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/174/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/174/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/a3/9d/83/a39d836b-7859-bd8e-5169-d22155f856f1/source",
         "cover_kosmos" : "http://web.archive.org/web/20220104131535if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/55/82/07/0888430093225580828a2c6a7d.jpg"
@@ -21995,7 +31566,9 @@
           "buchstabe" : "A",
           "titel" : "Teuflisches Duell",
           "autor" : "Christoph Dittert",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Kurz nach ihrem Einzug ins Studentenwohnheim werden die drei ??? Zeugen merkwürdiger Ereignisse auf dem Campus. Unmenschliche Schreie hallen über das Gelände, freundliche Studenten werden plötzlich aggressiv – geht hier alles mit rechten Dingen zu? Und wer ist der Teumessische Fuchs, über den man überall Gerüchte hört? Eine Fuchsjagd der besonderen Art beginnt …",
+          "veröffentlichungsdatum" : "2015-05-15",
           "kapitel" : [
             {
               "titel" : "Computerfehler",
@@ -22154,8 +31727,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/1/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/175/1/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/175/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/175/1/ffmetadata.txt"
           }
         },
         {
@@ -22163,7 +31735,9 @@
           "buchstabe" : "B",
           "titel" : "Angriff in der Nacht",
           "autor" : "Kari Erlhoff",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Ihre Ermittlungen führen die drei ??? immer weiter in einen Sumpf aus Lügen und dunklen Machenschaften. Doch wer steckt hinter alldem? Justus, Peter und Bob sind dem Teumessischen Fuchs auf der Spur, der überall und nirgends zu sein scheint. Doch haben die drei Detektive den richtigen Riecher? Eines Nachts schlägt ihr unbekannter Gegner plötzlich zu …",
+          "veröffentlichungsdatum" : "2015-05-15",
           "kapitel" : [
             {
               "titel" : "Kleinkriminelle mit Größenwahn",
@@ -22283,8 +31857,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/2/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/175/2/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/175/2/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/175/2/ffmetadata.txt"
           }
         },
         {
@@ -22292,7 +31865,9 @@
           "buchstabe" : "C",
           "titel" : "Die dunkle Macht",
           "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Die drei Detektive machen ein paar spektakuläre Entdeckungen. Doch der Teumessische Fuchs scheint ihnen stets einen Schritt voraus zu sein. Noch immer wissen sie nicht, wer sich hinter dem rätselhaften Wesen verbirgt. Und je näher die drei ??? ihm kommen, desto gefährlicher wird es für sie. Als Justus, Peter und Bob endlich auf ihren Widersacher treffen, zeigt der Fuchs sein wahres Gesicht …",
+          "veröffentlichungsdatum" : "2015-05-15",
           "kapitel" : [
             {
               "titel" : "Der Tag danach",
@@ -22399,8 +31974,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Serie/175/3/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Serie/175/3/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/175/3/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Serie/175/3/ffmetadata.txt"
           }
         }
       ],
@@ -22546,6 +32120,168 @@
           "sprecher" : "Die Gäste der Record-Release-Party am 14.01.2015 in Berlin. (Wir danken euch für's Mitmachen!)"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Computerfehler",
+              "start" : 0,
+              "end" : 358293
+            },
+            {
+              "titel" : "Die Universität und der Fuchs",
+              "start" : 358293,
+              "end" : 524413
+            },
+            {
+              "titel" : "Aufbruch ins Abenteuer",
+              "start" : 524413,
+              "end" : 841960
+            },
+            {
+              "titel" : "Seltsame Vögel",
+              "start" : 841960,
+              "end" : 1337653
+            },
+            {
+              "titel" : "Das Geheimnis von Ruxton",
+              "start" : 1337653,
+              "end" : 1586467
+            },
+            {
+              "titel" : "Im Studentenloch",
+              "start" : 1586467,
+              "end" : 2092947
+            },
+            {
+              "titel" : "Alpha Lambda Chi",
+              "start" : 2092947,
+              "end" : 2171440
+            },
+            {
+              "titel" : "\"… ich rate dir: Nun flieh!\"",
+              "start" : 2171440,
+              "end" : 2606787
+            },
+            {
+              "titel" : "Verbrechen aller Art",
+              "start" : 2606787,
+              "end" : 2861987
+            },
+            {
+              "titel" : "Ein Dieb namens Justus Jonas",
+              "start" : 2861987,
+              "end" : 2912840
+            },
+            {
+              "titel" : "Überrachung!",
+              "start" : 2912840,
+              "end" : 3451693
+            },
+            {
+              "titel" : "Etwas wirft seinen Schatten voraus",
+              "start" : 3451693,
+              "end" : 3648933
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Kleinkriminelle mit Größenwahn",
+              "start" : 0,
+              "end" : 410853
+            },
+            {
+              "titel" : "Ein tragischer Unfall",
+              "start" : 410853,
+              "end" : 560653
+            },
+            {
+              "titel" : "Party-Time",
+              "start" : 560653,
+              "end" : 984040
+            },
+            {
+              "titel" : "Im Keller",
+              "start" : 984040,
+              "end" : 1158787
+            },
+            {
+              "titel" : "Quaesitio",
+              "start" : 1158787,
+              "end" : 1275160
+            },
+            {
+              "titel" : "Lailaps",
+              "start" : 1275160,
+              "end" : 1788133
+            },
+            {
+              "titel" : "Angriff in der Nacht",
+              "start" : 1788133,
+              "end" : 2130360
+            },
+            {
+              "titel" : "Tödliches Gift",
+              "start" : 2130360,
+              "end" : 2830120
+            },
+            {
+              "titel" : "Verräterischer Duft",
+              "start" : 2830120,
+              "end" : 3434200
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Tag danach",
+              "start" : 0,
+              "end" : 286147
+            },
+            {
+              "titel" : "Eine neue Botschaft",
+              "start" : 286147,
+              "end" : 695000
+            },
+            {
+              "titel" : "Das Monster im Labor",
+              "start" : 695000,
+              "end" : 1323747
+            },
+            {
+              "titel" : "Ein unfassbarer Vorwurf",
+              "start" : 1323747,
+              "end" : 1693787
+            },
+            {
+              "titel" : "Kehrtwende",
+              "start" : 1693787,
+              "end" : 2374427
+            },
+            {
+              "titel" : "Auf der Fährte des Fuchses",
+              "start" : 2374427,
+              "end" : 2756973
+            },
+            {
+              "titel" : "Schattenwelt",
+              "start" : 2756973,
+              "end" : 3552200
+            },
+            {
+              "titel" : "Der letzte Kampf des Lailaps",
+              "start" : 3552200,
+              "end" : 4166493
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log3.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/175/metadata.json",
         "cover" : "http://dreimetadaten.de/data/Serie/175/cover.png",
@@ -22675,10 +32411,76 @@
           "sprecher" : "Die Gäste der Record-Release-Party am 22.02.2015 in Dortmund. (Wir danken euch für's Mitmachen!)"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein dämlicher Löwe",
+              "start" : 0,
+              "end" : 221627
+            },
+            {
+              "titel" : "Bluthunde",
+              "start" : 221627,
+              "end" : 395427
+            },
+            {
+              "titel" : "Lieblingsbär",
+              "start" : 395427,
+              "end" : 697280
+            },
+            {
+              "titel" : "Dünne Faktenlage",
+              "start" : 697280,
+              "end" : 832547
+            },
+            {
+              "titel" : "Adlernase",
+              "start" : 832547,
+              "end" : 1126760
+            },
+            {
+              "titel" : "Geflügelte Affen",
+              "start" : 1126760,
+              "end" : 1610533
+            },
+            {
+              "titel" : "Grinsekatze",
+              "start" : 1610533,
+              "end" : 2300720
+            },
+            {
+              "titel" : "Zwinkernde Augen",
+              "start" : 2300720,
+              "end" : 2541453
+            },
+            {
+              "titel" : "Der böse Wolf",
+              "start" : 2541453,
+              "end" : 2851093
+            },
+            {
+              "titel" : "Bienenzimmer",
+              "start" : 2851093,
+              "end" : 3612187
+            },
+            {
+              "titel" : "Kein Papagei, sondern …?",
+              "start" : 3612187,
+              "end" : 3882627
+            },
+            {
+              "titel" : "Und was es sonst noch so im Zoo gibt",
+              "start" : 3882627,
+              "end" : 4064107
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/176/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/176/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/176/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/176/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/176/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music122/v4/3d/a3/6f/3da36fd6-b627-8563-9b74-27376e5994ff/source",
         "cover_kosmos" : "http://web.archive.org/web/20220111022948if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/0c/ec/90/0888430093423.jpg"
@@ -22792,10 +32594,61 @@
           "sprecher" : "Kai Henrik Möller"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Willkommen im Dead Man's Canyon",
+              "start" : 0,
+              "end" : 376120
+            },
+            {
+              "titel" : "Sniffer",
+              "start" : 376120,
+              "end" : 1000640
+            },
+            {
+              "titel" : "Alarm",
+              "start" : 1000640,
+              "end" : 1432240
+            },
+            {
+              "titel" : "Mr. Sobek",
+              "start" : 1432240,
+              "end" : 2039133
+            },
+            {
+              "titel" : "Verräterisches Schuhwerk",
+              "start" : 2039133,
+              "end" : 2531453
+            },
+            {
+              "titel" : "Auf der Lauer",
+              "start" : 2531453,
+              "end" : 3030413
+            },
+            {
+              "titel" : "Im Keller",
+              "start" : 3030413,
+              "end" : 3382960
+            },
+            {
+              "titel" : "Geständnisse",
+              "start" : 3382960,
+              "end" : 3858933
+            },
+            {
+              "titel" : "Sniffer freut sich",
+              "start" : 3858933,
+              "end" : 4121080
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/177/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/177/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/177/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/177/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/177/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music122/v4/40/a6/8f/40a68f11-474a-dded-654b-a5d62a9e62d1/source",
         "cover_kosmos" : "http://web.archive.org/web/20220106180902if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/94/26/19/0888430093522.jpg"
@@ -22901,10 +32754,61 @@
           "sprecher" : "Holger Mahlich"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine alte Bekannte",
+              "start" : 0,
+              "end" : 315320
+            },
+            {
+              "titel" : "Meeresgetierrettungsaktion",
+              "start" : 315320,
+              "end" : 672373
+            },
+            {
+              "titel" : "Überwacht",
+              "start" : 672373,
+              "end" : 871867
+            },
+            {
+              "titel" : "Ornithologie der besonderen Art",
+              "start" : 871867,
+              "end" : 1593400
+            },
+            {
+              "titel" : "Erpressung",
+              "start" : 1593400,
+              "end" : 1860600
+            },
+            {
+              "titel" : "Blutige Federn",
+              "start" : 1860600,
+              "end" : 2474333
+            },
+            {
+              "titel" : "Aus eins mach zwei",
+              "start" : 2474333,
+              "end" : 2990413
+            },
+            {
+              "titel" : "In der Falle",
+              "start" : 2990413,
+              "end" : 3283293
+            },
+            {
+              "titel" : "Die Federn fallen",
+              "start" : 3283293,
+              "end" : 3955933
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/178/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/178/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/178/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/178/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/178/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music19/v4/6b/f2/73/6bf27389-03bd-4df6-30d8-a3bc066ece4b/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115152700if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/7b/28/f7/0888430093720.jpg"
@@ -23025,10 +32929,56 @@
           "sprecher" : "Stefan Weißenburger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Wege des Schicksals",
+              "start" : 0,
+              "end" : 584507
+            },
+            {
+              "titel" : "Reise ins Ungewisse",
+              "start" : 584507,
+              "end" : 963227
+            },
+            {
+              "titel" : "Das Tal der Klapperschlangen",
+              "start" : 963227,
+              "end" : 1622947
+            },
+            {
+              "titel" : "Nacht des Grauens",
+              "start" : 1622947,
+              "end" : 1993547
+            },
+            {
+              "titel" : "In der Gewalt des Geistes",
+              "start" : 1993547,
+              "end" : 2606293
+            },
+            {
+              "titel" : "Ein grauenhafter Fund",
+              "start" : 2606293,
+              "end" : 2815507
+            },
+            {
+              "titel" : "Straßensperre",
+              "start" : 2815507,
+              "end" : 3608627
+            },
+            {
+              "titel" : "Shakehands",
+              "start" : 3608627,
+              "end" : 4297960
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/179/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/179/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/179/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/179/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/179/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music69/v4/98/fc/fd/98fcfd62-42ca-9167-6c85-fdc51d4c05a7/source",
         "cover_kosmos" : "http://web.archive.org/web/20211227022641if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/2b/b4/d4/0888430093829.jpg"
@@ -23137,10 +33087,56 @@
           "sprecher" : "Renate Pichler"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine Leiche im Sessel",
+              "start" : 0,
+              "end" : 397987
+            },
+            {
+              "titel" : "Bianca",
+              "start" : 397987,
+              "end" : 892067
+            },
+            {
+              "titel" : "In einer anderen Welt",
+              "start" : 892067,
+              "end" : 1160013
+            },
+            {
+              "titel" : "Im dunklen Nirgendwo",
+              "start" : 1160013,
+              "end" : 2146773
+            },
+            {
+              "titel" : "Tote Augen",
+              "start" : 2146773,
+              "end" : 2489973
+            },
+            {
+              "titel" : "Aus drei mach eins",
+              "start" : 2489973,
+              "end" : 2952200
+            },
+            {
+              "titel" : "Sicheres Todesurteil",
+              "start" : 2952200,
+              "end" : 3273373
+            },
+            {
+              "titel" : "Die 7. Zeugin",
+              "start" : 3273373,
+              "end" : 4667840
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/180/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/180/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/180/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/180/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/180/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music49/v4/58/d1/08/58d10887-deb4-9900-0d2e-afa745b2fb57/source",
         "cover_kosmos" : "http://web.archive.org/web/20211231145703if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/54/6b/c5/0888430093928.jpg"
@@ -23265,10 +33261,56 @@
           "sprecher" : "Lilian Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der verschwundene Zauberer",
+              "start" : 0,
+              "end" : 252747
+            },
+            {
+              "titel" : "Im Zauberschrank",
+              "start" : 252747,
+              "end" : 1122507
+            },
+            {
+              "titel" : "Der Fremde im Spiegel",
+              "start" : 1122507,
+              "end" : 1494933
+            },
+            {
+              "titel" : "Hasentod",
+              "start" : 1494933,
+              "end" : 1919853
+            },
+            {
+              "titel" : "Auf der Spur des Hasenmörders",
+              "start" : 1919853,
+              "end" : 2356680
+            },
+            {
+              "titel" : "Nightingale, der Magier",
+              "start" : 2356680,
+              "end" : 2593667
+            },
+            {
+              "titel" : "Unsichtbar und trotzdem da",
+              "start" : 2593667,
+              "end" : 3211600
+            },
+            {
+              "titel" : "Nachts in den Bergen",
+              "start" : 3211600,
+              "end" : 4413560
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/181/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/181/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/181/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/181/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/181/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music49/v4/5d/5c/3c/5d5c3c06-d62b-cd67-077a-af7479f96522/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230851if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/72/dc/ab/0888751319622.jpg"
@@ -23412,10 +33454,51 @@
           "sprecher" : "Hugo Richert"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Notruf",
+              "start" : 0,
+              "end" : 426840
+            },
+            {
+              "titel" : "Eine erste Spur",
+              "start" : 426840,
+              "end" : 913093
+            },
+            {
+              "titel" : "Fahrt in die Hölle",
+              "start" : 913093,
+              "end" : 1609107
+            },
+            {
+              "titel" : "Schreckensbilder",
+              "start" : 1609107,
+              "end" : 2690160
+            },
+            {
+              "titel" : "Schuldig",
+              "start" : 2690160,
+              "end" : 3062493
+            },
+            {
+              "titel" : "Jagd auf Geister",
+              "start" : 3062493,
+              "end" : 4192173
+            },
+            {
+              "titel" : "Aber logo!",
+              "start" : 4192173,
+              "end" : 4546493
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/182/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/182/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/182/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/182/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/182/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music49/v4/66/11/5f/66115f6e-4d08-c01e-50e8-4bfbe714afbe/source",
         "cover_kosmos" : "http://web.archive.org/web/20220115135340if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/91/f6/c2/0888751319721.jpg"
@@ -23548,10 +33631,56 @@
           "sprecher" : "Die Gäste der Record-Release-Party am 08.05.2016 in Hasselburg. (Wir danken euch für's Mitmachen!)"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Einladung zur großen Party",
+              "start" : 0,
+              "end" : 530973
+            },
+            {
+              "titel" : "Ein schwieriger Gast",
+              "start" : 530973,
+              "end" : 1037227
+            },
+            {
+              "titel" : "The Disappearing of a Hobbit",
+              "start" : 1037227,
+              "end" : 1637920
+            },
+            {
+              "titel" : "Aus fünf mach sechs",
+              "start" : 1637920,
+              "end" : 2080733
+            },
+            {
+              "titel" : "Videostar",
+              "start" : 2080733,
+              "end" : 2342467
+            },
+            {
+              "titel" : "Schalldicht verpackt",
+              "start" : 2342467,
+              "end" : 2819707
+            },
+            {
+              "titel" : "The La-La-Song",
+              "start" : 2819707,
+              "end" : 3773813
+            },
+            {
+              "titel" : "Achtung, Steinschlag!",
+              "start" : 3773813,
+              "end" : 4566333
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/183/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/183/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/183/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/183/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/183/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music30/v4/d5/04/10/d5041038-b061-8c46-2c8b-e17821048e60/source",
         "cover_kosmos" : "http://web.archive.org/web/20220124230838if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/9f/1c/4e/0888751319820.jpg"
@@ -23670,10 +33799,46 @@
           "sprecher" : "Christian Concilio"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Böse Blumen",
+              "start" : 0,
+              "end" : 675133
+            },
+            {
+              "titel" : "Gewächse der Nacht",
+              "start" : 675133,
+              "end" : 1273240
+            },
+            {
+              "titel" : "Den Morlands auf der Spur",
+              "start" : 1273240,
+              "end" : 1827893
+            },
+            {
+              "titel" : "Nachteinsatz",
+              "start" : 1827893,
+              "end" : 2458413
+            },
+            {
+              "titel" : "Im Haus der Mitternacht",
+              "start" : 2458413,
+              "end" : 3555213
+            },
+            {
+              "titel" : "Letzte Fragen und ein neuer Fall",
+              "start" : 3555213,
+              "end" : 4139387
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/184/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/184/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/184/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/184/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/184/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music62/v4/af/66/01/af66014f-2a7e-36c0-3ca9-3fbea1a7e3a6/source",
         "cover_kosmos" : "http://web.archive.org/web/20220104131531if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/13/e9/32/0888751319929.jpg"
@@ -23799,10 +33964,61 @@
           "sprecher" : "Daniel Welbat"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Feuer!",
+              "start" : 0,
+              "end" : 326053
+            },
+            {
+              "titel" : "Auftrag",
+              "start" : 326053,
+              "end" : 523827
+            },
+            {
+              "titel" : "Unfall",
+              "start" : 523827,
+              "end" : 852653
+            },
+            {
+              "titel" : "Geständnis",
+              "start" : 852653,
+              "end" : 1638680
+            },
+            {
+              "titel" : "Entführungsopfer",
+              "start" : 1638680,
+              "end" : 2070400
+            },
+            {
+              "titel" : "Glasaugen",
+              "start" : 2070400,
+              "end" : 2374053
+            },
+            {
+              "titel" : "Kieselsteinchen 06",
+              "start" : 2374053,
+              "end" : 2700093
+            },
+            {
+              "titel" : "Puzzleteile",
+              "start" : 2700093,
+              "end" : 3168373
+            },
+            {
+              "titel" : "Im Lichte der Wahrheit",
+              "start" : 3168373,
+              "end" : 3685613
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/185/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/185/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/185/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/185/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/185/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music71/v4/43/aa/92/43aa9292-a0c7-97ea-f752-78af9e089509/source",
         "cover_kosmos" : "http://web.archive.org/web/20220123153348if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/57/f6/6c/0888751320024.jpg"
@@ -23923,10 +34139,56 @@
           "sprecher" : "André Minninger"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Notfallsitzung",
+              "start" : 0,
+              "end" : 291027
+            },
+            {
+              "titel" : "Spurensuche",
+              "start" : 291027,
+              "end" : 871520
+            },
+            {
+              "titel" : "Sunny Island",
+              "start" : 871520,
+              "end" : 1430973
+            },
+            {
+              "titel" : "Vertraue niemandem!",
+              "start" : 1430973,
+              "end" : 2164160
+            },
+            {
+              "titel" : "Verbündete",
+              "start" : 2164160,
+              "end" : 2670587
+            },
+            {
+              "titel" : "Der doppelte Tod",
+              "start" : 2670587,
+              "end" : 3273333
+            },
+            {
+              "titel" : "Rückkehr",
+              "start" : 3273333,
+              "end" : 3881533
+            },
+            {
+              "titel" : "Wie in Woodstock",
+              "start" : 3881533,
+              "end" : 4356747
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/186/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/186/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/186/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/186/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/186/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music82/v4/c0/5d/a1/c05da1e7-cac3-727b-b817-c6d222be40be/source",
         "cover_kosmos" : "http://web.archive.org/web/20220708021919if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/f4/06/7d/0888751320123593a75c5abfa5.jpg"
@@ -24056,10 +34318,61 @@
           "sprecher" : "Michael Bideller"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Alles außer Bonbons",
+              "start" : 0,
+              "end" : 335693
+            },
+            {
+              "titel" : "Tante Mathilda tobt",
+              "start" : 335693,
+              "end" : 581040
+            },
+            {
+              "titel" : "Verschossen",
+              "start" : 581040,
+              "end" : 842693
+            },
+            {
+              "titel" : "Kein Passwort",
+              "start" : 842693,
+              "end" : 1456560
+            },
+            {
+              "titel" : "Indianerschmuck",
+              "start" : 1456560,
+              "end" : 2048080
+            },
+            {
+              "titel" : "Das Geheimnis der Santa Catalina",
+              "start" : 2048080,
+              "end" : 2711080
+            },
+            {
+              "titel" : "Yoga",
+              "start" : 2711080,
+              "end" : 2972293
+            },
+            {
+              "titel" : "Dämonen in der Nacht",
+              "start" : 2972293,
+              "end" : 3581267
+            },
+            {
+              "titel" : "Pures Gold",
+              "start" : 3581267,
+              "end" : 4036133
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/187/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/187/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/187/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/187/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/187/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music111/v4/94/13/22/941322bf-360a-734a-06eb-ac5d84cf0928/source"
       }
@@ -24189,10 +34502,66 @@
           "sprecher" : "Christian Concilio"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Angstschweiß",
+              "start" : 0,
+              "end" : 335080
+            },
+            {
+              "titel" : "Auf Sendung",
+              "start" : 335080,
+              "end" : 905480
+            },
+            {
+              "titel" : "Irritationen",
+              "start" : 905480,
+              "end" : 1284333
+            },
+            {
+              "titel" : "Spurlos verschwunden",
+              "start" : 1284333,
+              "end" : 1731200
+            },
+            {
+              "titel" : "Erpressung",
+              "start" : 1731200,
+              "end" : 2451707
+            },
+            {
+              "titel" : "Zur besten Sendezeit",
+              "start" : 2451707,
+              "end" : 2691013
+            },
+            {
+              "titel" : "Weißes Pulver",
+              "start" : 2691013,
+              "end" : 2975760
+            },
+            {
+              "titel" : "Tiefe Gefühle",
+              "start" : 2975760,
+              "end" : 3296133
+            },
+            {
+              "titel" : "Eigenes Interesse",
+              "start" : 3296133,
+              "end" : 3432373
+            },
+            {
+              "titel" : "Das Blatt wendet sich",
+              "start" : 3432373,
+              "end" : 4807547
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/188/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/188/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/188/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/188/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/188/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music127/v4/d8/46/82/d8468287-11fd-c8fc-258b-d60ef79cdeec/source"
       }
@@ -24308,10 +34677,56 @@
           "sprecher" : "Joachim Kretzer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Verschwunden!",
+              "start" : 0,
+              "end" : 627440
+            },
+            {
+              "titel" : "Unmöglich, aber wahr",
+              "start" : 627440,
+              "end" : 1220813
+            },
+            {
+              "titel" : "Original oder Fälschung?",
+              "start" : 1220813,
+              "end" : 1822547
+            },
+            {
+              "titel" : "Kontroll-Aktion",
+              "start" : 1822547,
+              "end" : 2348027
+            },
+            {
+              "titel" : "Gigant auf vielen Beinen",
+              "start" : 2348027,
+              "end" : 2844253
+            },
+            {
+              "titel" : "Die Masken fallen",
+              "start" : 2844253,
+              "end" : 3317000
+            },
+            {
+              "titel" : "Stunde der Wahrheit",
+              "start" : 3317000,
+              "end" : 3622427
+            },
+            {
+              "titel" : "Ein fast perfektes Verbrechen",
+              "start" : 3622427,
+              "end" : 3917560
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/189/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/189/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/189/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/189/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/189/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music118/v4/af/7a/61/af7a610b-0f7b-d05c-af75-0919b14845ba/source"
       }
@@ -24405,10 +34820,46 @@
           "sprecher" : "Michael Lott"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine Bitte an Experten",
+              "start" : 0,
+              "end" : 483760
+            },
+            {
+              "titel" : "Merkwürdiger Empfang",
+              "start" : 483760,
+              "end" : 1106213
+            },
+            {
+              "titel" : "Gefangen in Kammer eins",
+              "start" : 1106213,
+              "end" : 1746320
+            },
+            {
+              "titel" : "Auf Kollisionskurs",
+              "start" : 1746320,
+              "end" : 2077440
+            },
+            {
+              "titel" : "Ohne Wasser",
+              "start" : 2077440,
+              "end" : 2823400
+            },
+            {
+              "titel" : "Zwei Glücksjäger",
+              "start" : 2823400,
+              "end" : 3834400
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/190/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/190/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/190/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/190/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/190/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music118/v4/55/98/d5/5598d5f8-6e87-8f4b-af1f-65aea74b5143/source"
       }
@@ -24508,10 +34959,56 @@
           "sprecher" : "Christian Rudolf"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Nichts im Nichts",
+              "start" : 0,
+              "end" : 410507
+            },
+            {
+              "titel" : "Seltsamer Ort",
+              "start" : 410507,
+              "end" : 1182187
+            },
+            {
+              "titel" : "Botschaft aus der Vergangenheit",
+              "start" : 1182187,
+              "end" : 1834987
+            },
+            {
+              "titel" : "Das Ende der Spur?",
+              "start" : 1834987,
+              "end" : 2295147
+            },
+            {
+              "titel" : "Schatten in der Nacht",
+              "start" : 2295147,
+              "end" : 2754867
+            },
+            {
+              "titel" : "Das Geheimnis hinter dem Geheimnis",
+              "start" : 2754867,
+              "end" : 3142227
+            },
+            {
+              "titel" : "Am Abgrund",
+              "start" : 3142227,
+              "end" : 3752707
+            },
+            {
+              "titel" : "Das Schicksal ruft",
+              "start" : 3752707,
+              "end" : 4266120
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/191/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/191/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/191/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/191/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/191/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music118/v4/23/5c/1b/235c1b67-dd15-9cdf-213c-41ff18a19ea5/source"
       }
@@ -24623,10 +35120,56 @@
           "sprecher" : "Matti Schmidt-Schaller"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Erwachen in einer anderen Welt",
+              "start" : 0,
+              "end" : 441587
+            },
+            {
+              "titel" : "Erkenntnisse auf zwei Kontinenten",
+              "start" : 441587,
+              "end" : 1040933
+            },
+            {
+              "titel" : "Im Jing'an-Tempel und in der Luft",
+              "start" : 1040933,
+              "end" : 1620360
+            },
+            {
+              "titel" : "Böse Geister im Zickzack",
+              "start" : 1620360,
+              "end" : 2073347
+            },
+            {
+              "titel" : "Drogen im Flaschenöffner",
+              "start" : 2073347,
+              "end" : 2441947
+            },
+            {
+              "titel" : "Familienangelegenheiten",
+              "start" : 2441947,
+              "end" : 3210333
+            },
+            {
+              "titel" : "Achterbahnfahrt",
+              "start" : 3210333,
+              "end" : 3842347
+            },
+            {
+              "titel" : "Telefonlawine",
+              "start" : 3842347,
+              "end" : 4081427
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/192/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/192/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/192/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/192/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/192/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music128/v4/1b/0d/89/1b0d8971-f4e4-262a-3155-0a140887ca85/source"
       }
@@ -24758,10 +35301,56 @@
           "sprecher" : "Jannik Schümann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ausnahmezustand",
+              "start" : 0,
+              "end" : 475760
+            },
+            {
+              "titel" : "Die Ermittlungen beginnen",
+              "start" : 475760,
+              "end" : 841120
+            },
+            {
+              "titel" : "Gespräch der Lichter",
+              "start" : 841120,
+              "end" : 1464960
+            },
+            {
+              "titel" : "Große Fische im Netz",
+              "start" : 1464960,
+              "end" : 1877600
+            },
+            {
+              "titel" : "Beutemeute",
+              "start" : 1877600,
+              "end" : 2354467
+            },
+            {
+              "titel" : "Peanuts in Gouda",
+              "start" : 2354467,
+              "end" : 2809173
+            },
+            {
+              "titel" : "Tauchgang mit Folgen",
+              "start" : 2809173,
+              "end" : 3207547
+            },
+            {
+              "titel" : "Verräterische Angst",
+              "start" : 3207547,
+              "end" : 4183227
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/193/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/193/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/193/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/193/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/193/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music118/v4/ed/a3/a1/eda3a179-4e94-e74a-bca0-fa72a742cad9/source"
       }
@@ -24889,10 +35478,56 @@
           "sprecher" : "Christopher Hoseit"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Premierenfieber",
+              "start" : 0,
+              "end" : 437667
+            },
+            {
+              "titel" : "Verschwunden",
+              "start" : 437667,
+              "end" : 914440
+            },
+            {
+              "titel" : "In Luft aufgelöst",
+              "start" : 914440,
+              "end" : 1807547
+            },
+            {
+              "titel" : "Unsichtbare Materie",
+              "start" : 1807547,
+              "end" : 2367693
+            },
+            {
+              "titel" : "Notruf",
+              "start" : 2367693,
+              "end" : 3100480
+            },
+            {
+              "titel" : "Erpressung",
+              "start" : 3100480,
+              "end" : 3442853
+            },
+            {
+              "titel" : "Verstorben",
+              "start" : 3442853,
+              "end" : 3867333
+            },
+            {
+              "titel" : "Die Masken fallen",
+              "start" : 3867333,
+              "end" : 4616840
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/194/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/194/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/194/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/194/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/194/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music128/v4/84/52/57/845257b7-0d44-2247-b82d-47192b50133f/source"
       }
@@ -24991,10 +35626,51 @@
           "sprecher" : "Riko Tauber"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Aus eins wird zwei",
+              "start" : 0,
+              "end" : 354520
+            },
+            {
+              "titel" : "Die Uhr tickt",
+              "start" : 354520,
+              "end" : 977280
+            },
+            {
+              "titel" : "Im Reich der Ungeheuer",
+              "start" : 977280,
+              "end" : 1730587
+            },
+            {
+              "titel" : "Die Suche beginnt",
+              "start" : 1730587,
+              "end" : 2295080
+            },
+            {
+              "titel" : "Wieder vereint",
+              "start" : 2295080,
+              "end" : 3097333
+            },
+            {
+              "titel" : "Die Fassade fällt",
+              "start" : 3097333,
+              "end" : 3913080
+            },
+            {
+              "titel" : "Ende mit Schrecken",
+              "start" : 3913080,
+              "end" : 4503053
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/195/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/195/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/195/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/195/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/195/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music115/v4/b7/6a/c8/b76ac83c-cf66-16dd-0380-3fe53d652255/source"
       }
@@ -25102,10 +35778,56 @@
           "sprecher" : "Constantin Stahlberg"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Magisches Ritual",
+              "start" : 0,
+              "end" : 626973
+            },
+            {
+              "titel" : "Die verfluchte Puppe",
+              "start" : 626973,
+              "end" : 1237760
+            },
+            {
+              "titel" : "Grüße von Giggles",
+              "start" : 1237760,
+              "end" : 1954253
+            },
+            {
+              "titel" : "Mission Fingerabdruck",
+              "start" : 1954253,
+              "end" : 2358880
+            },
+            {
+              "titel" : "Stars und Stiles",
+              "start" : 2358880,
+              "end" : 2998360
+            },
+            {
+              "titel" : "Das Haus am Ende der Straße",
+              "start" : 2998360,
+              "end" : 3667813
+            },
+            {
+              "titel" : "Miss Osborne unter Druck",
+              "start" : 3667813,
+              "end" : 4408320
+            },
+            {
+              "titel" : "Mit eigenen Augen",
+              "start" : 4408320,
+              "end" : 4728400
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/196/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/196/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/196/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/196/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/196/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music128/v4/2a/2a/52/2a2a5295-56ca-a27a-df67-494d1c340cdb/source"
       }
@@ -25243,10 +35965,61 @@
           "pseudonym" : "Gunnar Bergmann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Wind und Blut",
+              "start" : 0,
+              "end" : 526680
+            },
+            {
+              "titel" : "Wipe Out",
+              "start" : 526680,
+              "end" : 938120
+            },
+            {
+              "titel" : "Das Geheimnis der Gezeiten",
+              "start" : 938120,
+              "end" : 1223827
+            },
+            {
+              "titel" : "Tag, Uhrzeit, Ort",
+              "start" : 1223827,
+              "end" : 1741640
+            },
+            {
+              "titel" : "Endstation Las Tunas",
+              "start" : 1741640,
+              "end" : 2528240
+            },
+            {
+              "titel" : "Pikante Details",
+              "start" : 2528240,
+              "end" : 3190467
+            },
+            {
+              "titel" : "Kredithai",
+              "start" : 3190467,
+              "end" : 3543040
+            },
+            {
+              "titel" : "Im Auge des Sturms",
+              "start" : 3543040,
+              "end" : 4013173
+            },
+            {
+              "titel" : "Der Held von Rocky Beach",
+              "start" : 4013173,
+              "end" : 4190827
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/197/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/197/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/197/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/197/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/197/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music128/v4/8c/9a/4d/8c9a4d8e-6a2c-8686-1806-ab9ad03dc8a9/source"
       }
@@ -25378,10 +36151,56 @@
           "sprecher" : "Birte Kretschmer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "\"Helft mir zu gewinnen!\"",
+              "start" : 0,
+              "end" : 564493
+            },
+            {
+              "titel" : "Von Zwergen und Dieben",
+              "start" : 564493,
+              "end" : 998360
+            },
+            {
+              "titel" : "Drei Tote",
+              "start" : 998360,
+              "end" : 1735493
+            },
+            {
+              "titel" : "Zwei Lebende",
+              "start" : 1735493,
+              "end" : 1973867
+            },
+            {
+              "titel" : "Unheil",
+              "start" : 1973867,
+              "end" : 2400587
+            },
+            {
+              "titel" : "Unrat",
+              "start" : 2400587,
+              "end" : 3185547
+            },
+            {
+              "titel" : "Ahnenforschung",
+              "start" : 3185547,
+              "end" : 3560507
+            },
+            {
+              "titel" : "Fallensteller",
+              "start" : 3560507,
+              "end" : 4166400
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/198/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/198/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/198/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/198/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/198/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music124/v4/74/0a/2c/740a2ce8-3761-7bd4-a2c2-93e39a1873ff/source"
       }
@@ -25489,182 +36308,62 @@
           "sprecher" : "Holger Umbreit"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Schock in der Nacht",
+              "start" : 0,
+              "end" : 415733
+            },
+            {
+              "titel" : "Spuk im Hotel Lakshmi",
+              "start" : 415733,
+              "end" : 848040
+            },
+            {
+              "titel" : "Vegane Kost",
+              "start" : 848040,
+              "end" : 1314787
+            },
+            {
+              "titel" : "El Dorado",
+              "start" : 1314787,
+              "end" : 1838573
+            },
+            {
+              "titel" : "Die Geschichte eines Hauses",
+              "start" : 1838573,
+              "end" : 2245667
+            },
+            {
+              "titel" : "Koboldalarm",
+              "start" : 2245667,
+              "end" : 3022827
+            },
+            {
+              "titel" : "Steinchen für Steinchen",
+              "start" : 3022827,
+              "end" : 3475000
+            },
+            {
+              "titel" : "Sucht und Leidenschaft",
+              "start" : 3475000,
+              "end" : 4506587
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/199/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/199/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/199/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/199/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/199/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music114/v4/8b/8b/fe/8b8bfe3b-2c36-1455-5c9e-f0ff487450e7/source"
       }
     },
     {
       "nummer" : 200,
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "buchstabe" : "A",
-          "beschreibung" : "Justus Jonas ist über Nacht spurlos verschwunden!\nHat man den Ersten Detektiv entführt? Bob und Peter sind bei der Suche nach ihrem besten Freund auf sich allein gestellt …",
-          "kapitel" : [
-            {
-              "titel" : "Ohne Ausweg",
-              "start" : 0,
-              "end" : 641493
-            },
-            {
-              "titel" : "\"Hilfe!\"",
-              "start" : 641493,
-              "end" : 1326867
-            },
-            {
-              "titel" : "Leute verschwinden",
-              "start" : 1326867,
-              "end" : 2030093
-            },
-            {
-              "titel" : "Aus Bobs Archiv",
-              "start" : 2030093,
-              "end" : 2717587
-            },
-            {
-              "titel" : "Überfall",
-              "start" : 2717587,
-              "end" : 3376480
-            },
-            {
-              "titel" : "Der Blick der blauen Gottheit",
-              "start" : 3376480,
-              "end" : 4340627
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Serie/200/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/200/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "buchstabe" : "B",
-          "beschreibung" : "Eine rätselhafte Spur aus der Vergangenheit taucht auf. Sie führt zu einem alten Bekannten, zum Feurigen Auge und zu einer entlegenen Insel.",
-          "kapitel" : [
-            {
-              "titel" : "Geheimagent Blake Turner",
-              "start" : 0,
-              "end" : 831080
-            },
-            {
-              "titel" : "Whites Geheimnisse",
-              "start" : 831080,
-              "end" : 1580280
-            },
-            {
-              "titel" : "Es piept",
-              "start" : 1580280,
-              "end" : 1975800
-            },
-            {
-              "titel" : "Besuch aus der Vergangenheit",
-              "start" : 1975800,
-              "end" : 2710786
-            },
-            {
-              "titel" : "Nächtliche Verfolgung",
-              "start" : 2710786,
-              "end" : 3395373
-            },
-            {
-              "titel" : "Befreiung",
-              "start" : 3395373,
-              "end" : 4273520
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Serie/200/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/200/2/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 3,
-          "buchstabe" : "C",
-          "beschreibung" : "Wer ist der mysteriöse Unbekannte, der Justus in seiner Gewalt hat?\nUnd worauf hat er es abgesehen?\nDer Erste Detektiv sitzt in der Falle. Wird er seinen Gegner überlisten können und dem Kerker entkommen?",
-          "kapitel" : [
-            {
-              "titel" : "Im Kerker",
-              "start" : 0,
-              "end" : 1216920
-            },
-            {
-              "titel" : "Das rote Leuchten",
-              "start" : 1216920,
-              "end" : 1742906
-            },
-            {
-              "titel" : "Nach Dalton",
-              "start" : 1742906,
-              "end" : 2383493
-            },
-            {
-              "titel" : "Licht und Dunkelheit",
-              "start" : 2383493,
-              "end" : 3170906
-            },
-            {
-              "titel" : "Entkommen!",
-              "start" : 3170906,
-              "end" : 3711186
-            },
-            {
-              "titel" : "Das 13. Buch",
-              "start" : 3711186,
-              "end" : 4442693
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Serie/200/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/200/3/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 4,
-          "buchstabe" : "D",
-          "beschreibung" : "Justus, Peter und Bob sind nicht die Einzigen, die auf der Jagd nach dem Unglück bringenden Edelstein sind. Auch immer mehr Fragen tauchen auf. Doch die Antworten sind an einem geheimen Ort verborgen: dem sagenumwobenen Tempel der Gerechtigkeit.",
-          "kapitel" : [
-            {
-              "titel" : "Horatios Geheimnis",
-              "start" : 0,
-              "end" : 725493
-            },
-            {
-              "titel" : "Gold und Edelsteine",
-              "start" : 725493,
-              "end" : 1434600
-            },
-            {
-              "titel" : "Pleshiwar",
-              "start" : 1434600,
-              "end" : 2362307
-            },
-            {
-              "titel" : "Der Elefantenkopf",
-              "start" : 2362307,
-              "end" : 2869627
-            },
-            {
-              "titel" : "Das Feurige Auge",
-              "start" : 2869627,
-              "end" : 3912320
-            },
-            {
-              "titel" : "Berg ohne Wiederkehr",
-              "start" : 3912320,
-              "end" : 4655267
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Serie/200/4/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/200/4/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "Feuriges Auge",
       "autor" : "André Marx",
       "hörspielskriptautor" : "André Minninger",
@@ -25914,6 +36613,148 @@
           "sprecher" : "Helge Halvé"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ohne Ausweg",
+              "start" : 0,
+              "end" : 641493
+            },
+            {
+              "titel" : "\"Hilfe!\"",
+              "start" : 641493,
+              "end" : 1326867
+            },
+            {
+              "titel" : "Leute verschwinden",
+              "start" : 1326867,
+              "end" : 2030093
+            },
+            {
+              "titel" : "Aus Bobs Archiv",
+              "start" : 2030093,
+              "end" : 2717587
+            },
+            {
+              "titel" : "Überfall",
+              "start" : 2717587,
+              "end" : 3376480
+            },
+            {
+              "titel" : "Der Blick der blauen Gottheit",
+              "start" : 3376480,
+              "end" : 4340627
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Geheimagent Blake Turner",
+              "start" : 0,
+              "end" : 831080
+            },
+            {
+              "titel" : "Whites Geheimnisse",
+              "start" : 831080,
+              "end" : 1580280
+            },
+            {
+              "titel" : "Es piept",
+              "start" : 1580280,
+              "end" : 1975800
+            },
+            {
+              "titel" : "Besuch aus der Vergangenheit",
+              "start" : 1975800,
+              "end" : 2710786
+            },
+            {
+              "titel" : "Nächtliche Verfolgung",
+              "start" : 2710786,
+              "end" : 3395373
+            },
+            {
+              "titel" : "Befreiung",
+              "start" : 3395373,
+              "end" : 4273520
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Im Kerker",
+              "start" : 0,
+              "end" : 1216920
+            },
+            {
+              "titel" : "Das rote Leuchten",
+              "start" : 1216920,
+              "end" : 1742906
+            },
+            {
+              "titel" : "Nach Dalton",
+              "start" : 1742906,
+              "end" : 2383493
+            },
+            {
+              "titel" : "Licht und Dunkelheit",
+              "start" : 2383493,
+              "end" : 3170906
+            },
+            {
+              "titel" : "Entkommen!",
+              "start" : 3170906,
+              "end" : 3711186
+            },
+            {
+              "titel" : "Das 13. Buch",
+              "start" : 3711186,
+              "end" : 4442693
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log3.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Horatios Geheimnis",
+              "start" : 0,
+              "end" : 725493
+            },
+            {
+              "titel" : "Gold und Edelsteine",
+              "start" : 725493,
+              "end" : 1434600
+            },
+            {
+              "titel" : "Pleshiwar",
+              "start" : 1434600,
+              "end" : 2362307
+            },
+            {
+              "titel" : "Der Elefantenkopf",
+              "start" : 2362307,
+              "end" : 2869627
+            },
+            {
+              "titel" : "Das Feurige Auge",
+              "start" : 2869627,
+              "end" : 3912320
+            },
+            {
+              "titel" : "Berg ohne Wiederkehr",
+              "start" : 3912320,
+              "end" : 4655267
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log4.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/200/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/200/ffmetadata.txt",
@@ -26029,10 +36870,61 @@
           "sprecher" : "Woody Mues"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Loomy",
+              "start" : 0,
+              "end" : 327440
+            },
+            {
+              "titel" : "Harte Kost",
+              "start" : 327440,
+              "end" : 1000880
+            },
+            {
+              "titel" : "Lesley",
+              "start" : 1000880,
+              "end" : 1261093
+            },
+            {
+              "titel" : "Vollgas",
+              "start" : 1261093,
+              "end" : 1581600
+            },
+            {
+              "titel" : "Eisige Kälte",
+              "start" : 1581600,
+              "end" : 1995933
+            },
+            {
+              "titel" : "In Luft aufgelöst",
+              "start" : 1995933,
+              "end" : 2297253
+            },
+            {
+              "titel" : "Schweigepflicht",
+              "start" : 2297253,
+              "end" : 3317827
+            },
+            {
+              "titel" : "Höhenangst",
+              "start" : 3317827,
+              "end" : 4159653
+            },
+            {
+              "titel" : "Ausgetrickst",
+              "start" : 4159653,
+              "end" : 4703027
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/201/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/201/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/201/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/201/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/201/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music124/v4/ae/dd/c0/aeddc0e7-e6b8-6753-2330-4174ab626e2b/source"
       }
@@ -26123,10 +37015,51 @@
           "sprecher" : "Stephan Benson"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ausgerutscht!",
+              "start" : 0,
+              "end" : 533907
+            },
+            {
+              "titel" : "Geisterlift",
+              "start" : 533907,
+              "end" : 1077133
+            },
+            {
+              "titel" : "Die verbotene Zone",
+              "start" : 1077133,
+              "end" : 1831493
+            },
+            {
+              "titel" : "Das weiße Grab",
+              "start" : 1831493,
+              "end" : 2691493
+            },
+            {
+              "titel" : "Alte Geschichten",
+              "start" : 2691493,
+              "end" : 3143307
+            },
+            {
+              "titel" : "Das Astloch",
+              "start" : 3143307,
+              "end" : 3671613
+            },
+            {
+              "titel" : "Demaskiert",
+              "start" : 3671613,
+              "end" : 4568253
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/202/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/202/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/202/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/202/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/202/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music124/v4/50/9a/48/509a481a-df7e-5b54-b5b0-a7115e36ace7/source"
       }
@@ -26222,10 +37155,56 @@
           "sprecher" : "Peter Franke"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Jorunn",
+              "start" : 0,
+              "end" : 384933
+            },
+            {
+              "titel" : "Gegenverkehr",
+              "start" : 384933,
+              "end" : 813400
+            },
+            {
+              "titel" : "Aus dem Meer",
+              "start" : 813400,
+              "end" : 1259853
+            },
+            {
+              "titel" : "Gefangen",
+              "start" : 1259853,
+              "end" : 1651000
+            },
+            {
+              "titel" : "Unter Wasser",
+              "start" : 1651000,
+              "end" : 2425533
+            },
+            {
+              "titel" : "Sandy Miller",
+              "start" : 2425533,
+              "end" : 2970080
+            },
+            {
+              "titel" : "Tiefschlaf",
+              "start" : 2970080,
+              "end" : 3942533
+            },
+            {
+              "titel" : "Die Wahrheit",
+              "start" : 3942533,
+              "end" : 4610333
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/203/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/203/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/203/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/203/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/203/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music123/v4/3d/d6/a7/3dd6a76e-c5f4-4587-1251-a0c38790399d/source"
       }
@@ -26315,10 +37294,46 @@
           "sprecher" : "Holger Mahlich"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Auftrag",
+              "start" : 0,
+              "end" : 645507
+            },
+            {
+              "titel" : "Überraschungsgast",
+              "start" : 645507,
+              "end" : 1409787
+            },
+            {
+              "titel" : "Lebenszeichen",
+              "start" : 1409787,
+              "end" : 2141507
+            },
+            {
+              "titel" : "Überraschende Nachricht",
+              "start" : 2141507,
+              "end" : 2731773
+            },
+            {
+              "titel" : "Auf leisen Sohlen",
+              "start" : 2731773,
+              "end" : 3328347
+            },
+            {
+              "titel" : "In der Hölle",
+              "start" : 3328347,
+              "end" : 4144067
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/204/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/204/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/204/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/204/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/204/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music123/v4/ea/6c/b8/ea6cb899-c301-3b96-7d45-86011cfa1289/source"
       }
@@ -26432,10 +37447,46 @@
           "sprecher" : "Merete Brettschneider"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Hände hoch, oder es knallt!",
+              "start" : 0,
+              "end" : 198507
+            },
+            {
+              "titel" : "Der letzte Wille",
+              "start" : 198507,
+              "end" : 778467
+            },
+            {
+              "titel" : "Mann ohne Gesicht",
+              "start" : 778467,
+              "end" : 1767080
+            },
+            {
+              "titel" : "Eine stille Bewunderin",
+              "start" : 1767080,
+              "end" : 2446760
+            },
+            {
+              "titel" : "Blutige Zeichen",
+              "start" : 2446760,
+              "end" : 3076320
+            },
+            {
+              "titel" : "Das Geheimnis der Familie di Santo",
+              "start" : 3076320,
+              "end" : 4255120
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/205/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/205/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/205/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/205/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/205/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music114/v4/45/cb/d4/45cbd478-3077-4d72-55e0-91ddf1a83aa1/source"
       }
@@ -26525,10 +37576,46 @@
           "sprecher" : "Sandra Keck"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "\"Hüte dich vor dem Mottenmann!\"",
+              "start" : 0,
+              "end" : 562933
+            },
+            {
+              "titel" : "Kwakwaka'wakw oder Nuu-cha-nulth?",
+              "start" : 562933,
+              "end" : 1172267
+            },
+            {
+              "titel" : "Brennender Puppenwagen",
+              "start" : 1172267,
+              "end" : 1597760
+            },
+            {
+              "titel" : "Laothoe populi und andere Spuren",
+              "start" : 1597760,
+              "end" : 2311107
+            },
+            {
+              "titel" : "Das große Vergessen",
+              "start" : 2311107,
+              "end" : 3220400
+            },
+            {
+              "titel" : "Heilig",
+              "start" : 3220400,
+              "end" : 3762867
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/206/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/206/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/206/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/206/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/206/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music123/v4/b2/d4/57/b2d457c8-a56d-debd-e5cf-75d998ef9d85/source"
       }
@@ -26630,10 +37717,46 @@
           "sprecher" : "Caroline Kiesewetter"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Geistergeschichten",
+              "start" : 0,
+              "end" : 658667
+            },
+            {
+              "titel" : "Ein Papier voller Rätsel",
+              "start" : 658667,
+              "end" : 1397013
+            },
+            {
+              "titel" : "Der Totentisch",
+              "start" : 1397013,
+              "end" : 1679360
+            },
+            {
+              "titel" : "Beschattung",
+              "start" : 1679360,
+              "end" : 2204293
+            },
+            {
+              "titel" : "Der Geist erscheint",
+              "start" : 2204293,
+              "end" : 2959080
+            },
+            {
+              "titel" : "Die Masken fallen",
+              "start" : 2959080,
+              "end" : 3725680
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/207/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/207/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/207/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/207/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/207/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music123/v4/7e/90/93/7e9093a9-d9c9-0fd7-aca4-06c49b65d10e/source"
       }
@@ -26751,10 +37874,46 @@
           "sprecher" : "Andreas Zaron"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Ding in der Dunkelheit",
+              "start" : 0,
+              "end" : 701600
+            },
+            {
+              "titel" : "Verräterische Spuren",
+              "start" : 701600,
+              "end" : 1405773
+            },
+            {
+              "titel" : "Gefährliche Ermittlungen",
+              "start" : 1405773,
+              "end" : 2020867
+            },
+            {
+              "titel" : "Recherchen und Archiv",
+              "start" : 2020867,
+              "end" : 2483227
+            },
+            {
+              "titel" : "Coldfield",
+              "start" : 2483227,
+              "end" : 3174680
+            },
+            {
+              "titel" : "Zurück zum Schrottplatz",
+              "start" : 3174680,
+              "end" : 4250387
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/208/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/208/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/208/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/208/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/208/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music124/v4/51/d8/57/51d857b6-6613-f50e-7805-fbc71204533f/source"
       }
@@ -26857,10 +38016,51 @@
           "sprecher" : "Paul Michaeli"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "FMTM",
+              "start" : 0,
+              "end" : 480307
+            },
+            {
+              "titel" : "Dem Tod auf der Spur",
+              "start" : 480307,
+              "end" : 1091640
+            },
+            {
+              "titel" : "Backstage",
+              "start" : 1091640,
+              "end" : 1526053
+            },
+            {
+              "titel" : "TB 34F-42",
+              "start" : 1526053,
+              "end" : 1766573
+            },
+            {
+              "titel" : "Überfall",
+              "start" : 1766573,
+              "end" : 2392480
+            },
+            {
+              "titel" : "Geisterstunde",
+              "start" : 2392480,
+              "end" : 2991520
+            },
+            {
+              "titel" : "Kreaturen der Nacht",
+              "start" : 2991520,
+              "end" : 3596773
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/209/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/209/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/209/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/209/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/209/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music114/v4/c8/c9/90/c8c99025-0e8b-1ffd-12f3-f664fb75e124/source"
       }
@@ -26950,10 +38150,46 @@
           "sprecher" : "Andreas Birnbaum"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Mann verschwindet",
+              "start" : 0,
+              "end" : 442800
+            },
+            {
+              "titel" : "Der Tausend-Dollar-Fisch",
+              "start" : 442800,
+              "end" : 905693
+            },
+            {
+              "titel" : "Delfine und begeisterte Fans",
+              "start" : 905693,
+              "end" : 1621267
+            },
+            {
+              "titel" : "Im Zwielicht",
+              "start" : 1621267,
+              "end" : 2030867
+            },
+            {
+              "titel" : "Visite bei der Privatärztin",
+              "start" : 2030867,
+              "end" : 2802013
+            },
+            {
+              "titel" : "Zugang zur Vergangenheit",
+              "start" : 2802013,
+              "end" : 3627267
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/210/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/210/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/210/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/210/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/210/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music114/v4/aa/4f/af/aa4faf88-6890-65f9-e72e-4d76e753a22e/source"
       }
@@ -27051,10 +38287,46 @@
           "sprecher" : "Rosemarie Wohlbauer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Anfang",
+              "start" : 0,
+              "end" : 452387
+            },
+            {
+              "titel" : "Green British Nanda 2 Pence",
+              "start" : 452387,
+              "end" : 994880
+            },
+            {
+              "titel" : "Rick und Marlow",
+              "start" : 994880,
+              "end" : 1676240
+            },
+            {
+              "titel" : "Nächtlicher Besuch",
+              "start" : 1676240,
+              "end" : 2336853
+            },
+            {
+              "titel" : "Ein Liebespaar",
+              "start" : 2336853,
+              "end" : 3260760
+            },
+            {
+              "titel" : "In Flammen",
+              "start" : 3260760,
+              "end" : 4321973
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/211/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/211/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/211/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/211/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/211/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music115/v4/b9/49/4f/b9494ff8-0fff-45c3-609b-1aef8010d5d1/source"
       }
@@ -27157,10 +38429,51 @@
           "sprecher" : "Achim Schülke"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Alarm in Bel Air",
+              "start" : 0,
+              "end" : 434947
+            },
+            {
+              "titel" : "Ein seltsames Haus",
+              "start" : 434947,
+              "end" : 1244267
+            },
+            {
+              "titel" : "Ein Phantom schlägt zu",
+              "start" : 1244267,
+              "end" : 2065120
+            },
+            {
+              "titel" : "Klient in Not",
+              "start" : 2065120,
+              "end" : 2457933
+            },
+            {
+              "titel" : "In der Höhle des Shoguns",
+              "start" : 2457933,
+              "end" : 3091853
+            },
+            {
+              "titel" : "Wendepunkt",
+              "start" : 3091853,
+              "end" : 3778587
+            },
+            {
+              "titel" : "Die Villa der Lügen",
+              "start" : 3778587,
+              "end" : 4395213
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/212/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/212/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/212/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/212/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/212/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music125/v4/92/05/66/92056605-b0d2-8a87-f9e9-50b15cb8d847/source"
       }
@@ -27279,10 +38592,51 @@
           "sprecher" : "Till Huster"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "An Messers Schneide",
+              "start" : 0,
+              "end" : 586013
+            },
+            {
+              "titel" : "Weiskopfadlr",
+              "start" : 586013,
+              "end" : 1335907
+            },
+            {
+              "titel" : "Das Auge des Außerirdischen",
+              "start" : 1335907,
+              "end" : 2011347
+            },
+            {
+              "titel" : "Naknek",
+              "start" : 2011347,
+              "end" : 2498373
+            },
+            {
+              "titel" : "Zombie-Alarm",
+              "start" : 2498373,
+              "end" : 2919427
+            },
+            {
+              "titel" : "Verstellte Stimme",
+              "start" : 2919427,
+              "end" : 3345640
+            },
+            {
+              "titel" : "Das Geheimnis der Medusa",
+              "start" : 3345640,
+              "end" : 4378267
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/213/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/213/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/213/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/213/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/213/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music125/v4/aa/93/82/aa938236-7558-e880-fe67-d2992bb3ae21/source"
       }
@@ -27388,10 +38742,46 @@
           "sprecher" : "Barbara Schipper"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Neue Fälle stapelweise",
+              "start" : 0,
+              "end" : 656000
+            },
+            {
+              "titel" : "Geisterstimmen",
+              "start" : 656000,
+              "end" : 1042987
+            },
+            {
+              "titel" : "Die Enttarnung",
+              "start" : 1042987,
+              "end" : 1644973
+            },
+            {
+              "titel" : "Justus' Trick",
+              "start" : 1644973,
+              "end" : 2402027
+            },
+            {
+              "titel" : "Die Insel des Todes",
+              "start" : 2402027,
+              "end" : 3456947
+            },
+            {
+              "titel" : "Verhaftet",
+              "start" : 3456947,
+              "end" : 3938600
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/214/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/214/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/214/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/214/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/214/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music126/v4/0f/7e/db/0f7edb85-4817-c615-bf6d-a767ed3b0536/source"
       }
@@ -27503,10 +38893,56 @@
           "sprecher" : "Anne Moll"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Gemälde, das es gar nicht geben kann",
+              "start" : 0,
+              "end" : 539067
+            },
+            {
+              "titel" : "3582",
+              "start" : 539067,
+              "end" : 966160
+            },
+            {
+              "titel" : "Der 9. Oktober 1582",
+              "start" : 966160,
+              "end" : 1776080
+            },
+            {
+              "titel" : "Platzhalter",
+              "start" : 1776080,
+              "end" : 2506427
+            },
+            {
+              "titel" : "(Un)bekannter Verfolger",
+              "start" : 2506427,
+              "end" : 2842187
+            },
+            {
+              "titel" : "Einbruch",
+              "start" : 2842187,
+              "end" : 3227760
+            },
+            {
+              "titel" : "Erwischt",
+              "start" : 3227760,
+              "end" : 3546960
+            },
+            {
+              "titel" : "Zusammentreffen",
+              "start" : 3546960,
+              "end" : 3954893
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/215/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/215/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/215/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/215/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/215/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music116/v4/5c/da/a0/5cdaa0d3-b590-a858-c44d-760b4603cb5f/source"
       }
@@ -27615,10 +39051,61 @@
           "sprecher" : "Heikedine Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "XFLR-7",
+              "start" : 0,
+              "end" : 609813
+            },
+            {
+              "titel" : "Suche nach einer Melodie",
+              "start" : 609813,
+              "end" : 1059640
+            },
+            {
+              "titel" : "In Feindes Hand",
+              "start" : 1059640,
+              "end" : 1366147
+            },
+            {
+              "titel" : "Heimlichtuerei",
+              "start" : 1366147,
+              "end" : 1939253
+            },
+            {
+              "titel" : "Gefesselt",
+              "start" : 1939253,
+              "end" : 2317253
+            },
+            {
+              "titel" : "Bob will Ärger",
+              "start" : 2317253,
+              "end" : 2781707
+            },
+            {
+              "titel" : "Tödliche Flut",
+              "start" : 2781707,
+              "end" : 3240027
+            },
+            {
+              "titel" : "Ablenkungsmanöver",
+              "start" : 3240027,
+              "end" : 3515293
+            },
+            {
+              "titel" : "In der Schusslinie",
+              "start" : 3515293,
+              "end" : 3884267
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/216/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/216/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/216/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/216/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/216/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/us/r30/Music126/v4/eb/74/2f/eb742faa-8677-eded-4d52-fa45dbf62e8c/source"
       }
@@ -27735,10 +39222,56 @@
           "sprecher" : "Hans-Jürgen Mende"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Haus von Hunter Scott",
+              "start" : 0,
+              "end" : 726773
+            },
+            {
+              "titel" : "Ein Schädel löst sich in Luft auf",
+              "start" : 726773,
+              "end" : 1352067
+            },
+            {
+              "titel" : "Kosmische Energien",
+              "start" : 1352067,
+              "end" : 1747840
+            },
+            {
+              "titel" : "Lauschaktion",
+              "start" : 1747840,
+              "end" : 2328440
+            },
+            {
+              "titel" : "Wo ist der Kristallschädel?",
+              "start" : 2328440,
+              "end" : 2968147
+            },
+            {
+              "titel" : "Im Uhrenturm",
+              "start" : 2968147,
+              "end" : 3468000
+            },
+            {
+              "titel" : "Maskerade",
+              "start" : 3468000,
+              "end" : 3969453
+            },
+            {
+              "titel" : "Abgemacht!",
+              "start" : 3969453,
+              "end" : 4520653
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/217/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/217/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/217/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/217/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/217/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music112/v4/6f/30/56/6f3056fb-3bec-1355-04b3-0b9f234dd9ca/886449413096.jpg"
       }
@@ -27855,10 +39388,56 @@
           "sprecher" : "Tim Grobe"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Der Countdown läuft",
+              "start" : 0,
+              "end" : 688360
+            },
+            {
+              "titel" : "Tatort Rocky Beach",
+              "start" : 688360,
+              "end" : 1449067
+            },
+            {
+              "titel" : "Das Messer",
+              "start" : 1449067,
+              "end" : 1866880
+            },
+            {
+              "titel" : "Ein alter Freund erinnert sich",
+              "start" : 1866880,
+              "end" : 2283573
+            },
+            {
+              "titel" : "Gefährlicher Einbrecher",
+              "start" : 2283573,
+              "end" : 2711333
+            },
+            {
+              "titel" : "Gefahr im Mondschein",
+              "start" : 2711333,
+              "end" : 3145973
+            },
+            {
+              "titel" : "Geliebtes Sammlerobjekt",
+              "start" : 3145973,
+              "end" : 3527000
+            },
+            {
+              "titel" : "Showtime",
+              "start" : 3527000,
+              "end" : 4372133
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/218/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/218/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/218/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/218/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/218/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music112/v4/c0/13/4d/c0134d60-2ae9-48cf-6002-5ce6766a1b46/886449413232.jpg"
       }
@@ -27975,10 +39554,56 @@
           "sprecher" : "Frank Meyer-Brockmann"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Sturz ins Meer",
+              "start" : 0,
+              "end" : 452693
+            },
+            {
+              "titel" : "Unter Verdacht",
+              "start" : 452693,
+              "end" : 793640
+            },
+            {
+              "titel" : "Justus will es wissen",
+              "start" : 793640,
+              "end" : 1532880
+            },
+            {
+              "titel" : "Eine interessante Begegnung",
+              "start" : 1532880,
+              "end" : 1966933
+            },
+            {
+              "titel" : "Auf der Teufelszunge",
+              "start" : 1966933,
+              "end" : 2607067
+            },
+            {
+              "titel" : "Kunde 37",
+              "start" : 2607067,
+              "end" : 2928693
+            },
+            {
+              "titel" : "Entführt",
+              "start" : 2928693,
+              "end" : 3430307
+            },
+            {
+              "titel" : "Das letzte Geheimnis",
+              "start" : 3430307,
+              "end" : 4189547
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/219/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/219/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/219/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/219/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/219/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music112/v4/d0/fa/95/d0fa95d3-9318-de46-9413-504016bf071f/886449413300.jpg"
       }
@@ -28097,10 +39722,66 @@
           "sprecher" : "Holger Wemhoff"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Montana",
+              "start" : 0,
+              "end" : 389293
+            },
+            {
+              "titel" : "Vorstellungsrunde",
+              "start" : 389293,
+              "end" : 831853
+            },
+            {
+              "titel" : "Der tote Briefkasten",
+              "start" : 831853,
+              "end" : 1266027
+            },
+            {
+              "titel" : "Sturz",
+              "start" : 1266027,
+              "end" : 1547800
+            },
+            {
+              "titel" : "Aufwärts",
+              "start" : 1547800,
+              "end" : 2104947
+            },
+            {
+              "titel" : "Pilze und Blaubeerpudding",
+              "start" : 2104947,
+              "end" : 2498453
+            },
+            {
+              "titel" : "Das Versteck in den Weiden",
+              "start" : 2498453,
+              "end" : 2886960
+            },
+            {
+              "titel" : "Getroffener Tank",
+              "start" : 2886960,
+              "end" : 3327920
+            },
+            {
+              "titel" : "Ein Mann namens Thomas",
+              "start" : 3327920,
+              "end" : 3757160
+            },
+            {
+              "titel" : "Geheime Superkraft",
+              "start" : 3757160,
+              "end" : 4446747
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/220/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/220/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/220/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/220/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/220/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music112/v4/a3/5d/6c/a35d6cfc-8219-1e66-8923-a8c227a1ac35/196589194510.jpg"
       }
@@ -28202,10 +39883,61 @@
           "sprecher" : "Marc Zabinski"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Satanische Attacken",
+              "start" : 0,
+              "end" : 466173
+            },
+            {
+              "titel" : "Bowling-Bedrohung",
+              "start" : 466173,
+              "end" : 965973
+            },
+            {
+              "titel" : "Die drei Söhne",
+              "start" : 965973,
+              "end" : 1436000
+            },
+            {
+              "titel" : "Offenes Fenster in der Nacht",
+              "start" : 1436000,
+              "end" : 1861853
+            },
+            {
+              "titel" : "Bancroft und Bancroft",
+              "start" : 1861853,
+              "end" : 2209573
+            },
+            {
+              "titel" : "Seltsames Klebeband",
+              "start" : 2209573,
+              "end" : 2728627
+            },
+            {
+              "titel" : "Verstorbene Ehefrau",
+              "start" : 2728627,
+              "end" : 3019400
+            },
+            {
+              "titel" : "Eine Wand mit Geschichte",
+              "start" : 3019400,
+              "end" : 3533053
+            },
+            {
+              "titel" : "Endstation Keller",
+              "start" : 3533053,
+              "end" : 3932520
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/221/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/221/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/221/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/221/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/221/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music122/v4/ee/d9/25/eed925e9-91ae-071f-51ac-8f95f4a20cf6/196589194671.jpg"
       }
@@ -28322,10 +40054,56 @@
           "sprecher" : "Konstantin Graudus"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Das Grauen in Pink",
+              "start" : 0,
+              "end" : 397733
+            },
+            {
+              "titel" : "Entführung",
+              "start" : 397733,
+              "end" : 799173
+            },
+            {
+              "titel" : "Warnung",
+              "start" : 799173,
+              "end" : 1508667
+            },
+            {
+              "titel" : "Sacramento",
+              "start" : 1508667,
+              "end" : 1948347
+            },
+            {
+              "titel" : "Stichwort: Wahrheit",
+              "start" : 1948347,
+              "end" : 2595200
+            },
+            {
+              "titel" : "Gleichungen mit drei Unbekannten",
+              "start" : 2595200,
+              "end" : 3546747
+            },
+            {
+              "titel" : "Jede Menge Geld",
+              "start" : 3546747,
+              "end" : 3909253
+            },
+            {
+              "titel" : "Schlangenjagd",
+              "start" : 3909253,
+              "end" : 4615480
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/222/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/222/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/222/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/222/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/222/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music126/v4/a7/67/37/a7673797-8db6-01f7-da10-d19466f06130/196589194695.jpg"
       }
@@ -28447,10 +40225,56 @@
           "sprecher" : "Barbara Schipper"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Erde bebt",
+              "start" : 0,
+              "end" : 492760
+            },
+            {
+              "titel" : "Verschwunden",
+              "start" : 492760,
+              "end" : 847573
+            },
+            {
+              "titel" : "Hänsel und Gretel",
+              "start" : 847573,
+              "end" : 1172987
+            },
+            {
+              "titel" : "Sonniger Zeitgenosse",
+              "start" : 1172987,
+              "end" : 1690400
+            },
+            {
+              "titel" : "Bissige Spuren",
+              "start" : 1690400,
+              "end" : 2394147
+            },
+            {
+              "titel" : "Die Katze",
+              "start" : 2394147,
+              "end" : 3125573
+            },
+            {
+              "titel" : "Erdrückende Beweise",
+              "start" : 3125573,
+              "end" : 4321573
+            },
+            {
+              "titel" : "Romeo, Julia und … Bob",
+              "start" : 4321573,
+              "end" : 4799880
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/223/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/223/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/223/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/223/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/223/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music126/v4/2f/90/b7/2f90b777-86d1-c1c3-9b85-b8e5da917f8c/196589971913.jpg"
       }
@@ -28555,135 +40379,62 @@
           "sprecher" : "Heidi Berndt"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Tokoloshe",
+              "start" : 0,
+              "end" : 543227
+            },
+            {
+              "titel" : "Die Vodoo-Frau",
+              "start" : 543227,
+              "end" : 1058413
+            },
+            {
+              "titel" : "Ein gefährlicher Plan",
+              "start" : 1058413,
+              "end" : 1532147
+            },
+            {
+              "titel" : "Mission Peter",
+              "start" : 1532147,
+              "end" : 1919067
+            },
+            {
+              "titel" : "An Bord",
+              "start" : 1919067,
+              "end" : 2564413
+            },
+            {
+              "titel" : "Leinen los!",
+              "start" : 2564413,
+              "end" : 3009173
+            },
+            {
+              "titel" : "Mann über Bord!",
+              "start" : 3009173,
+              "end" : 3630933
+            },
+            {
+              "titel" : "Enttarnt",
+              "start" : 3630933,
+              "end" : 4363613
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/224/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/224/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/224/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/224/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/224/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music116/v4/1a/1d/2d/1a1d2d8a-eb6e-8d6b-3eaa-2fb8d0817c65/196871057400.jpg"
       }
     },
     {
       "nummer" : 225,
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Überraschung!",
-              "start" : 0,
-              "end" : 399667
-            },
-            {
-              "titel" : "Das Tischdecken-Gespenst",
-              "start" : 399667,
-              "end" : 806227
-            },
-            {
-              "titel" : "Hände hoch",
-              "start" : 806227,
-              "end" : 1546920
-            },
-            {
-              "titel" : "Funkloch",
-              "start" : 1546920,
-              "end" : 2365227
-            },
-            {
-              "titel" : "Spurensuche",
-              "start" : 2365227,
-              "end" : 2736467
-            },
-            {
-              "titel" : "Schüsse im Maisfeld",
-              "start" : 2736467,
-              "end" : 3077933
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Serie/225/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/225/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Das gehängte Brautpaar",
-              "start" : 0,
-              "end" : 700813
-            },
-            {
-              "titel" : "Wenn man vom Teufel spricht",
-              "start" : 700813,
-              "end" : 1108613
-            },
-            {
-              "titel" : "Regenbogenrosen",
-              "start" : 1108613,
-              "end" : 1547107
-            },
-            {
-              "titel" : "In der Falle",
-              "start" : 1547107,
-              "end" : 2341440
-            },
-            {
-              "titel" : "Dreißig Stunden",
-              "start" : 2341440,
-              "end" : 3042893
-            },
-            {
-              "titel" : "Der Mann im Nachthemd",
-              "start" : 3042893,
-              "end" : 3689613
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Serie/225/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/225/2/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 3,
-          "kapitel" : [
-            {
-              "titel" : "Sie haben das Recht zu schweigen",
-              "start" : 0,
-              "end" : 371253
-            },
-            {
-              "titel" : "Beschattung",
-              "start" : 371253,
-              "end" : 1171040
-            },
-            {
-              "titel" : "Das Hochzeitsgeschenk",
-              "start" : 1171040,
-              "end" : 1740613
-            },
-            {
-              "titel" : "Unter Druck",
-              "start" : 1740613,
-              "end" : 2092733
-            },
-            {
-              "titel" : "Deconvulsan",
-              "start" : 2092733,
-              "end" : 3235867
-            },
-            {
-              "titel" : "Hochzeitstag",
-              "start" : 3235867,
-              "end" : 3928907
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Serie/225/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Serie/225/3/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "und der Puppenmacher",
       "autor" : "André Marx",
       "hörspielskriptautor" : "André Minninger",
@@ -28860,6 +40611,113 @@
           "sprecher" : "Angelika Berg"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Überraschung!",
+              "start" : 0,
+              "end" : 399667
+            },
+            {
+              "titel" : "Das Tischdecken-Gespenst",
+              "start" : 399667,
+              "end" : 806227
+            },
+            {
+              "titel" : "Hände hoch",
+              "start" : 806227,
+              "end" : 1546920
+            },
+            {
+              "titel" : "Funkloch",
+              "start" : 1546920,
+              "end" : 2365227
+            },
+            {
+              "titel" : "Spurensuche",
+              "start" : 2365227,
+              "end" : 2736467
+            },
+            {
+              "titel" : "Schüsse im Maisfeld",
+              "start" : 2736467,
+              "end" : 3077933
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Das gehängte Brautpaar",
+              "start" : 0,
+              "end" : 700813
+            },
+            {
+              "titel" : "Wenn man vom Teufel spricht",
+              "start" : 700813,
+              "end" : 1108613
+            },
+            {
+              "titel" : "Regenbogenrosen",
+              "start" : 1108613,
+              "end" : 1547107
+            },
+            {
+              "titel" : "In der Falle",
+              "start" : 1547107,
+              "end" : 2341440
+            },
+            {
+              "titel" : "Dreißig Stunden",
+              "start" : 2341440,
+              "end" : 3042893
+            },
+            {
+              "titel" : "Der Mann im Nachthemd",
+              "start" : 3042893,
+              "end" : 3689613
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Sie haben das Recht zu schweigen",
+              "start" : 0,
+              "end" : 371253
+            },
+            {
+              "titel" : "Beschattung",
+              "start" : 371253,
+              "end" : 1171040
+            },
+            {
+              "titel" : "Das Hochzeitsgeschenk",
+              "start" : 1171040,
+              "end" : 1740613
+            },
+            {
+              "titel" : "Unter Druck",
+              "start" : 1740613,
+              "end" : 2092733
+            },
+            {
+              "titel" : "Deconvulsan",
+              "start" : 2092733,
+              "end" : 3235867
+            },
+            {
+              "titel" : "Hochzeitstag",
+              "start" : 3235867,
+              "end" : 3928907
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log3.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/225/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/225/ffmetadata.txt",
@@ -28961,10 +40819,46 @@
           "sprecher" : "Merle Tucholka"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Lebensbilanz",
+              "start" : 0,
+              "end" : 644680
+            },
+            {
+              "titel" : "Entlassen",
+              "start" : 644680,
+              "end" : 1188493
+            },
+            {
+              "titel" : "Innere Uhr",
+              "start" : 1188493,
+              "end" : 1837627
+            },
+            {
+              "titel" : "Äußerste Konzentration",
+              "start" : 1837627,
+              "end" : 2583333
+            },
+            {
+              "titel" : "Schock",
+              "start" : 2583333,
+              "end" : 3764320
+            },
+            {
+              "titel" : "Richtig geschlussfolgert",
+              "start" : 3764320,
+              "end" : 4953600
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/226/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/226/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/226/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/226/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/226/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music116/v4/30/d4/77/30d47722-aed3-7ce0-7a21-f0d96e7bf82e/196871249775.jpg"
       }
@@ -29063,10 +40957,46 @@
           "sprecher" : "Stefan Zinkgraf"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "PJs Bassgitarre",
+              "start" : 0,
+              "end" : 637667
+            },
+            {
+              "titel" : "Sprungtuchdiebstahl",
+              "start" : 637667,
+              "end" : 1264133
+            },
+            {
+              "titel" : "Terminar em pizza",
+              "start" : 1264133,
+              "end" : 1672373
+            },
+            {
+              "titel" : "Monster-Alarm",
+              "start" : 1672373,
+              "end" : 2266160
+            },
+            {
+              "titel" : "Neue Spuren",
+              "start" : 2266160,
+              "end" : 3004040
+            },
+            {
+              "titel" : "Konfrontation mit der Wahrheit",
+              "start" : 3004040,
+              "end" : 3870227
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Serie/227/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Serie/227/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Serie/227/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Serie/227/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Serie/227/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music122/v4/aa/a3/a1/aaa3a16c-3d3c-a164-c8e7-feaa43a0c0ba/196871288071.jpg"
       }

--- a/metadata/json/Spezial.json
+++ b/metadata/json/Spezial.json
@@ -1,96 +1,6 @@
 {
   "spezial" : [
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Ein Hilferuf",
-              "start" : 0,
-              "end" : 557187
-            },
-            {
-              "titel" : "Errare humanum est",
-              "start" : 557187,
-              "end" : 1134733
-            },
-            {
-              "titel" : "Ist Sherlock Holmes zuhause?",
-              "start" : 1134733,
-              "end" : 1352707
-            },
-            {
-              "titel" : "Die Telefonlawine",
-              "start" : 1352707,
-              "end" : 2080920
-            },
-            {
-              "titel" : "Blackbeard",
-              "start" : 2080920,
-              "end" : 2426173
-            },
-            {
-              "titel" : "Ein spezial gelagerter Sonderfall",
-              "start" : 2426173,
-              "end" : 2677653
-            },
-            {
-              "titel" : "Sterbenskrank",
-              "start" : 2677653,
-              "end" : 2921387
-            },
-            {
-              "titel" : "Skinny Norris",
-              "start" : 2921387,
-              "end" : 3178987
-            },
-            {
-              "titel" : "Robin Hood",
-              "start" : 3178987,
-              "end" : 3418440
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Ein gerissener Kunstdieb",
-              "start" : 0,
-              "end" : 692667
-            },
-            {
-              "titel" : "Al Capone",
-              "start" : 692667,
-              "end" : 978747
-            },
-            {
-              "titel" : "Baker Street in London",
-              "start" : 978747,
-              "end" : 1177880
-            },
-            {
-              "titel" : "Auf dem Friedhof",
-              "start" : 1177880,
-              "end" : 1809400
-            },
-            {
-              "titel" : "Wo sind die Papageien?",
-              "start" : 1809400,
-              "end" : 1981684
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "und der Super-Papagei 2004",
       "autor" : "Robert Arthur",
       "hörspielskriptautor" : "André Minninger",
@@ -231,6 +141,88 @@
           "sprecher" : "Barbara Benuel"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Hilferuf",
+              "start" : 0,
+              "end" : 557187
+            },
+            {
+              "titel" : "Errare humanum est",
+              "start" : 557187,
+              "end" : 1134733
+            },
+            {
+              "titel" : "Ist Sherlock Holmes zuhause?",
+              "start" : 1134733,
+              "end" : 1352707
+            },
+            {
+              "titel" : "Die Telefonlawine",
+              "start" : 1352707,
+              "end" : 2080920
+            },
+            {
+              "titel" : "Blackbeard",
+              "start" : 2080920,
+              "end" : 2426173
+            },
+            {
+              "titel" : "Ein spezial gelagerter Sonderfall",
+              "start" : 2426173,
+              "end" : 2677653
+            },
+            {
+              "titel" : "Sterbenskrank",
+              "start" : 2677653,
+              "end" : 2921387
+            },
+            {
+              "titel" : "Skinny Norris",
+              "start" : 2921387,
+              "end" : 3178987
+            },
+            {
+              "titel" : "Robin Hood",
+              "start" : 3178987,
+              "end" : 3418440
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein gerissener Kunstdieb",
+              "start" : 0,
+              "end" : 692667
+            },
+            {
+              "titel" : "Al Capone",
+              "start" : 692667,
+              "end" : 978747
+            },
+            {
+              "titel" : "Baker Street in London",
+              "start" : 978747,
+              "end" : 1177880
+            },
+            {
+              "titel" : "Auf dem Friedhof",
+              "start" : 1177880,
+              "end" : 1809400
+            },
+            {
+              "titel" : "Wo sind die Papageien?",
+              "start" : 1809400,
+              "end" : 1981684
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/ffmetadata.txt",
@@ -244,7 +236,9 @@
           "buchstabe" : "J",
           "titel" : "Sicht J: Der Fluch der Sheldon Street",
           "autor" : "Hendrik Buchna",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Alles beginnt mit dem Kauf eines alten Projektors und der Entdeckung einer schmalen Super-8-Filmrolle. Als die drei Detektive das Fundstück begutachten, entdecken sie die verstörende Aufnahme einer albtraumhaften Gestalt. Schnell stellen die drei ??? fest, dass es um weit mehr geht, als sie zunächst ahnen: Eine ganze Straße scheint unter dem Bann eines düsteren Geheimnisses zu stehen. Doch kaum beginnen Justus, Peter und Bob mit ihren Nachforschungen, da tauchen plötzlich Gegner auf, die ihnen mit allen Mitteln zuvorkommen wollen …",
+          "veröffentlichungsdatum" : "2010-10-01",
           "kapitel" : [
             {
               "titel" : "Die Cola",
@@ -409,8 +403,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/1/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/1/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/1/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/1/ffmetadata.txt"
           }
         },
         {
@@ -418,7 +411,9 @@
           "buchstabe" : "B",
           "titel" : "Sicht B: Im Zeichen der Ritter",
           "autor" : "Tim Wenderoth",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Geheimnisvolle Symbole beunruhigen die Bewohner von Rocky Beach. Was steckt hinter den kryptischen Zeichen, die von einer geisterhaften Gestalt nachts an die Häuser gemalt werden? Und warum verhalten sich einige Bewohner der kleinen Küstenstadt so merkwürdig? Ihre ersten Nachforschungen bringen Justus, Peter und vor allem Bob auf die Spur einer mittelalterlichen Ritterlegende. Je intensiver sie sich mit dem Fall beschäftigen, umso klarer scheint, dass ihnen nur wenige Stunden bleiben, um am unheilvollen Freitag den 13. Schlimmeres zu verhindern …",
+          "veröffentlichungsdatum" : "2010-10-01",
           "kapitel" : [
             {
               "titel" : "Die Cola",
@@ -573,8 +568,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/2/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/2/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/2/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/2/ffmetadata.txt"
           }
         },
         {
@@ -582,7 +576,9 @@
           "buchstabe" : "P",
           "titel" : "Sicht P: Fremder Freund",
           "autor" : "Ivar Leon Menger",
+          "hörspielskriptautor" : "André Minninger",
           "beschreibung" : "Peter schwebt im siebten Himmel, denn er hat in einem Café Bekanntschaft mit einem großen Fan der drei ??? gemacht. Er wird sogar um ein Autogramm gebeten. Stolz und gut gelaunt verbringt Peter einen tollen Tag mit seinen Freunden, und alles wäre einfach perfekt, wenn er nicht plötzlich diese seltsamen Telefonanrufe und mysteriösen Briefe erhalten würde. Die drei Detektive werden heimlich beobachtet und sogar von einem Unbekannten fotografiert! Was soll das alles? Wer ist dieser seltsame Verfolger? Ist Peters Leben in Gefahr?",
+          "veröffentlichungsdatum" : "2010-10-01",
           "kapitel" : [
             {
               "titel" : "Die Cola",
@@ -707,19 +703,19 @@
             },
             {
               "rolle" : "Ian Bush",
-              "sprecher" : "Sky du Mont / Lukas T. Sperber"
+              "sprecher" : "Sky du Mont, Lukas T. Sperber"
             },
             {
               "rolle" : "Jimmy Sinclair",
-              "sprecher" : "Siegfried W. Kernen / Nils Noller"
+              "sprecher" : "Siegfried W. Kernen, Nils Noller"
             },
             {
               "rolle" : "Charlie Parker",
-              "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+              "sprecher" : "Oliver Böttcher, Laurence Kalaidjian"
             },
             {
               "rolle" : "Brianna Jackson",
-              "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+              "sprecher" : "Hansi Jochmann, Natalie Demtrøder"
             },
             {
               "rolle" : "Chloe Smathers",
@@ -788,8 +784,7 @@
           ],
           "links" : {
             "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/3/metadata.json",
-            "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/3/ffmetadata.txt",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/3/rip_log.txt"
+            "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/3/ffmetadata.txt"
           }
         }
       ],
@@ -937,19 +932,19 @@
         },
         {
           "rolle" : "Ian Bush",
-          "sprecher" : "Sky du Mont / Lukas T. Sperber"
+          "sprecher" : "Sky du Mont, Lukas T. Sperber"
         },
         {
           "rolle" : "Jimmy Sinclair",
-          "sprecher" : "Siegfried W. Kernen / Nils Noller"
+          "sprecher" : "Siegfried W. Kernen, Nils Noller"
         },
         {
           "rolle" : "Charlie Parker",
-          "sprecher" : "Oliver Böttcher / Laurence Kalaidjian"
+          "sprecher" : "Oliver Böttcher, Laurence Kalaidjian"
         },
         {
           "rolle" : "Brianna Jackson",
-          "sprecher" : "Hansi Jochmann / Natalie Demtrøder"
+          "sprecher" : "Hansi Jochmann, Natalie Demtrøder"
         },
         {
           "rolle" : "Chloe Smathers",
@@ -978,6 +973,223 @@
         {
           "rolle" : "Sekretärin",
           "sprecher" : "Corinna Wodrich"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Cola",
+              "start" : 0,
+              "end" : 249733
+            },
+            {
+              "titel" : "Bleiche Fratze",
+              "start" : 249733,
+              "end" : 518160
+            },
+            {
+              "titel" : "Sammlerstück",
+              "start" : 518160,
+              "end" : 743333
+            },
+            {
+              "titel" : "Dunkle Erinnerung",
+              "start" : 743333,
+              "end" : 1150133
+            },
+            {
+              "titel" : "Eine Straße in Angst",
+              "start" : 1150133,
+              "end" : 1828053
+            },
+            {
+              "titel" : "Verfolgt",
+              "start" : 1828053,
+              "end" : 2374027
+            },
+            {
+              "titel" : "Kriegsrat",
+              "start" : 2374027,
+              "end" : 2635387
+            },
+            {
+              "titel" : "Unheimliche Begegnungen",
+              "start" : 2635387,
+              "end" : 3167667
+            },
+            {
+              "titel" : "Sturm",
+              "start" : 3167667,
+              "end" : 3467800
+            },
+            {
+              "titel" : "Eine heiße Spur",
+              "start" : 3467800,
+              "end" : 3850653
+            },
+            {
+              "titel" : "Wendepunkt",
+              "start" : 3850653,
+              "end" : 4188920
+            },
+            {
+              "titel" : "Der Fluch der Sheldon Street",
+              "start" : 4188920,
+              "end" : 4589640
+            },
+            {
+              "titel" : "Triumph",
+              "start" : 4589640,
+              "end" : 4757160
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Cola",
+              "start" : 0,
+              "end" : 262987
+            },
+            {
+              "titel" : "Papierdrachen",
+              "start" : 262987,
+              "end" : 490387
+            },
+            {
+              "titel" : "Außerirdische",
+              "start" : 490387,
+              "end" : 801680
+            },
+            {
+              "titel" : "Der Heilige Gral",
+              "start" : 801680,
+              "end" : 1008107
+            },
+            {
+              "titel" : "Freitag, der 13.",
+              "start" : 1008107,
+              "end" : 1488693
+            },
+            {
+              "titel" : "3 × 9 = 27",
+              "start" : 1488693,
+              "end" : 1719373
+            },
+            {
+              "titel" : "Blamiert",
+              "start" : 1719373,
+              "end" : 1958373
+            },
+            {
+              "titel" : "Jesper",
+              "start" : 1958373,
+              "end" : 2380533
+            },
+            {
+              "titel" : "Exklusivrechte",
+              "start" : 2380533,
+              "end" : 2786640
+            },
+            {
+              "titel" : "Cliffhanger",
+              "start" : 2786640,
+              "end" : 3126560
+            },
+            {
+              "titel" : "Film ab!",
+              "start" : 3126560,
+              "end" : 3353253
+            },
+            {
+              "titel" : "Rote Farbe",
+              "start" : 3353253,
+              "end" : 3904933
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Cola",
+              "start" : 0,
+              "end" : 231413
+            },
+            {
+              "titel" : "Du hast noch nicht einmal gefragt!",
+              "start" : 231413,
+              "end" : 560493
+            },
+            {
+              "titel" : "Du bist doch verliebt, Peter!",
+              "start" : 560493,
+              "end" : 750533
+            },
+            {
+              "titel" : "Das Geschäft des Monats!",
+              "start" : 750533,
+              "end" : 1009533
+            },
+            {
+              "titel" : "Mein Name ist Peter!",
+              "start" : 1009533,
+              "end" : 1371053
+            },
+            {
+              "titel" : "Der Brief wurde abgegeben!",
+              "start" : 1371053,
+              "end" : 1580600
+            },
+            {
+              "titel" : "Auf den Novalux-Projektor!",
+              "start" : 1580600,
+              "end" : 1942960
+            },
+            {
+              "titel" : "Das bin ich dir schuldig!",
+              "start" : 1942960,
+              "end" : 2201400
+            },
+            {
+              "titel" : "Warum sollte ich das tun?",
+              "start" : 2201400,
+              "end" : 2382760
+            },
+            {
+              "titel" : "Hört ihr das nicht?",
+              "start" : 2382760,
+              "end" : 2814560
+            },
+            {
+              "titel" : "Nein, Bob! Die mag mich doch!",
+              "start" : 2814560,
+              "end" : 3104720
+            },
+            {
+              "titel" : "Aber genau das ist doch sehr seltsam!",
+              "start" : 3104720,
+              "end" : 3363200
+            },
+            {
+              "titel" : "Ein Zeichen?",
+              "start" : 3363200,
+              "end" : 3675013
+            },
+            {
+              "titel" : "Hier eine Sondermeldung!",
+              "start" : 3675013,
+              "end" : 3978200
+            },
+            {
+              "titel" : "Darf ich reinkommen?",
+              "start" : 3978200,
+              "end" : 4416000
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log3.txt"
         }
       ],
       "links" : {
@@ -1151,620 +1363,81 @@
           "sprecher" : "Lauscherlounge-Zuschauer (www.dreifragezeichen.de/www/menge-brainwash)"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Band-Probe",
+              "start" : 0,
+              "end" : 240240
+            },
+            {
+              "titel" : "Verschwunden",
+              "start" : 240240,
+              "end" : 764587
+            },
+            {
+              "titel" : "Zwischen den Stühlen",
+              "start" : 764587,
+              "end" : 911680
+            },
+            {
+              "titel" : "Depressionen?",
+              "start" : 911680,
+              "end" : 1175453
+            },
+            {
+              "titel" : "Ausreißer",
+              "start" : 1175453,
+              "end" : 1661507
+            },
+            {
+              "titel" : "SynRea",
+              "start" : 1661507,
+              "end" : 1812533
+            },
+            {
+              "titel" : "Neue Energie",
+              "start" : 1812533,
+              "end" : 2010333
+            },
+            {
+              "titel" : "Elite-Einheiten",
+              "start" : 2010333,
+              "end" : 2307147
+            },
+            {
+              "titel" : "Ertappt",
+              "start" : 2307147,
+              "end" : 2921373
+            },
+            {
+              "titel" : "Der Meister",
+              "start" : 2921373,
+              "end" : 3390173
+            },
+            {
+              "titel" : "Am Ende des Weges",
+              "start" : 3390173,
+              "end" : 3565613
+            },
+            {
+              "titel" : "Alles vergessen",
+              "start" : 3565613,
+              "end" : 3675453
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music49/v4/b9/f2/a8/b9f2a801-34a1-4d5d-c745-5ef921fba6cb/886445749403.jpg"
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Die Geisterbahn",
-              "start" : 0,
-              "end" : 418747
-            },
-            {
-              "titel" : "Paket dem Gouverneur übergeben",
-              "start" : 418747,
-              "end" : 494627
-            },
-            {
-              "titel" : "Werbeanzeigen lesen",
-              "start" : 494627,
-              "end" : 644347
-            },
-            {
-              "titel" : "Vor Bubba verstecken",
-              "start" : 644347,
-              "end" : 748173
-            },
-            {
-              "titel" : "Geisterbahn beobachten",
-              "start" : 748173,
-              "end" : 798067
-            },
-            {
-              "titel" : "Paket selbst öffnen",
-              "start" : 798067,
-              "end" : 844267
-            },
-            {
-              "titel" : "Bei Bubba bleiben",
-              "start" : 844267,
-              "end" : 913187
-            },
-            {
-              "titel" : "Mit Joey sprechen",
-              "start" : 913187,
-              "end" : 1143093
-            },
-            {
-              "titel" : "Flucht zu den drei ???",
-              "start" : 1143093,
-              "end" : 1214400
-            },
-            {
-              "titel" : "Mit Bubba Detroit sprechen",
-              "start" : 1214400,
-              "end" : 1282880
-            },
-            {
-              "titel" : "Joey verfolgen",
-              "start" : 1282880,
-              "end" : 1425973
-            },
-            {
-              "titel" : "Justus hinterher rennen",
-              "start" : 1425973,
-              "end" : 1474547
-            },
-            {
-              "titel" : "Bei den drei ??? bleiben",
-              "start" : 1474547,
-              "end" : 1574467
-            },
-            {
-              "titel" : "Ich habe viel Geld",
-              "start" : 1574467,
-              "end" : 1649973
-            },
-            {
-              "titel" : "Bubba abschütteln",
-              "start" : 1649973,
-              "end" : 1767320
-            },
-            {
-              "titel" : "Geisterbahn von innen untersuchen",
-              "start" : 1767320,
-              "end" : 1916067
-            },
-            {
-              "titel" : "Verstecken in der Achterbahn",
-              "start" : 1916067,
-              "end" : 2045960
-            },
-            {
-              "titel" : "Geisterbahn von außen untersuchen",
-              "start" : 2045960,
-              "end" : 2190267
-            },
-            {
-              "titel" : "Die Zaubershow besuchen",
-              "start" : 2190267,
-              "end" : 2334773
-            },
-            {
-              "titel" : "Ich habe wenig Geld",
-              "start" : 2334773,
-              "end" : 2451360
-            },
-            {
-              "titel" : "Mit Marilyn sprechen",
-              "start" : 2451360,
-              "end" : 2654120
-            },
-            {
-              "titel" : "Verstecken in der Geisterbahn",
-              "start" : 2654120,
-              "end" : 2995320
-            },
-            {
-              "titel" : "Die Frau mit der Flugtasche befragen",
-              "start" : 2995320,
-              "end" : 3132573
-            },
-            {
-              "titel" : "Zu Margarine schleichen",
-              "start" : 3132573,
-              "end" : 3249360
-            },
-            {
-              "titel" : "Flucht über die Grenze nach Süden",
-              "start" : 3249360,
-              "end" : 3330787
-            },
-            {
-              "titel" : "Der nimmt mir alles weg",
-              "start" : 3330787,
-              "end" : 3430867
-            },
-            {
-              "titel" : "Den Verfolger verfolgen",
-              "start" : 3430867,
-              "end" : 3498480
-            }
-          ],
-          "sprechrollen" : [
-            {
-              "rolle" : "Off-Stimme",
-              "sprecher" : "Claudia Stocksieker"
-            },
-            {
-              "rolle" : "Justus Jonas, Erster Detektiv",
-              "sprecher" : "Oliver Rohrbeck"
-            },
-            {
-              "rolle" : "Peter Shaw, Zweiter Detektiv",
-              "sprecher" : "Jens Wawrczeck"
-            },
-            {
-              "rolle" : "Bob Andrews, Recherchen und Archiv",
-              "sprecher" : "Andreas Fröhlich"
-            },
-            {
-              "rolle" : "Tony",
-              "sprecher" : "Stefan Kaminski"
-            },
-            {
-              "rolle" : "Joey",
-              "sprecher" : "Tommaso Cacciapuoti"
-            },
-            {
-              "rolle" : "Ansager in der Schlammringkampfarena",
-              "sprecher" : "Christian Rudolf"
-            },
-            {
-              "rolle" : "Margarine",
-              "sprecher" : "Alma Clausen"
-            },
-            {
-              "rolle" : "Lincolnfahrer",
-              "sprecher" : "Mike Olsowski"
-            },
-            {
-              "rolle" : "Freakshow-Jack",
-              "sprecher" : "Peter Bänker"
-            },
-            {
-              "rolle" : "Der unergründliche Mickey",
-              "sprecher" : "Krystian Martinek"
-            },
-            {
-              "rolle" : "Die bärtige Marilyn",
-              "sprecher" : "Santiago Ziesmer"
-            },
-            {
-              "rolle" : "Miss Luzzy",
-              "sprecher" : "Katja Brügger"
-            },
-            {
-              "rolle" : "Bubba Detroit",
-              "sprecher" : "Klaus Dittmann"
-            },
-            {
-              "rolle" : "Junge",
-              "sprecher" : "Patrick Bach"
-            },
-            {
-              "rolle" : "Burger-Verkäufer Arnie",
-              "sprecher" : "Manou Lubowski"
-            },
-            {
-              "rolle" : "Reporterin",
-              "sprecher" : "Mara Bergmann"
-            },
-            {
-              "rolle" : "Anna Millar",
-              "sprecher" : "Christine Pappert"
-            },
-            {
-              "rolle" : "Bombenattentäter Daniel",
-              "sprecher" : "Tim Grobe"
-            },
-            {
-              "rolle" : "Polizist",
-              "sprecher" : "Wolfgang Kaven"
-            },
-            {
-              "rolle" : "Blacky",
-              "sprecher" : "Heikedine Körting"
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 0,
-              "end" : 15467
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 15467,
-              "end" : 30707
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 30707,
-              "end" : 45947
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 45947,
-              "end" : 61187
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 61187,
-              "end" : 76427
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 76427,
-              "end" : 91667
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 91667,
-              "end" : 106907
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 106907,
-              "end" : 122147
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 122147,
-              "end" : 137387
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 137387,
-              "end" : 152627
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 152627,
-              "end" : 167867
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 167867,
-              "end" : 183107
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 183107,
-              "end" : 198347
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 198347,
-              "end" : 213587
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 213587,
-              "end" : 228827
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 228827,
-              "end" : 244067
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 244067,
-              "end" : 259307
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 259307,
-              "end" : 274547
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 274547,
-              "end" : 289787
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 289787,
-              "end" : 305027
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 305027,
-              "end" : 320267
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 320267,
-              "end" : 335507
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 335507,
-              "end" : 350747
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 350747,
-              "end" : 365987
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 365987,
-              "end" : 381227
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 381227,
-              "end" : 396467
-            },
-            {
-              "titel" : "weiter mit Track 28",
-              "start" : 396467,
-              "end" : 411707
-            },
-            {
-              "titel" : "Die Frau mit der Flugtasche verfolgen",
-              "start" : 411707,
-              "end" : 537960
-            },
-            {
-              "titel" : "Wir warten auf Mrs. Millar",
-              "start" : 537960,
-              "end" : 653493
-            },
-            {
-              "titel" : "Wir wollen bleiben",
-              "start" : 653493,
-              "end" : 893067
-            },
-            {
-              "titel" : "Die Tür öffnen",
-              "start" : 893067,
-              "end" : 1104507
-            },
-            {
-              "titel" : "Wir wollen die Belohnung",
-              "start" : 1104507,
-              "end" : 1264053
-            },
-            {
-              "titel" : "Eine Autofahrt",
-              "start" : 1264053,
-              "end" : 1508440
-            },
-            {
-              "titel" : "Ich helfe Justus bei der Arbeit",
-              "start" : 1508440,
-              "end" : 1682947
-            },
-            {
-              "titel" : "Mrs. Millar nicht treffen",
-              "start" : 1682947,
-              "end" : 1777307
-            },
-            {
-              "titel" : "Die Popcorntüte stehlen",
-              "start" : 1777307,
-              "end" : 1889027
-            },
-            {
-              "titel" : "Jemand soll mich umprogrammieren",
-              "start" : 1889027,
-              "end" : 1992520
-            },
-            {
-              "titel" : "Die Krebs-Anzeige ist wichtig",
-              "start" : 1992520,
-              "end" : 2141507
-            },
-            {
-              "titel" : "Joey an der Flucht hindern",
-              "start" : 2141507,
-              "end" : 2218093
-            },
-            {
-              "titel" : "$100 auftreiben",
-              "start" : 2218093,
-              "end" : 2338853
-            },
-            {
-              "titel" : "Mit einem Schuh werfen",
-              "start" : 2338853,
-              "end" : 2457427
-            },
-            {
-              "titel" : "In der Geisterbahn nachsehen",
-              "start" : 2457427,
-              "end" : 2837493
-            },
-            {
-              "titel" : "Um eine Mitfahrgelegenheit bitten",
-              "start" : 2837493,
-              "end" : 2913627
-            },
-            {
-              "titel" : "Die Popcorn-Anzeige ist wichtig",
-              "start" : 2913627,
-              "end" : 2997907
-            },
-            {
-              "titel" : "Postfächer überwachen",
-              "start" : 2997907,
-              "end" : 3203520
-            },
-            {
-              "titel" : "Wir wollen gehen",
-              "start" : 3203520,
-              "end" : 3289667
-            },
-            {
-              "titel" : "Mehr als vier Mal \"Ja!\" geantwortet",
-              "start" : 3289667,
-              "end" : 3402813
-            },
-            {
-              "titel" : "Weniger als vier Mal \"Ja!\" geantwortet",
-              "start" : 3402813,
-              "end" : 3480800
-            },
-            {
-              "titel" : "Ich will für immer bleiben",
-              "start" : 3480800,
-              "end" : 3570440
-            },
-            {
-              "titel" : "Durch das Fenster fliehen",
-              "start" : 3570440,
-              "end" : 3762907
-            },
-            {
-              "titel" : "Wir wollen die Belohnung nicht",
-              "start" : 3762907,
-              "end" : 3830293
-            },
-            {
-              "titel" : "Justus arbeitet alleine",
-              "start" : 3830293,
-              "end" : 3955293
-            },
-            {
-              "titel" : "Um Hilfe rufen",
-              "start" : 3955293,
-              "end" : 4017853
-            },
-            {
-              "titel" : "Etwas Einmaliges tun",
-              "start" : 4017853,
-              "end" : 4146813
-            },
-            {
-              "titel" : "Mrs. Millar treffen",
-              "start" : 4146813,
-              "end" : 4220507
-            },
-            {
-              "titel" : "Auf dem Riesenrad",
-              "start" : 4220507,
-              "end" : 4326973
-            },
-            {
-              "titel" : "Wir gehen hinein",
-              "start" : 4326973,
-              "end" : 4409547
-            },
-            {
-              "titel" : "Mortons zweite Chance",
-              "start" : 4409547,
-              "end" : 4497427
-            }
-          ],
-          "sprechrollen" : [
-            {
-              "rolle" : "Off-Stimme",
-              "sprecher" : "Claudia Stocksieker"
-            },
-            {
-              "rolle" : "Justus Jonas, Erster Detektiv",
-              "sprecher" : "Oliver Rohrbeck"
-            },
-            {
-              "rolle" : "Peter Shaw, Zweiter Detektiv",
-              "sprecher" : "Jens Wawrczeck"
-            },
-            {
-              "rolle" : "Bob Andrews, Recherchen und Archiv",
-              "sprecher" : "Andreas Fröhlich"
-            },
-            {
-              "rolle" : "Tony",
-              "sprecher" : "Stefan Kaminski"
-            },
-            {
-              "rolle" : "Joey",
-              "sprecher" : "Tommaso Cacciapuoti"
-            },
-            {
-              "rolle" : "Anna Millar",
-              "sprecher" : "Christine Pappert"
-            },
-            {
-              "rolle" : "Lily",
-              "sprecher" : "Verena Wolfien"
-            },
-            {
-              "rolle" : "Max",
-              "sprecher" : "Holger Umbreit"
-            },
-            {
-              "rolle" : "Milli",
-              "sprecher" : "Ulrike Knief"
-            },
-            {
-              "rolle" : "Celeste Hummer",
-              "sprecher" : "Maria Willer"
-            },
-            {
-              "rolle" : "Anthem Hummer",
-              "sprecher" : "Martin May"
-            },
-            {
-              "rolle" : "Morton",
-              "sprecher" : "Andreas von der Meden"
-            },
-            {
-              "rolle" : "Blacky",
-              "sprecher" : "Heikedine Körting"
-            },
-            {
-              "rolle" : "Bruce Millar",
-              "sprecher" : "Ben Hecker"
-            },
-            {
-              "rolle" : "Kommissar Reynolds",
-              "sprecher" : "Wolfgang Draeger"
-            },
-            {
-              "rolle" : "Albert Hitfield",
-              "sprecher" : "Volker Bogdan"
-            },
-            {
-              "rolle" : "TV-Sprecher",
-              "sprecher" : "Friedel Bott"
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "House of Horrors: Haus der Angst",
       "autor" : "Megan & H. William Stine",
       "hörspielskriptautor" : "André Minninger",
@@ -2189,6 +1862,443 @@
           "sprecher" : "Heikedine Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Die Geisterbahn",
+              "start" : 0,
+              "end" : 418747
+            },
+            {
+              "titel" : "Paket dem Gouverneur übergeben",
+              "start" : 418747,
+              "end" : 494627
+            },
+            {
+              "titel" : "Werbeanzeigen lesen",
+              "start" : 494627,
+              "end" : 644347
+            },
+            {
+              "titel" : "Vor Bubba verstecken",
+              "start" : 644347,
+              "end" : 748173
+            },
+            {
+              "titel" : "Geisterbahn beobachten",
+              "start" : 748173,
+              "end" : 798067
+            },
+            {
+              "titel" : "Paket selbst öffnen",
+              "start" : 798067,
+              "end" : 844267
+            },
+            {
+              "titel" : "Bei Bubba bleiben",
+              "start" : 844267,
+              "end" : 913187
+            },
+            {
+              "titel" : "Mit Joey sprechen",
+              "start" : 913187,
+              "end" : 1143093
+            },
+            {
+              "titel" : "Flucht zu den drei ???",
+              "start" : 1143093,
+              "end" : 1214400
+            },
+            {
+              "titel" : "Mit Bubba Detroit sprechen",
+              "start" : 1214400,
+              "end" : 1282880
+            },
+            {
+              "titel" : "Joey verfolgen",
+              "start" : 1282880,
+              "end" : 1425973
+            },
+            {
+              "titel" : "Justus hinterher rennen",
+              "start" : 1425973,
+              "end" : 1474547
+            },
+            {
+              "titel" : "Bei den drei ??? bleiben",
+              "start" : 1474547,
+              "end" : 1574467
+            },
+            {
+              "titel" : "Ich habe viel Geld",
+              "start" : 1574467,
+              "end" : 1649973
+            },
+            {
+              "titel" : "Bubba abschütteln",
+              "start" : 1649973,
+              "end" : 1767320
+            },
+            {
+              "titel" : "Geisterbahn von innen untersuchen",
+              "start" : 1767320,
+              "end" : 1916067
+            },
+            {
+              "titel" : "Verstecken in der Achterbahn",
+              "start" : 1916067,
+              "end" : 2045960
+            },
+            {
+              "titel" : "Geisterbahn von außen untersuchen",
+              "start" : 2045960,
+              "end" : 2190267
+            },
+            {
+              "titel" : "Die Zaubershow besuchen",
+              "start" : 2190267,
+              "end" : 2334773
+            },
+            {
+              "titel" : "Ich habe wenig Geld",
+              "start" : 2334773,
+              "end" : 2451360
+            },
+            {
+              "titel" : "Mit Marilyn sprechen",
+              "start" : 2451360,
+              "end" : 2654120
+            },
+            {
+              "titel" : "Verstecken in der Geisterbahn",
+              "start" : 2654120,
+              "end" : 2995320
+            },
+            {
+              "titel" : "Die Frau mit der Flugtasche befragen",
+              "start" : 2995320,
+              "end" : 3132573
+            },
+            {
+              "titel" : "Zu Margarine schleichen",
+              "start" : 3132573,
+              "end" : 3249360
+            },
+            {
+              "titel" : "Flucht über die Grenze nach Süden",
+              "start" : 3249360,
+              "end" : 3330787
+            },
+            {
+              "titel" : "Der nimmt mir alles weg",
+              "start" : 3330787,
+              "end" : 3430867
+            },
+            {
+              "titel" : "Den Verfolger verfolgen",
+              "start" : 3430867,
+              "end" : 3498480
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 0,
+              "end" : 15467
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 15467,
+              "end" : 30707
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 30707,
+              "end" : 45947
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 45947,
+              "end" : 61187
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 61187,
+              "end" : 76427
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 76427,
+              "end" : 91667
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 91667,
+              "end" : 106907
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 106907,
+              "end" : 122147
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 122147,
+              "end" : 137387
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 137387,
+              "end" : 152627
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 152627,
+              "end" : 167867
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 167867,
+              "end" : 183107
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 183107,
+              "end" : 198347
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 198347,
+              "end" : 213587
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 213587,
+              "end" : 228827
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 228827,
+              "end" : 244067
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 244067,
+              "end" : 259307
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 259307,
+              "end" : 274547
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 274547,
+              "end" : 289787
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 289787,
+              "end" : 305027
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 305027,
+              "end" : 320267
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 320267,
+              "end" : 335507
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 335507,
+              "end" : 350747
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 350747,
+              "end" : 365987
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 365987,
+              "end" : 381227
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 381227,
+              "end" : 396467
+            },
+            {
+              "titel" : "weiter mit Track 28",
+              "start" : 396467,
+              "end" : 411707
+            },
+            {
+              "titel" : "Die Frau mit der Flugtasche verfolgen",
+              "start" : 411707,
+              "end" : 537960
+            },
+            {
+              "titel" : "Wir warten auf Mrs. Millar",
+              "start" : 537960,
+              "end" : 653493
+            },
+            {
+              "titel" : "Wir wollen bleiben",
+              "start" : 653493,
+              "end" : 893067
+            },
+            {
+              "titel" : "Die Tür öffnen",
+              "start" : 893067,
+              "end" : 1104507
+            },
+            {
+              "titel" : "Wir wollen die Belohnung",
+              "start" : 1104507,
+              "end" : 1264053
+            },
+            {
+              "titel" : "Eine Autofahrt",
+              "start" : 1264053,
+              "end" : 1508440
+            },
+            {
+              "titel" : "Ich helfe Justus bei der Arbeit",
+              "start" : 1508440,
+              "end" : 1682947
+            },
+            {
+              "titel" : "Mrs. Millar nicht treffen",
+              "start" : 1682947,
+              "end" : 1777307
+            },
+            {
+              "titel" : "Die Popcorntüte stehlen",
+              "start" : 1777307,
+              "end" : 1889027
+            },
+            {
+              "titel" : "Jemand soll mich umprogrammieren",
+              "start" : 1889027,
+              "end" : 1992520
+            },
+            {
+              "titel" : "Die Krebs-Anzeige ist wichtig",
+              "start" : 1992520,
+              "end" : 2141507
+            },
+            {
+              "titel" : "Joey an der Flucht hindern",
+              "start" : 2141507,
+              "end" : 2218093
+            },
+            {
+              "titel" : "$100 auftreiben",
+              "start" : 2218093,
+              "end" : 2338853
+            },
+            {
+              "titel" : "Mit einem Schuh werfen",
+              "start" : 2338853,
+              "end" : 2457427
+            },
+            {
+              "titel" : "In der Geisterbahn nachsehen",
+              "start" : 2457427,
+              "end" : 2837493
+            },
+            {
+              "titel" : "Um eine Mitfahrgelegenheit bitten",
+              "start" : 2837493,
+              "end" : 2913627
+            },
+            {
+              "titel" : "Die Popcorn-Anzeige ist wichtig",
+              "start" : 2913627,
+              "end" : 2997907
+            },
+            {
+              "titel" : "Postfächer überwachen",
+              "start" : 2997907,
+              "end" : 3203520
+            },
+            {
+              "titel" : "Wir wollen gehen",
+              "start" : 3203520,
+              "end" : 3289667
+            },
+            {
+              "titel" : "Mehr als vier Mal \"Ja!\" geantwortet",
+              "start" : 3289667,
+              "end" : 3402813
+            },
+            {
+              "titel" : "Weniger als vier Mal \"Ja!\" geantwortet",
+              "start" : 3402813,
+              "end" : 3480800
+            },
+            {
+              "titel" : "Ich will für immer bleiben",
+              "start" : 3480800,
+              "end" : 3570440
+            },
+            {
+              "titel" : "Durch das Fenster fliehen",
+              "start" : 3570440,
+              "end" : 3762907
+            },
+            {
+              "titel" : "Wir wollen die Belohnung nicht",
+              "start" : 3762907,
+              "end" : 3830293
+            },
+            {
+              "titel" : "Justus arbeitet alleine",
+              "start" : 3830293,
+              "end" : 3955293
+            },
+            {
+              "titel" : "Um Hilfe rufen",
+              "start" : 3955293,
+              "end" : 4017853
+            },
+            {
+              "titel" : "Etwas Einmaliges tun",
+              "start" : 4017853,
+              "end" : 4146813
+            },
+            {
+              "titel" : "Mrs. Millar treffen",
+              "start" : 4146813,
+              "end" : 4220507
+            },
+            {
+              "titel" : "Auf dem Riesenrad",
+              "start" : 4220507,
+              "end" : 4326973
+            },
+            {
+              "titel" : "Wir gehen hinein",
+              "start" : 4326973,
+              "end" : 4409547
+            },
+            {
+              "titel" : "Mortons zweite Chance",
+              "start" : 4409547,
+              "end" : 4497427
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/ffmetadata.txt",
@@ -2304,164 +2414,66 @@
           "sprecher" : "Heikedine Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Guten Morgen, Rocky Beach",
+              "start" : 0,
+              "end" : 404573
+            },
+            {
+              "titel" : "Haltet den Dieb!",
+              "start" : 404573,
+              "end" : 942667
+            },
+            {
+              "titel" : "Alarm!",
+              "start" : 942667,
+              "end" : 1209693
+            },
+            {
+              "titel" : "Überfall",
+              "start" : 1209693,
+              "end" : 1369080
+            },
+            {
+              "titel" : "Aufgekauft",
+              "start" : 1369080,
+              "end" : 1568280
+            },
+            {
+              "titel" : "Vorsicht, Schlange!",
+              "start" : 1568280,
+              "end" : 2410227
+            },
+            {
+              "titel" : "Weiße Weihnacht",
+              "start" : 2410227,
+              "end" : 2536653
+            },
+            {
+              "titel" : "Was fehlt denn da?",
+              "start" : 2536653,
+              "end" : 2972787
+            },
+            {
+              "titel" : "Jailhouse Rock",
+              "start" : 2972787,
+              "end" : 3170453
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music49/v4/30/a3/5b/30a35bd3-ae05-4a15-cd1b-674753aee0e2/886445749465.jpg"
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "1. Dezember",
-              "start" : 0,
-              "end" : 528880
-            },
-            {
-              "titel" : "2. Dezember",
-              "start" : 528880,
-              "end" : 1052733
-            },
-            {
-              "titel" : "3. Dezember",
-              "start" : 1052733,
-              "end" : 1392027
-            },
-            {
-              "titel" : "4. Dezember",
-              "start" : 1392027,
-              "end" : 1723400
-            },
-            {
-              "titel" : "5. Dezember",
-              "start" : 1723400,
-              "end" : 2275853
-            },
-            {
-              "titel" : "6. Dezember",
-              "start" : 2275853,
-              "end" : 2536933
-            },
-            {
-              "titel" : "7. Dezember",
-              "start" : 2536933,
-              "end" : 3046067
-            },
-            {
-              "titel" : "8. Dezember",
-              "start" : 3046067,
-              "end" : 3369320
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "9. Dezember",
-              "start" : 0,
-              "end" : 418440
-            },
-            {
-              "titel" : "10. Dezember",
-              "start" : 418440,
-              "end" : 808827
-            },
-            {
-              "titel" : "11. Dezember",
-              "start" : 808827,
-              "end" : 1281680
-            },
-            {
-              "titel" : "12. Dezember",
-              "start" : 1281680,
-              "end" : 1650720
-            },
-            {
-              "titel" : "13. Dezember",
-              "start" : 1650720,
-              "end" : 2057747
-            },
-            {
-              "titel" : "14. Dezember",
-              "start" : 2057747,
-              "end" : 2301000
-            },
-            {
-              "titel" : "15. Dezember",
-              "start" : 2301000,
-              "end" : 2676493
-            },
-            {
-              "titel" : "16. Dezember",
-              "start" : 2676493,
-              "end" : 2843747
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/2/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 3,
-          "kapitel" : [
-            {
-              "titel" : "17. Dezember",
-              "start" : 0,
-              "end" : 435120
-            },
-            {
-              "titel" : "18. Dezember",
-              "start" : 435120,
-              "end" : 682693
-            },
-            {
-              "titel" : "19. Dezember",
-              "start" : 682693,
-              "end" : 1369906
-            },
-            {
-              "titel" : "20. Dezember",
-              "start" : 1369906,
-              "end" : 1597800
-            },
-            {
-              "titel" : "21. Dezember",
-              "start" : 1597800,
-              "end" : 1897186
-            },
-            {
-              "titel" : "22. Dezember",
-              "start" : 1897186,
-              "end" : 2452800
-            },
-            {
-              "titel" : "23. Dezember",
-              "start" : 2452800,
-              "end" : 3054146
-            },
-            {
-              "titel" : "24. Dezember",
-              "start" : 3054146,
-              "end" : 4068240
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/3/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "und der 5. Advent",
       "autor" : "André Minninger",
       "hörspielskriptautor" : "André Minninger",
@@ -2651,6 +2663,143 @@
           "sprecher" : "Heikedine Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "1. Dezember",
+              "start" : 0,
+              "end" : 528880
+            },
+            {
+              "titel" : "2. Dezember",
+              "start" : 528880,
+              "end" : 1052733
+            },
+            {
+              "titel" : "3. Dezember",
+              "start" : 1052733,
+              "end" : 1392027
+            },
+            {
+              "titel" : "4. Dezember",
+              "start" : 1392027,
+              "end" : 1723400
+            },
+            {
+              "titel" : "5. Dezember",
+              "start" : 1723400,
+              "end" : 2275853
+            },
+            {
+              "titel" : "6. Dezember",
+              "start" : 2275853,
+              "end" : 2536933
+            },
+            {
+              "titel" : "7. Dezember",
+              "start" : 2536933,
+              "end" : 3046067
+            },
+            {
+              "titel" : "8. Dezember",
+              "start" : 3046067,
+              "end" : 3369320
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "9. Dezember",
+              "start" : 0,
+              "end" : 418440
+            },
+            {
+              "titel" : "10. Dezember",
+              "start" : 418440,
+              "end" : 808827
+            },
+            {
+              "titel" : "11. Dezember",
+              "start" : 808827,
+              "end" : 1281680
+            },
+            {
+              "titel" : "12. Dezember",
+              "start" : 1281680,
+              "end" : 1650720
+            },
+            {
+              "titel" : "13. Dezember",
+              "start" : 1650720,
+              "end" : 2057747
+            },
+            {
+              "titel" : "14. Dezember",
+              "start" : 2057747,
+              "end" : 2301000
+            },
+            {
+              "titel" : "15. Dezember",
+              "start" : 2301000,
+              "end" : 2676493
+            },
+            {
+              "titel" : "16. Dezember",
+              "start" : 2676493,
+              "end" : 2843747
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "17. Dezember",
+              "start" : 0,
+              "end" : 435120
+            },
+            {
+              "titel" : "18. Dezember",
+              "start" : 435120,
+              "end" : 682693
+            },
+            {
+              "titel" : "19. Dezember",
+              "start" : 682693,
+              "end" : 1369906
+            },
+            {
+              "titel" : "20. Dezember",
+              "start" : 1369906,
+              "end" : 1597800
+            },
+            {
+              "titel" : "21. Dezember",
+              "start" : 1597800,
+              "end" : 1897186
+            },
+            {
+              "titel" : "22. Dezember",
+              "start" : 1897186,
+              "end" : 2452800
+            },
+            {
+              "titel" : "23. Dezember",
+              "start" : 2452800,
+              "end" : 3054146
+            },
+            {
+              "titel" : "24. Dezember",
+              "start" : 3054146,
+              "end" : 4068240
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log3.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/ffmetadata.txt",
@@ -2659,155 +2808,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Noch 24 Stunden – 23. Dezember, zwölf Uhr mittags",
-              "start" : 0,
-              "end" : 432200
-            },
-            {
-              "titel" : "Noch 23 Stunden – 23. Dezember, ein Uhr mittags",
-              "start" : 432200,
-              "end" : 887973
-            },
-            {
-              "titel" : "Noch 22 Stunden – 23. Dezember, zwei Uhr mittags",
-              "start" : 887973,
-              "end" : 1325493
-            },
-            {
-              "titel" : "Noch 21 Stunden – 23 Dezember, drei Uhr nachmittags",
-              "start" : 1325493,
-              "end" : 1808987
-            },
-            {
-              "titel" : "Noch 20 Stunden – 23 Dezember, vier Uhr nachmittags",
-              "start" : 1808987,
-              "end" : 2128173
-            },
-            {
-              "titel" : "Noch 19 Stunden – 23 Dezember, fünf Uhr nachmittags",
-              "start" : 2128173,
-              "end" : 2676680
-            },
-            {
-              "titel" : "Noch 18 Stunden – 23 Dezember, sechs Uhr abends",
-              "start" : 2676680,
-              "end" : 3123987
-            },
-            {
-              "titel" : "Noch 17 Stunden – 23 Dezember, sieben Uhr abends",
-              "start" : 3123987,
-              "end" : 3650720
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Noch 16 Stunden – 23. Dezember, acht Uhr abends",
-              "start" : 0,
-              "end" : 452653
-            },
-            {
-              "titel" : "Noch 15 Stunden – 23. Dezember, neun Uhr abends",
-              "start" : 452653,
-              "end" : 952880
-            },
-            {
-              "titel" : "Noch 14 Stunden – 23. Dezember, zehn Uhr abends",
-              "start" : 952880,
-              "end" : 1339000
-            },
-            {
-              "titel" : "Noch 13 Stunden – 23. Dezember, elf Uhr abends",
-              "start" : 1339000,
-              "end" : 1731893
-            },
-            {
-              "titel" : "Noch 12 Stunden – 24. Dezember, Mitternacht",
-              "start" : 1731893,
-              "end" : 2041880
-            },
-            {
-              "titel" : "Noch 11 Stunden – 24. Dezember, ein Uhr nachts",
-              "start" : 2041880,
-              "end" : 2370413
-            },
-            {
-              "titel" : "Noch 10 Stunden – 24. Dezember, zwei Uhr nachts",
-              "start" : 2370413,
-              "end" : 2694627
-            },
-            {
-              "titel" : "Noch 9 Stunden – 24. Dezember, drei Uhr nachts",
-              "start" : 2694627,
-              "end" : 2881880
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/2/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 3,
-          "kapitel" : [
-            {
-              "titel" : "Noch 8 Stunden – 24. Dezember, vier Uhr morgens",
-              "start" : 0,
-              "end" : 228467
-            },
-            {
-              "titel" : "Noch 7 Stunden – 24. Dezember, fünf Uhr morgens",
-              "start" : 228467,
-              "end" : 460160
-            },
-            {
-              "titel" : "Noch 6 Stunden – 24. Dezember, sechs Uhr morgens",
-              "start" : 460160,
-              "end" : 727147
-            },
-            {
-              "titel" : "Noch 5 Stunden – 24. Dezember, sieben Uhr morgens",
-              "start" : 727147,
-              "end" : 984053
-            },
-            {
-              "titel" : "Noch 4 Stunden – 24. Dezember, acht Uhr morgens",
-              "start" : 984053,
-              "end" : 1260013
-            },
-            {
-              "titel" : "Noch 3 Stunden – 24. Dezember, neun Uhr morgens",
-              "start" : 1260013,
-              "end" : 1819947
-            },
-            {
-              "titel" : "Noch 2 Stunden – 24. Dezember, zehn Uhr vormittags",
-              "start" : 1819947,
-              "end" : 2827160
-            },
-            {
-              "titel" : "Noch 1 Stunde – 24. Dezember, elf Uhr vormittags",
-              "start" : 2827160,
-              "end" : 3360800
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/3/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "Stille Nacht, düstere Nacht",
       "autor" : "Hendrik Buchna",
       "hörspielskriptautor" : "André Minninger",
@@ -3009,6 +3009,143 @@
           "sprecher" : "Marianne Bernhardt"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Noch 24 Stunden – 23. Dezember, zwölf Uhr mittags",
+              "start" : 0,
+              "end" : 432200
+            },
+            {
+              "titel" : "Noch 23 Stunden – 23. Dezember, ein Uhr mittags",
+              "start" : 432200,
+              "end" : 887973
+            },
+            {
+              "titel" : "Noch 22 Stunden – 23. Dezember, zwei Uhr mittags",
+              "start" : 887973,
+              "end" : 1325493
+            },
+            {
+              "titel" : "Noch 21 Stunden – 23 Dezember, drei Uhr nachmittags",
+              "start" : 1325493,
+              "end" : 1808987
+            },
+            {
+              "titel" : "Noch 20 Stunden – 23 Dezember, vier Uhr nachmittags",
+              "start" : 1808987,
+              "end" : 2128173
+            },
+            {
+              "titel" : "Noch 19 Stunden – 23 Dezember, fünf Uhr nachmittags",
+              "start" : 2128173,
+              "end" : 2676680
+            },
+            {
+              "titel" : "Noch 18 Stunden – 23 Dezember, sechs Uhr abends",
+              "start" : 2676680,
+              "end" : 3123987
+            },
+            {
+              "titel" : "Noch 17 Stunden – 23 Dezember, sieben Uhr abends",
+              "start" : 3123987,
+              "end" : 3650720
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Noch 16 Stunden – 23. Dezember, acht Uhr abends",
+              "start" : 0,
+              "end" : 452653
+            },
+            {
+              "titel" : "Noch 15 Stunden – 23. Dezember, neun Uhr abends",
+              "start" : 452653,
+              "end" : 952880
+            },
+            {
+              "titel" : "Noch 14 Stunden – 23. Dezember, zehn Uhr abends",
+              "start" : 952880,
+              "end" : 1339000
+            },
+            {
+              "titel" : "Noch 13 Stunden – 23. Dezember, elf Uhr abends",
+              "start" : 1339000,
+              "end" : 1731893
+            },
+            {
+              "titel" : "Noch 12 Stunden – 24. Dezember, Mitternacht",
+              "start" : 1731893,
+              "end" : 2041880
+            },
+            {
+              "titel" : "Noch 11 Stunden – 24. Dezember, ein Uhr nachts",
+              "start" : 2041880,
+              "end" : 2370413
+            },
+            {
+              "titel" : "Noch 10 Stunden – 24. Dezember, zwei Uhr nachts",
+              "start" : 2370413,
+              "end" : 2694627
+            },
+            {
+              "titel" : "Noch 9 Stunden – 24. Dezember, drei Uhr nachts",
+              "start" : 2694627,
+              "end" : 2881880
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Noch 8 Stunden – 24. Dezember, vier Uhr morgens",
+              "start" : 0,
+              "end" : 228467
+            },
+            {
+              "titel" : "Noch 7 Stunden – 24. Dezember, fünf Uhr morgens",
+              "start" : 228467,
+              "end" : 460160
+            },
+            {
+              "titel" : "Noch 6 Stunden – 24. Dezember, sechs Uhr morgens",
+              "start" : 460160,
+              "end" : 727147
+            },
+            {
+              "titel" : "Noch 5 Stunden – 24. Dezember, sieben Uhr morgens",
+              "start" : 727147,
+              "end" : 984053
+            },
+            {
+              "titel" : "Noch 4 Stunden – 24. Dezember, acht Uhr morgens",
+              "start" : 984053,
+              "end" : 1260013
+            },
+            {
+              "titel" : "Noch 3 Stunden – 24. Dezember, neun Uhr morgens",
+              "start" : 1260013,
+              "end" : 1819947
+            },
+            {
+              "titel" : "Noch 2 Stunden – 24. Dezember, zehn Uhr vormittags",
+              "start" : 1819947,
+              "end" : 2827160
+            },
+            {
+              "titel" : "Noch 1 Stunde – 24. Dezember, elf Uhr vormittags",
+              "start" : 2827160,
+              "end" : 3360800
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/ffmetadata.txt",
@@ -3017,155 +3154,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "1. Dezember: Auf ins Winterwunderland",
-              "start" : 0,
-              "end" : 466467
-            },
-            {
-              "titel" : "2. Dezember: Tief in den Wäldern",
-              "start" : 466467,
-              "end" : 777480
-            },
-            {
-              "titel" : "3. Dezember: Licht im Dunkel",
-              "start" : 777480,
-              "end" : 1297787
-            },
-            {
-              "titel" : "4. Dezember: Böse Erinnerungen",
-              "start" : 1297787,
-              "end" : 1720960
-            },
-            {
-              "titel" : "5. Dezember: Gruß vom Krampus!",
-              "start" : 1720960,
-              "end" : 2074240
-            },
-            {
-              "titel" : "6. Dezember: Keine stille Nacht",
-              "start" : 2074240,
-              "end" : 2519587
-            },
-            {
-              "titel" : "7. Dezember: Abreisen oder bleiben",
-              "start" : 2519587,
-              "end" : 2873680
-            },
-            {
-              "titel" : "8. Dezember: (K)ein Fall für die drei ???",
-              "start" : 2873680,
-              "end" : 3271667
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "9. Dezember: Adventsdämon und Geisterkind",
-              "start" : 0,
-              "end" : 304906
-            },
-            {
-              "titel" : "10. Dezember: Ein unglaublicher Verdacht",
-              "start" : 304906,
-              "end" : 721200
-            },
-            {
-              "titel" : "11. Dezember: Bär gegen Teufel",
-              "start" : 721200,
-              "end" : 1233560
-            },
-            {
-              "titel" : "12. Dezember: Der Sessellift",
-              "start" : 1233560,
-              "end" : 1606146
-            },
-            {
-              "titel" : "13. Dezember: Gefangen im Nichts",
-              "start" : 1606146,
-              "end" : 2001853
-            },
-            {
-              "titel" : "14. Dezember: Eisnebel",
-              "start" : 2001853,
-              "end" : 2484173
-            },
-            {
-              "titel" : "15. Dezember: Überraschende Erkenntnisse",
-              "start" : 2484173,
-              "end" : 2748786
-            },
-            {
-              "titel" : "16. Dezember: Gekränkte Liebe",
-              "start" : 2748786,
-              "end" : 3143893
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/2/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 3,
-          "kapitel" : [
-            {
-              "titel" : "17. Dezember: Bitterböser Schneemann",
-              "start" : 0,
-              "end" : 384427
-            },
-            {
-              "titel" : "18. Dezember: Schatten der Vergangenheit",
-              "start" : 384427,
-              "end" : 776427
-            },
-            {
-              "titel" : "19. Dezember: Unerwartete Wendung",
-              "start" : 776427,
-              "end" : 1218773
-            },
-            {
-              "titel" : "20. Dezember: Neustart",
-              "start" : 1218773,
-              "end" : 1767920
-            },
-            {
-              "titel" : "21. Dezember: Ein Albtraum wird wahr!",
-              "start" : 1767920,
-              "end" : 2100453
-            },
-            {
-              "titel" : "22. Dezember: Die Masken fallen",
-              "start" : 2100453,
-              "end" : 2618627
-            },
-            {
-              "titel" : "23. Dezember: Auge in Auge mit dem Feind",
-              "start" : 2618627,
-              "end" : 3110867
-            },
-            {
-              "titel" : "24. Dezember: O Tannenbaum",
-              "start" : 3110867,
-              "end" : 3533293
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/3/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "O du finstere",
       "autor" : "Hendrik Buchna",
       "hörspielskriptautor" : "André Minninger",
@@ -3356,6 +3344,143 @@
           "sprecher" : "Fabian Harloff"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "1. Dezember: Auf ins Winterwunderland",
+              "start" : 0,
+              "end" : 466467
+            },
+            {
+              "titel" : "2. Dezember: Tief in den Wäldern",
+              "start" : 466467,
+              "end" : 777480
+            },
+            {
+              "titel" : "3. Dezember: Licht im Dunkel",
+              "start" : 777480,
+              "end" : 1297787
+            },
+            {
+              "titel" : "4. Dezember: Böse Erinnerungen",
+              "start" : 1297787,
+              "end" : 1720960
+            },
+            {
+              "titel" : "5. Dezember: Gruß vom Krampus!",
+              "start" : 1720960,
+              "end" : 2074240
+            },
+            {
+              "titel" : "6. Dezember: Keine stille Nacht",
+              "start" : 2074240,
+              "end" : 2519587
+            },
+            {
+              "titel" : "7. Dezember: Abreisen oder bleiben",
+              "start" : 2519587,
+              "end" : 2873680
+            },
+            {
+              "titel" : "8. Dezember: (K)ein Fall für die drei ???",
+              "start" : 2873680,
+              "end" : 3271667
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "9. Dezember: Adventsdämon und Geisterkind",
+              "start" : 0,
+              "end" : 304906
+            },
+            {
+              "titel" : "10. Dezember: Ein unglaublicher Verdacht",
+              "start" : 304906,
+              "end" : 721200
+            },
+            {
+              "titel" : "11. Dezember: Bär gegen Teufel",
+              "start" : 721200,
+              "end" : 1233560
+            },
+            {
+              "titel" : "12. Dezember: Der Sessellift",
+              "start" : 1233560,
+              "end" : 1606146
+            },
+            {
+              "titel" : "13. Dezember: Gefangen im Nichts",
+              "start" : 1606146,
+              "end" : 2001853
+            },
+            {
+              "titel" : "14. Dezember: Eisnebel",
+              "start" : 2001853,
+              "end" : 2484173
+            },
+            {
+              "titel" : "15. Dezember: Überraschende Erkenntnisse",
+              "start" : 2484173,
+              "end" : 2748786
+            },
+            {
+              "titel" : "16. Dezember: Gekränkte Liebe",
+              "start" : 2748786,
+              "end" : 3143893
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "17. Dezember: Bitterböser Schneemann",
+              "start" : 0,
+              "end" : 384427
+            },
+            {
+              "titel" : "18. Dezember: Schatten der Vergangenheit",
+              "start" : 384427,
+              "end" : 776427
+            },
+            {
+              "titel" : "19. Dezember: Unerwartete Wendung",
+              "start" : 776427,
+              "end" : 1218773
+            },
+            {
+              "titel" : "20. Dezember: Neustart",
+              "start" : 1218773,
+              "end" : 1767920
+            },
+            {
+              "titel" : "21. Dezember: Ein Albtraum wird wahr!",
+              "start" : 1767920,
+              "end" : 2100453
+            },
+            {
+              "titel" : "22. Dezember: Die Masken fallen",
+              "start" : 2100453,
+              "end" : 2618627
+            },
+            {
+              "titel" : "23. Dezember: Auge in Auge mit dem Feind",
+              "start" : 2618627,
+              "end" : 3110867
+            },
+            {
+              "titel" : "24. Dezember: O Tannenbaum",
+              "start" : 3110867,
+              "end" : 3533293
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log3.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/ffmetadata.txt",
@@ -3364,146 +3489,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Tag 01: Winterwunderland",
-              "start" : 0,
-              "end" : 483987
-            },
-            {
-              "titel" : "Tag 02: Angriff auf Santa Claus",
-              "start" : 483987,
-              "end" : 634960
-            },
-            {
-              "titel" : "Tag 03: Sabotage",
-              "start" : 634960,
-              "end" : 950920
-            },
-            {
-              "titel" : "Tag 04: Ein Sack voller Geheimnisse",
-              "start" : 950920,
-              "end" : 1342133
-            },
-            {
-              "titel" : "Tag 05: 36 x Elf",
-              "start" : 1342133,
-              "end" : 1805067
-            },
-            {
-              "titel" : "Tag 06: Bruder Justus",
-              "start" : 1805067,
-              "end" : 2202560
-            },
-            {
-              "titel" : "Tag 07: Elf gegen drei",
-              "start" : 2202560,
-              "end" : 2448800
-            },
-            {
-              "titel" : "Tag 08: Märchenstunde",
-              "start" : 2448800,
-              "end" : 2705213
-            },
-            {
-              "titel" : "Tag 09: Köder mit Schleife",
-              "start" : 2705213,
-              "end" : 3227933
-            },
-            {
-              "titel" : "Tag 10: Auf frischer Tat",
-              "start" : 3227933,
-              "end" : 3552400
-            },
-            {
-              "titel" : "Tag 11: Kurzfinger",
-              "start" : 3552400,
-              "end" : 3785267
-            },
-            {
-              "titel" : "Tag 12: Der Alligator",
-              "start" : 3785267,
-              "end" : 4156227
-            },
-            {
-              "titel" : "Tag 13: Eine schräge Nachtmusik",
-              "start" : 4156227,
-              "end" : 4545373
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Tag 14: Die magische Laterne",
-              "start" : 0,
-              "end" : 396960
-            },
-            {
-              "titel" : "Tag 15: 96930 Arctic Circle",
-              "start" : 396960,
-              "end" : 810973
-            },
-            {
-              "titel" : "Tag 16: Die Übergabe",
-              "start" : 810973,
-              "end" : 1187973
-            },
-            {
-              "titel" : "Tag 17: Schritte im Dunkeln",
-              "start" : 1187973,
-              "end" : 1566493
-            },
-            {
-              "titel" : "Tag 18: Eine schreckliche Überraschung",
-              "start" : 1566493,
-              "end" : 2015493
-            },
-            {
-              "titel" : "Tag 19: Die Frau vom Polarkreis",
-              "start" : 2015493,
-              "end" : 2446413
-            },
-            {
-              "titel" : "Tag 20: Elf auf der Flucht",
-              "start" : 2446413,
-              "end" : 2969680
-            },
-            {
-              "titel" : "Tag 21: Verfolgte Verbrecher",
-              "start" : 2969680,
-              "end" : 3329387
-            },
-            {
-              "titel" : "Tag 22: Im Würgegriff der Rentiere",
-              "start" : 3329387,
-              "end" : 3695293
-            },
-            {
-              "titel" : "Tag 23: Nächstes Weihnachten",
-              "start" : 3695293,
-              "end" : 4101187
-            },
-            {
-              "titel" : "Tag 24: Mitarbeiter des Monats",
-              "start" : 4101187,
-              "end" : 4609387
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "Eine schreckliche Bescherung",
       "autor" : "Marco Sonnleitner",
       "hörspielskriptautor" : "André Minninger",
@@ -3760,6 +3745,138 @@
           "sprecher" : "Lars Schmidtke"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Tag 01: Winterwunderland",
+              "start" : 0,
+              "end" : 483987
+            },
+            {
+              "titel" : "Tag 02: Angriff auf Santa Claus",
+              "start" : 483987,
+              "end" : 634960
+            },
+            {
+              "titel" : "Tag 03: Sabotage",
+              "start" : 634960,
+              "end" : 950920
+            },
+            {
+              "titel" : "Tag 04: Ein Sack voller Geheimnisse",
+              "start" : 950920,
+              "end" : 1342133
+            },
+            {
+              "titel" : "Tag 05: 36 x Elf",
+              "start" : 1342133,
+              "end" : 1805067
+            },
+            {
+              "titel" : "Tag 06: Bruder Justus",
+              "start" : 1805067,
+              "end" : 2202560
+            },
+            {
+              "titel" : "Tag 07: Elf gegen drei",
+              "start" : 2202560,
+              "end" : 2448800
+            },
+            {
+              "titel" : "Tag 08: Märchenstunde",
+              "start" : 2448800,
+              "end" : 2705213
+            },
+            {
+              "titel" : "Tag 09: Köder mit Schleife",
+              "start" : 2705213,
+              "end" : 3227933
+            },
+            {
+              "titel" : "Tag 10: Auf frischer Tat",
+              "start" : 3227933,
+              "end" : 3552400
+            },
+            {
+              "titel" : "Tag 11: Kurzfinger",
+              "start" : 3552400,
+              "end" : 3785267
+            },
+            {
+              "titel" : "Tag 12: Der Alligator",
+              "start" : 3785267,
+              "end" : 4156227
+            },
+            {
+              "titel" : "Tag 13: Eine schräge Nachtmusik",
+              "start" : 4156227,
+              "end" : 4545373
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Tag 14: Die magische Laterne",
+              "start" : 0,
+              "end" : 396960
+            },
+            {
+              "titel" : "Tag 15: 96930 Arctic Circle",
+              "start" : 396960,
+              "end" : 810973
+            },
+            {
+              "titel" : "Tag 16: Die Übergabe",
+              "start" : 810973,
+              "end" : 1187973
+            },
+            {
+              "titel" : "Tag 17: Schritte im Dunkeln",
+              "start" : 1187973,
+              "end" : 1566493
+            },
+            {
+              "titel" : "Tag 18: Eine schreckliche Überraschung",
+              "start" : 1566493,
+              "end" : 2015493
+            },
+            {
+              "titel" : "Tag 19: Die Frau vom Polarkreis",
+              "start" : 2015493,
+              "end" : 2446413
+            },
+            {
+              "titel" : "Tag 20: Elf auf der Flucht",
+              "start" : 2446413,
+              "end" : 2969680
+            },
+            {
+              "titel" : "Tag 21: Verfolgte Verbrecher",
+              "start" : 2969680,
+              "end" : 3329387
+            },
+            {
+              "titel" : "Tag 22: Im Würgegriff der Rentiere",
+              "start" : 3329387,
+              "end" : 3695293
+            },
+            {
+              "titel" : "Tag 23: Nächstes Weihnachten",
+              "start" : 3695293,
+              "end" : 4101187
+            },
+            {
+              "titel" : "Tag 24: Mitarbeiter des Monats",
+              "start" : 4101187,
+              "end" : 4609387
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/ffmetadata.txt",
@@ -3768,155 +3885,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Tag 01 – Unbekannter Herkunft",
-              "start" : 0,
-              "end" : 569440
-            },
-            {
-              "titel" : "Tag 02 – Alarm",
-              "start" : 569440,
-              "end" : 1208960
-            },
-            {
-              "titel" : "Tag 03 – Tante Mathildas beste Freundin",
-              "start" : 1208960,
-              "end" : 1561053
-            },
-            {
-              "titel" : "Tag 04 – Ein viertes Fragezeichen",
-              "start" : 1561053,
-              "end" : 1862027
-            },
-            {
-              "titel" : "Tag 05 – Fairer Deal",
-              "start" : 1862027,
-              "end" : 2481240
-            },
-            {
-              "titel" : "Tag 06 – Auf in den Kampf",
-              "start" : 2481240,
-              "end" : 2910240
-            },
-            {
-              "titel" : "Tag 07 – Zimmer 7",
-              "start" : 2910240,
-              "end" : 3594720
-            },
-            {
-              "titel" : "Tag 08 – Erwischt!",
-              "start" : 3594720,
-              "end" : 4319693
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Tag 09 – Heftiger Streit",
-              "start" : 0,
-              "end" : 425360
-            },
-            {
-              "titel" : "Tag 10 – Dicht auf der Spur",
-              "start" : 425360,
-              "end" : 908480
-            },
-            {
-              "titel" : "Tag 11 – Hausdurchsuchung",
-              "start" : 908480,
-              "end" : 1438067
-            },
-            {
-              "titel" : "Tag 12 – Observation",
-              "start" : 1438067,
-              "end" : 1705520
-            },
-            {
-              "titel" : "Tag 13 – Bittere Realität",
-              "start" : 1705520,
-              "end" : 2078467
-            },
-            {
-              "titel" : "Tag 14 – Razzia",
-              "start" : 2078467,
-              "end" : 2353653
-            },
-            {
-              "titel" : "Tag 15 – Stich ins Wespennest",
-              "start" : 2353653,
-              "end" : 2752413
-            },
-            {
-              "titel" : "Tag 16 – Effektive Strategie",
-              "start" : 2752413,
-              "end" : 2885320
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/2/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 3,
-          "kapitel" : [
-            {
-              "titel" : "Tag 17 - Der Verzweiflung nah",
-              "start" : 0,
-              "end" : 394947
-            },
-            {
-              "titel" : "Tag 18 - Heißes Eisen",
-              "start" : 394947,
-              "end" : 1121147
-            },
-            {
-              "titel" : "Tag 19 - Wie im Märchen",
-              "start" : 1121147,
-              "end" : 1892680
-            },
-            {
-              "titel" : "Tag 20 - Verzweiflungstat",
-              "start" : 1892680,
-              "end" : 3169320
-            },
-            {
-              "titel" : "Tag 21 - Polizeieinsatz",
-              "start" : 3169320,
-              "end" : 3433040
-            },
-            {
-              "titel" : "Tag 22 - Verdacht",
-              "start" : 3433040,
-              "end" : 3810627
-            },
-            {
-              "titel" : "Tag 23 - Stockender Atem",
-              "start" : 3810627,
-              "end" : 4527920
-            },
-            {
-              "titel" : "Tag 24 - Beichte",
-              "start" : 4527920,
-              "end" : 5005253
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/3/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/3/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "Böser die Glocken nie klingen",
       "autor" : "André Minninger",
       "hörspielskriptautor" : "André Minninger",
@@ -4120,6 +4088,143 @@
           "sprecher" : "Heikedine Körting"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Tag 01 – Unbekannter Herkunft",
+              "start" : 0,
+              "end" : 569440
+            },
+            {
+              "titel" : "Tag 02 – Alarm",
+              "start" : 569440,
+              "end" : 1208960
+            },
+            {
+              "titel" : "Tag 03 – Tante Mathildas beste Freundin",
+              "start" : 1208960,
+              "end" : 1561053
+            },
+            {
+              "titel" : "Tag 04 – Ein viertes Fragezeichen",
+              "start" : 1561053,
+              "end" : 1862027
+            },
+            {
+              "titel" : "Tag 05 – Fairer Deal",
+              "start" : 1862027,
+              "end" : 2481240
+            },
+            {
+              "titel" : "Tag 06 – Auf in den Kampf",
+              "start" : 2481240,
+              "end" : 2910240
+            },
+            {
+              "titel" : "Tag 07 – Zimmer 7",
+              "start" : 2910240,
+              "end" : 3594720
+            },
+            {
+              "titel" : "Tag 08 – Erwischt!",
+              "start" : 3594720,
+              "end" : 4319693
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Tag 09 – Heftiger Streit",
+              "start" : 0,
+              "end" : 425360
+            },
+            {
+              "titel" : "Tag 10 – Dicht auf der Spur",
+              "start" : 425360,
+              "end" : 908480
+            },
+            {
+              "titel" : "Tag 11 – Hausdurchsuchung",
+              "start" : 908480,
+              "end" : 1438067
+            },
+            {
+              "titel" : "Tag 12 – Observation",
+              "start" : 1438067,
+              "end" : 1705520
+            },
+            {
+              "titel" : "Tag 13 – Bittere Realität",
+              "start" : 1705520,
+              "end" : 2078467
+            },
+            {
+              "titel" : "Tag 14 – Razzia",
+              "start" : 2078467,
+              "end" : 2353653
+            },
+            {
+              "titel" : "Tag 15 – Stich ins Wespennest",
+              "start" : 2353653,
+              "end" : 2752413
+            },
+            {
+              "titel" : "Tag 16 – Effektive Strategie",
+              "start" : 2752413,
+              "end" : 2885320
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Tag 17 - Der Verzweiflung nah",
+              "start" : 0,
+              "end" : 394947
+            },
+            {
+              "titel" : "Tag 18 - Heißes Eisen",
+              "start" : 394947,
+              "end" : 1121147
+            },
+            {
+              "titel" : "Tag 19 - Wie im Märchen",
+              "start" : 1121147,
+              "end" : 1892680
+            },
+            {
+              "titel" : "Tag 20 - Verzweiflungstat",
+              "start" : 1892680,
+              "end" : 3169320
+            },
+            {
+              "titel" : "Tag 21 - Polizeieinsatz",
+              "start" : 3169320,
+              "end" : 3433040
+            },
+            {
+              "titel" : "Tag 22 - Verdacht",
+              "start" : 3433040,
+              "end" : 3810627
+            },
+            {
+              "titel" : "Tag 23 - Stockender Atem",
+              "start" : 3810627,
+              "end" : 4527920
+            },
+            {
+              "titel" : "Tag 24 - Beichte",
+              "start" : 4527920,
+              "end" : 5005253
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/ffmetadata.txt",
@@ -4128,86 +4233,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Ein Mumienschrein in Rocky Beach",
-              "start" : 0,
-              "end" : 517133
-            },
-            {
-              "titel" : "Doch ein Auftrag",
-              "start" : 517133,
-              "end" : 766627
-            },
-            {
-              "titel" : "Ein halber Inka",
-              "start" : 766627,
-              "end" : 1054493
-            },
-            {
-              "titel" : "Frauengeschichten",
-              "start" : 1054493,
-              "end" : 1278067
-            },
-            {
-              "titel" : "Kein Entkommen",
-              "start" : 1278067,
-              "end" : 1533707
-            },
-            {
-              "titel" : "Einbruch ins Dunkel",
-              "start" : 1533707,
-              "end" : 2322920
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Eine Mumie im Luxusbad",
-              "start" : 0,
-              "end" : 701947
-            },
-            {
-              "titel" : "Willkommen daheim",
-              "start" : 701947,
-              "end" : 871147
-            },
-            {
-              "titel" : "Der Einzige Inka",
-              "start" : 871147,
-              "end" : 1402027
-            },
-            {
-              "titel" : "Stadt, Land, Fluss",
-              "start" : 1402027,
-              "end" : 1901187
-            },
-            {
-              "titel" : "Sommersonnenwendabenteuer",
-              "start" : 1901187,
-              "end" : 2237160
-            },
-            {
-              "titel" : "Tränen des Mondes",
-              "start" : 2237160,
-              "end" : 3059627
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "Das Grab der Inka-Mumie",
       "autor" : "Christoph Dittert",
       "hörspielskriptautor" : "Yona Franke",
@@ -4371,6 +4396,78 @@
           "sprecher" : "Julia Fölster"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein Mumienschrein in Rocky Beach",
+              "start" : 0,
+              "end" : 517133
+            },
+            {
+              "titel" : "Doch ein Auftrag",
+              "start" : 517133,
+              "end" : 766627
+            },
+            {
+              "titel" : "Ein halber Inka",
+              "start" : 766627,
+              "end" : 1054493
+            },
+            {
+              "titel" : "Frauengeschichten",
+              "start" : 1054493,
+              "end" : 1278067
+            },
+            {
+              "titel" : "Kein Entkommen",
+              "start" : 1278067,
+              "end" : 1533707
+            },
+            {
+              "titel" : "Einbruch ins Dunkel",
+              "start" : 1533707,
+              "end" : 2322920
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine Mumie im Luxusbad",
+              "start" : 0,
+              "end" : 701947
+            },
+            {
+              "titel" : "Willkommen daheim",
+              "start" : 701947,
+              "end" : 871147
+            },
+            {
+              "titel" : "Der Einzige Inka",
+              "start" : 871147,
+              "end" : 1402027
+            },
+            {
+              "titel" : "Stadt, Land, Fluss",
+              "start" : 1402027,
+              "end" : 1901187
+            },
+            {
+              "titel" : "Sommersonnenwendabenteuer",
+              "start" : 1901187,
+              "end" : 2237160
+            },
+            {
+              "titel" : "Tränen des Mondes",
+              "start" : 2237160,
+              "end" : 3059627
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/ffmetadata.txt",
@@ -4513,90 +4610,81 @@
           "sprecher" : "Susan Jarling, Hilla Fitzen, Nina Minninger, Marine Endemann, Zelda Jahreis, Maud Ackermann, Heikedine Körting, Stephanie Damare, Ingeborg Christiansen, Micaëla Kreißler, Theresa Underberg, Kerstin Draeger, Lennardt Krüger, Kjell Wenzel, Norma Draeger, Florian Herkenrath, Jannik Endemann, Dirk Eichhorn, Stephan Benson"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Eine rasante Flucht",
+              "start" : 0,
+              "end" : 318187
+            },
+            {
+              "titel" : "Superhelden der besonderen Art",
+              "start" : 318187,
+              "end" : 741440
+            },
+            {
+              "titel" : "Die Lauscherin",
+              "start" : 741440,
+              "end" : 1025947
+            },
+            {
+              "titel" : "Überraschende Enthüllungen",
+              "start" : 1025947,
+              "end" : 1323813
+            },
+            {
+              "titel" : "Auf Rachefeldzug",
+              "start" : 1323813,
+              "end" : 1848493
+            },
+            {
+              "titel" : "Intrigen überall",
+              "start" : 1848493,
+              "end" : 2262707
+            },
+            {
+              "titel" : "Entführt!",
+              "start" : 2262707,
+              "end" : 2755507
+            },
+            {
+              "titel" : "Schlussfolgerungen",
+              "start" : 2755507,
+              "end" : 2884867
+            },
+            {
+              "titel" : "Schein und Sein",
+              "start" : 2884867,
+              "end" : 3224013
+            },
+            {
+              "titel" : "Licht ins Dunkel",
+              "start" : 3224013,
+              "end" : 3761333
+            },
+            {
+              "titel" : "Ein Paar",
+              "start" : 3761333,
+              "end" : 4068907
+            },
+            {
+              "titel" : "Sonnenklar",
+              "start" : 4068907,
+              "end" : 4300133
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/rip_log.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/ffmetadata.txt",
-        "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/rip_log.txt",
         "cover" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/cover.png",
         "cover_itunes" : "http://a1.mzstatic.com/r40/Music127/v4/5c/bd/e2/5cbde282-7308-b942-a2d6-e7fd717b9f47/886444438681.jpg"
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Doppelter Diebstahl",
-              "start" : 0,
-              "end" : 326533
-            },
-            {
-              "titel" : "Mystik und Mythos",
-              "start" : 326533,
-              "end" : 1045907
-            },
-            {
-              "titel" : "Der Indianer",
-              "start" : 1045907,
-              "end" : 1500400
-            },
-            {
-              "titel" : "Die Zauberzwillinge",
-              "start" : 1500400,
-              "end" : 1989427
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Auftritt: Skinny!",
-              "start" : 0,
-              "end" : 421893
-            },
-            {
-              "titel" : "Der Fall Norris",
-              "start" : 421893,
-              "end" : 814973
-            },
-            {
-              "titel" : "Das Phantom, der Diebstahl und die Katze",
-              "start" : 814973,
-              "end" : 1457520
-            },
-            {
-              "titel" : "Zitrone, Minze oder Birne?",
-              "start" : 1457520,
-              "end" : 1950506
-            },
-            {
-              "titel" : "Auf der richtigen Spur?",
-              "start" : 1950506,
-              "end" : 2293880
-            },
-            {
-              "titel" : "Ohne Hindernisse?",
-              "start" : 2293880,
-              "end" : 2619760
-            },
-            {
-              "titel" : "Der einzige Gewinner",
-              "start" : 2619760,
-              "end" : 3077053
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "und das kalte Auge",
       "autor" : "Christoph Dittert",
       "hörspielskriptautor" : "Yona Franke",
@@ -4771,6 +4859,73 @@
           "sprecher" : "Birte Kretschmer"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Doppelter Diebstahl",
+              "start" : 0,
+              "end" : 326533
+            },
+            {
+              "titel" : "Mystik und Mythos",
+              "start" : 326533,
+              "end" : 1045907
+            },
+            {
+              "titel" : "Der Indianer",
+              "start" : 1045907,
+              "end" : 1500400
+            },
+            {
+              "titel" : "Die Zauberzwillinge",
+              "start" : 1500400,
+              "end" : 1989427
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Auftritt: Skinny!",
+              "start" : 0,
+              "end" : 421893
+            },
+            {
+              "titel" : "Der Fall Norris",
+              "start" : 421893,
+              "end" : 814973
+            },
+            {
+              "titel" : "Das Phantom, der Diebstahl und die Katze",
+              "start" : 814973,
+              "end" : 1457520
+            },
+            {
+              "titel" : "Zitrone, Minze oder Birne?",
+              "start" : 1457520,
+              "end" : 1950506
+            },
+            {
+              "titel" : "Auf der richtigen Spur?",
+              "start" : 1950506,
+              "end" : 2293880
+            },
+            {
+              "titel" : "Ohne Hindernisse?",
+              "start" : 2293880,
+              "end" : 2619760
+            },
+            {
+              "titel" : "Der einzige Gewinner",
+              "start" : 2619760,
+              "end" : 3077053
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/ffmetadata.txt",
@@ -4779,96 +4934,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Prolog",
-              "start" : 0,
-              "end" : 112213
-            },
-            {
-              "titel" : "Auf zum Zirkus",
-              "start" : 112213,
-              "end" : 307867
-            },
-            {
-              "titel" : "Haltet den Dieb",
-              "start" : 307867,
-              "end" : 828760
-            },
-            {
-              "titel" : "Fünf Schuss — fünf Treffer",
-              "start" : 828760,
-              "end" : 1086160
-            },
-            {
-              "titel" : "Der Löwe ist los",
-              "start" : 1086160,
-              "end" : 1351960
-            },
-            {
-              "titel" : "Eine Pechsträhne",
-              "start" : 1351960,
-              "end" : 1659760
-            },
-            {
-              "titel" : "Andy wundert sich",
-              "start" : 1659760,
-              "end" : 2349640
-            },
-            {
-              "titel" : "Der Mann mit der Tätowierung",
-              "start" : 2349640,
-              "end" : 2641800
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "In der Falle",
-              "start" : 0,
-              "end" : 557093
-            },
-            {
-              "titel" : "Justus kombiniert",
-              "start" : 557093,
-              "end" : 1192707
-            },
-            {
-              "titel" : "Nächtliche Jagd",
-              "start" : 1192707,
-              "end" : 1558400
-            },
-            {
-              "titel" : "Bart ab!",
-              "start" : 1558400,
-              "end" : 1774000
-            },
-            {
-              "titel" : "Ein seltsamer Anblick",
-              "start" : 1774000,
-              "end" : 2213840
-            },
-            {
-              "titel" : "Der Räuber wird entlarvt",
-              "start" : 2213840,
-              "end" : 2675787
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "und die schwarze Katze",
       "autor" : "William Arden",
       "hörspielskriptautor" : "André Minninger",
@@ -5038,6 +5103,88 @@
           "sprecher" : "Timo Alexander Wenzel"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Prolog",
+              "start" : 0,
+              "end" : 112213
+            },
+            {
+              "titel" : "Auf zum Zirkus",
+              "start" : 112213,
+              "end" : 307867
+            },
+            {
+              "titel" : "Haltet den Dieb",
+              "start" : 307867,
+              "end" : 828760
+            },
+            {
+              "titel" : "Fünf Schuss — fünf Treffer",
+              "start" : 828760,
+              "end" : 1086160
+            },
+            {
+              "titel" : "Der Löwe ist los",
+              "start" : 1086160,
+              "end" : 1351960
+            },
+            {
+              "titel" : "Eine Pechsträhne",
+              "start" : 1351960,
+              "end" : 1659760
+            },
+            {
+              "titel" : "Andy wundert sich",
+              "start" : 1659760,
+              "end" : 2349640
+            },
+            {
+              "titel" : "Der Mann mit der Tätowierung",
+              "start" : 2349640,
+              "end" : 2641800
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "In der Falle",
+              "start" : 0,
+              "end" : 557093
+            },
+            {
+              "titel" : "Justus kombiniert",
+              "start" : 557093,
+              "end" : 1192707
+            },
+            {
+              "titel" : "Nächtliche Jagd",
+              "start" : 1192707,
+              "end" : 1558400
+            },
+            {
+              "titel" : "Bart ab!",
+              "start" : 1558400,
+              "end" : 1774000
+            },
+            {
+              "titel" : "Ein seltsamer Anblick",
+              "start" : 1774000,
+              "end" : 2213840
+            },
+            {
+              "titel" : "Der Räuber wird entlarvt",
+              "start" : 2213840,
+              "end" : 2675787
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/ffmetadata.txt",
@@ -5046,106 +5193,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Prolog",
-              "start" : 0,
-              "end" : 68400
-            },
-            {
-              "titel" : "Sandfield",
-              "start" : 68400,
-              "end" : 317720
-            },
-            {
-              "titel" : "Brother Jonathan",
-              "start" : 317720,
-              "end" : 1169600
-            },
-            {
-              "titel" : "Tauchgang",
-              "start" : 1169600,
-              "end" : 1466533
-            },
-            {
-              "titel" : "Hai-Alarm",
-              "start" : 1466533,
-              "end" : 1729467
-            },
-            {
-              "titel" : "Pläne für Sandfield",
-              "start" : 1729467,
-              "end" : 2182733
-            },
-            {
-              "titel" : "Schatzsuche!",
-              "start" : 2182733,
-              "end" : 2513693
-            },
-            {
-              "titel" : "Paprika",
-              "start" : 2513693,
-              "end" : 2852240
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Am Abgrund",
-              "start" : 0,
-              "end" : 471347
-            },
-            {
-              "titel" : "Afrika",
-              "start" : 471347,
-              "end" : 737973
-            },
-            {
-              "titel" : "Abbruchgefährdet",
-              "start" : 737973,
-              "end" : 1350440
-            },
-            {
-              "titel" : "Goldrausch",
-              "start" : 1350440,
-              "end" : 1531307
-            },
-            {
-              "titel" : "Verdacht",
-              "start" : 1531307,
-              "end" : 2102547
-            },
-            {
-              "titel" : "Elaine",
-              "start" : 2102547,
-              "end" : 2621133
-            },
-            {
-              "titel" : "Countdown",
-              "start" : 2621133,
-              "end" : 3035933
-            },
-            {
-              "titel" : "Glück im Unglück",
-              "start" : 3035933,
-              "end" : 3273800
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "und das versunkene Schiff",
       "autor" : "André Marx",
       "hörspielskriptautor" : "Kai Schwind",
@@ -5300,6 +5347,98 @@
           "sprecher" : "Pierre Brand"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Prolog",
+              "start" : 0,
+              "end" : 68400
+            },
+            {
+              "titel" : "Sandfield",
+              "start" : 68400,
+              "end" : 317720
+            },
+            {
+              "titel" : "Brother Jonathan",
+              "start" : 317720,
+              "end" : 1169600
+            },
+            {
+              "titel" : "Tauchgang",
+              "start" : 1169600,
+              "end" : 1466533
+            },
+            {
+              "titel" : "Hai-Alarm",
+              "start" : 1466533,
+              "end" : 1729467
+            },
+            {
+              "titel" : "Pläne für Sandfield",
+              "start" : 1729467,
+              "end" : 2182733
+            },
+            {
+              "titel" : "Schatzsuche!",
+              "start" : 2182733,
+              "end" : 2513693
+            },
+            {
+              "titel" : "Paprika",
+              "start" : 2513693,
+              "end" : 2852240
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Am Abgrund",
+              "start" : 0,
+              "end" : 471347
+            },
+            {
+              "titel" : "Afrika",
+              "start" : 471347,
+              "end" : 737973
+            },
+            {
+              "titel" : "Abbruchgefährdet",
+              "start" : 737973,
+              "end" : 1350440
+            },
+            {
+              "titel" : "Goldrausch",
+              "start" : 1350440,
+              "end" : 1531307
+            },
+            {
+              "titel" : "Verdacht",
+              "start" : 1531307,
+              "end" : 2102547
+            },
+            {
+              "titel" : "Elaine",
+              "start" : 2102547,
+              "end" : 2621133
+            },
+            {
+              "titel" : "Countdown",
+              "start" : 2621133,
+              "end" : 3035933
+            },
+            {
+              "titel" : "Glück im Unglück",
+              "start" : 3035933,
+              "end" : 3273800
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/ffmetadata.txt",
@@ -5308,76 +5447,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Prolog",
-              "start" : 0,
-              "end" : 70560
-            },
-            {
-              "titel" : "Anruf aus Hollywood",
-              "start" : 70560,
-              "end" : 342933
-            },
-            {
-              "titel" : "Ein echter Smaragd?",
-              "start" : 342933,
-              "end" : 1343907
-            },
-            {
-              "titel" : "Wiedersehen am Set",
-              "start" : 1343907,
-              "end" : 1959800
-            },
-            {
-              "titel" : "Monsterpuppen",
-              "start" : 1959800,
-              "end" : 2444173
-            },
-            {
-              "titel" : "Gerald liebt Besuch",
-              "start" : 2444173,
-              "end" : 3019707
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Ein wunder Punkt",
-              "start" : 0,
-              "end" : 565146
-            },
-            {
-              "titel" : "Das Strandhaus",
-              "start" : 565146,
-              "end" : 1324360
-            },
-            {
-              "titel" : "Im Horrormuseum",
-              "start" : 1324360,
-              "end" : 1848946
-            },
-            {
-              "titel" : "Neuigkeiten für Mr. Kushing",
-              "start" : 1848946,
-              "end" : 2733640
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "und der dreiäugige Totenkopf",
       "autor" : "Ivar Leon Menger, John Beckmann",
       "hörspielskriptautor" : "Ivar Leon Menger, John Beckmann",
@@ -5518,6 +5587,68 @@
           "sprecher" : "Timo Alexander Wenzel"
         }
       ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Prolog",
+              "start" : 0,
+              "end" : 70560
+            },
+            {
+              "titel" : "Anruf aus Hollywood",
+              "start" : 70560,
+              "end" : 342933
+            },
+            {
+              "titel" : "Ein echter Smaragd?",
+              "start" : 342933,
+              "end" : 1343907
+            },
+            {
+              "titel" : "Wiedersehen am Set",
+              "start" : 1343907,
+              "end" : 1959800
+            },
+            {
+              "titel" : "Monsterpuppen",
+              "start" : 1959800,
+              "end" : 2444173
+            },
+            {
+              "titel" : "Gerald liebt Besuch",
+              "start" : 2444173,
+              "end" : 3019707
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Ein wunder Punkt",
+              "start" : 0,
+              "end" : 565146
+            },
+            {
+              "titel" : "Das Strandhaus",
+              "start" : 565146,
+              "end" : 1324360
+            },
+            {
+              "titel" : "Im Horrormuseum",
+              "start" : 1324360,
+              "end" : 1848946
+            },
+            {
+              "titel" : "Neuigkeiten für Mr. Kushing",
+              "start" : 1848946,
+              "end" : 2733640
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt"
+        }
+      ],
       "links" : {
         "json" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json",
         "ffmetadata" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/ffmetadata.txt",
@@ -5526,126 +5657,6 @@
       }
     },
     {
-      "teile" : [
-        {
-          "teilNummer" : 1,
-          "kapitel" : [
-            {
-              "titel" : "Prolog",
-              "start" : 0,
-              "end" : 105067
-            },
-            {
-              "titel" : "Maya-Kunst",
-              "start" : 105067,
-              "end" : 470347
-            },
-            {
-              "titel" : "Zufall oder Missverständnis?",
-              "start" : 470347,
-              "end" : 676293
-            },
-            {
-              "titel" : "Ein krasser Typ",
-              "start" : 676293,
-              "end" : 1079867
-            },
-            {
-              "titel" : "Tunchan",
-              "start" : 1079867,
-              "end" : 1460320
-            },
-            {
-              "titel" : "Yaxché",
-              "start" : 1460320,
-              "end" : 2107547
-            },
-            {
-              "titel" : "Schriftzeichen",
-              "start" : 2107547,
-              "end" : 2522907
-            },
-            {
-              "titel" : "Das kalte Tor",
-              "start" : 2522907,
-              "end" : 2836227
-            },
-            {
-              "titel" : "Sheryl",
-              "start" : 2836227,
-              "end" : 3120467
-            },
-            {
-              "titel" : "Zachary",
-              "start" : 3120467,
-              "end" : 3351587
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/1/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/1/rip_log.txt"
-          }
-        },
-        {
-          "teilNummer" : 2,
-          "kapitel" : [
-            {
-              "titel" : "Sunset Motel",
-              "start" : 0,
-              "end" : 376546
-            },
-            {
-              "titel" : "Die Drei-Teile-Theorie",
-              "start" : 376546,
-              "end" : 820146
-            },
-            {
-              "titel" : "Tuyuchim",
-              "start" : 820146,
-              "end" : 1080946
-            },
-            {
-              "titel" : "Alle für einen?",
-              "start" : 1080946,
-              "end" : 1441440
-            },
-            {
-              "titel" : "Zum Clubhaus",
-              "start" : 1441440,
-              "end" : 1676626
-            },
-            {
-              "titel" : "Überraschender Besuch",
-              "start" : 1676626,
-              "end" : 1846146
-            },
-            {
-              "titel" : "Im Urwald?",
-              "start" : 1846146,
-              "end" : 2136546
-            },
-            {
-              "titel" : "Nach Mexiko",
-              "start" : 2136546,
-              "end" : 2487226
-            },
-            {
-              "titel" : "Blaue Wolke",
-              "start" : 2487226,
-              "end" : 2844960
-            },
-            {
-              "titel" : "Das große Geheimnis",
-              "start" : 2844960,
-              "end" : 3418800
-            }
-          ],
-          "links" : {
-            "json" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/2/metadata.json",
-            "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/2/rip_log.txt"
-          }
-        }
-      ],
       "titel" : "und das Grab der Maya",
       "autor" : "André Marx",
       "hörspielskriptautor" : "Kai Schwind",
@@ -5814,6 +5825,118 @@
         {
           "rolle" : "Nachrichtensprecher",
           "sprecher" : "André Schünke"
+        }
+      ],
+      "medien" : [
+        {
+          "tracks" : [
+            {
+              "titel" : "Prolog",
+              "start" : 0,
+              "end" : 105067
+            },
+            {
+              "titel" : "Maya-Kunst",
+              "start" : 105067,
+              "end" : 470347
+            },
+            {
+              "titel" : "Zufall oder Missverständnis?",
+              "start" : 470347,
+              "end" : 676293
+            },
+            {
+              "titel" : "Ein krasser Typ",
+              "start" : 676293,
+              "end" : 1079867
+            },
+            {
+              "titel" : "Tunchan",
+              "start" : 1079867,
+              "end" : 1460320
+            },
+            {
+              "titel" : "Yaxché",
+              "start" : 1460320,
+              "end" : 2107547
+            },
+            {
+              "titel" : "Schriftzeichen",
+              "start" : 2107547,
+              "end" : 2522907
+            },
+            {
+              "titel" : "Das kalte Tor",
+              "start" : 2522907,
+              "end" : 2836227
+            },
+            {
+              "titel" : "Sheryl",
+              "start" : 2836227,
+              "end" : 3120467
+            },
+            {
+              "titel" : "Zachary",
+              "start" : 3120467,
+              "end" : 3351587
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt"
+        },
+        {
+          "tracks" : [
+            {
+              "titel" : "Sunset Motel",
+              "start" : 0,
+              "end" : 376546
+            },
+            {
+              "titel" : "Die Drei-Teile-Theorie",
+              "start" : 376546,
+              "end" : 820146
+            },
+            {
+              "titel" : "Tuyuchim",
+              "start" : 820146,
+              "end" : 1080946
+            },
+            {
+              "titel" : "Alle für einen?",
+              "start" : 1080946,
+              "end" : 1441440
+            },
+            {
+              "titel" : "Zum Clubhaus",
+              "start" : 1441440,
+              "end" : 1676626
+            },
+            {
+              "titel" : "Überraschender Besuch",
+              "start" : 1676626,
+              "end" : 1846146
+            },
+            {
+              "titel" : "Im Urwald?",
+              "start" : 1846146,
+              "end" : 2136546
+            },
+            {
+              "titel" : "Nach Mexiko",
+              "start" : 2136546,
+              "end" : 2487226
+            },
+            {
+              "titel" : "Blaue Wolke",
+              "start" : 2487226,
+              "end" : 2844960
+            },
+            {
+              "titel" : "Das große Geheimnis",
+              "start" : 2844960,
+              "end" : 3418800
+            }
+          ],
+          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt"
         }
       ],
       "links" : {


### PR DESCRIPTION
### Code:
* Added "medium" to object model to represent "medium" table in relational model
* Implemented object model instantiation from database
* Implemented JSON export from database

### New subcommand:
* `export json`: Export object model as JSON files.

### Metadata:
* Exported object model generated from database as JSON files to *metadata/json/*