### PR TITLE
Add web index for Apple Music and Spotify IDs

### DIFF
--- a/code/dreimetadaten/Command/Command.swift
+++ b/code/dreimetadaten/Command/Command.swift
@@ -32,21 +32,25 @@ struct Command: ParsableCommand {
 	static let webURL = URL(string: "http://dreimetadaten.de")!
 	static let webDir = url(projectRelativePath: "web")
 	private static let webDataDirRelativePath = "data"
-	static var webDataURL: URL { webURL.appendingPathComponent(webDataDirRelativePath) }
-	static var webDataDir: URL { webDir.appendingPathComponent(webDataDirRelativePath) }
+	static var webDataURL = webURL.appendingPathComponent(webDataDirRelativePath)
+	static var webDataDir = webDir.appendingPathComponent(webDataDirRelativePath)
+	static var webIndexDir = webDir.appendingPathComponent("index")
 	
 	static func url(projectRelativePath projectDirRelativePath: String) -> URL {
 		let dest = URL(fileURLWithPath: projectDirRelativePath, relativeTo: projectDir)
 		let base = workingDir
+		let workingDirRelativePath = relativePath(of: dest, toDirectory: base)
+		return URL(fileURLWithPath: workingDirRelativePath, relativeTo: workingDir)
+	}
+	static func relativePath(of dest: URL, toDirectory base: URL) -> String {
 		let destComponents = dest.standardizedFileURL.pathComponents
 		let baseComponents = base.standardizedFileURL.pathComponents
 		var index = 0
 		while index < destComponents.count && index < baseComponents.count && destComponents[index] == baseComponents[index] {
 			index += 1
 		}
-		var workingDirRelativeComponents = Array(repeating: "..", count: baseComponents.count - index)
-		workingDirRelativeComponents.append(contentsOf: destComponents[index...])
-		let workingDirRelativePath = workingDirRelativeComponents.joined(separator: "/")
-		return URL(fileURLWithPath: workingDirRelativePath, relativeTo: workingDir)
+		var relComponents = Array(repeating: "..", count: baseComponents.count - index)
+		relComponents.append(contentsOf: destComponents[index...])
+		return relComponents.joined(separator: "/")
 	}
 }

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -1,3 +1,4 @@
 AddDefaultCharset utf-8
 AddType 'application/json; charset=UTF-8' .json
 AddType 'text/plain; charset=UTF-8' .swift
+ErrorDocument 404 default

--- a/web/index/apple-music/1092501646
+++ b/web/index/apple-music/1092501646
@@ -1,0 +1,1 @@
+../../data/Serie/043/metadata.json

--- a/web/index/apple-music/1092502471
+++ b/web/index/apple-music/1092502471
@@ -1,0 +1,1 @@
+../../data/Serie/050/metadata.json

--- a/web/index/apple-music/1092503309
+++ b/web/index/apple-music/1092503309
@@ -1,0 +1,1 @@
+../../data/Serie/047/metadata.json

--- a/web/index/apple-music/1092503380
+++ b/web/index/apple-music/1092503380
@@ -1,0 +1,1 @@
+../../data/Serie/049/metadata.json

--- a/web/index/apple-music/1092503388
+++ b/web/index/apple-music/1092503388
@@ -1,0 +1,1 @@
+../../data/Serie/046/metadata.json

--- a/web/index/apple-music/1092504628
+++ b/web/index/apple-music/1092504628
@@ -1,0 +1,1 @@
+../../data/Serie/045/metadata.json

--- a/web/index/apple-music/1092518600
+++ b/web/index/apple-music/1092518600
@@ -1,0 +1,1 @@
+../../data/Serie/048/metadata.json

--- a/web/index/apple-music/1092527886
+++ b/web/index/apple-music/1092527886
@@ -1,0 +1,1 @@
+../../data/Serie/041/metadata.json

--- a/web/index/apple-music/1092528550
+++ b/web/index/apple-music/1092528550
@@ -1,0 +1,1 @@
+../../data/Serie/007/metadata.json

--- a/web/index/apple-music/1092528575
+++ b/web/index/apple-music/1092528575
@@ -1,0 +1,1 @@
+../../data/Serie/005/metadata.json

--- a/web/index/apple-music/1092529538
+++ b/web/index/apple-music/1092529538
@@ -1,0 +1,1 @@
+../../data/Serie/010/metadata.json

--- a/web/index/apple-music/1092529766
+++ b/web/index/apple-music/1092529766
@@ -1,0 +1,1 @@
+../../data/Serie/018/metadata.json

--- a/web/index/apple-music/1092529767
+++ b/web/index/apple-music/1092529767
@@ -1,0 +1,1 @@
+../../data/Serie/037/metadata.json

--- a/web/index/apple-music/1092529875
+++ b/web/index/apple-music/1092529875
@@ -1,0 +1,1 @@
+../../data/Serie/001/metadata.json

--- a/web/index/apple-music/1092529878
+++ b/web/index/apple-music/1092529878
@@ -1,0 +1,1 @@
+../../data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json

--- a/web/index/apple-music/1092530263
+++ b/web/index/apple-music/1092530263
@@ -1,0 +1,1 @@
+../../data/Serie/022/metadata.json

--- a/web/index/apple-music/1092530380
+++ b/web/index/apple-music/1092530380
@@ -1,0 +1,1 @@
+../../data/Serie/034/metadata.json

--- a/web/index/apple-music/1092530740
+++ b/web/index/apple-music/1092530740
@@ -1,0 +1,1 @@
+../../data/Serie/021/metadata.json

--- a/web/index/apple-music/1092530929
+++ b/web/index/apple-music/1092530929
@@ -1,0 +1,1 @@
+../../data/Serie/002/metadata.json

--- a/web/index/apple-music/1092531572
+++ b/web/index/apple-music/1092531572
@@ -1,0 +1,1 @@
+../../data/Serie/003/metadata.json

--- a/web/index/apple-music/1092531916
+++ b/web/index/apple-music/1092531916
@@ -1,0 +1,1 @@
+../../data/Serie/040/metadata.json

--- a/web/index/apple-music/1092532671
+++ b/web/index/apple-music/1092532671
@@ -1,0 +1,1 @@
+../../data/Serie/044/metadata.json

--- a/web/index/apple-music/1092533372
+++ b/web/index/apple-music/1092533372
@@ -1,0 +1,1 @@
+../../data/Serie/020/metadata.json

--- a/web/index/apple-music/1092533811
+++ b/web/index/apple-music/1092533811
@@ -1,0 +1,1 @@
+../../data/Serie/015/metadata.json

--- a/web/index/apple-music/1092534668
+++ b/web/index/apple-music/1092534668
@@ -1,0 +1,1 @@
+../../data/Serie/013/metadata.json

--- a/web/index/apple-music/1092534669
+++ b/web/index/apple-music/1092534669
@@ -1,0 +1,1 @@
+../../data/Serie/006/metadata.json

--- a/web/index/apple-music/1092534775
+++ b/web/index/apple-music/1092534775
@@ -1,0 +1,1 @@
+../../data/Serie/038/metadata.json

--- a/web/index/apple-music/1092534844
+++ b/web/index/apple-music/1092534844
@@ -1,0 +1,1 @@
+../../data/Serie/028/metadata.json

--- a/web/index/apple-music/1092535180
+++ b/web/index/apple-music/1092535180
@@ -1,0 +1,1 @@
+../../data/Serie/011/metadata.json

--- a/web/index/apple-music/1092535345
+++ b/web/index/apple-music/1092535345
@@ -1,0 +1,1 @@
+../../data/Serie/025/metadata.json

--- a/web/index/apple-music/1092535668
+++ b/web/index/apple-music/1092535668
@@ -1,0 +1,1 @@
+../../data/Serie/032/metadata.json

--- a/web/index/apple-music/1092535830
+++ b/web/index/apple-music/1092535830
@@ -1,0 +1,1 @@
+../../data/Serie/027/metadata.json

--- a/web/index/apple-music/1092535832
+++ b/web/index/apple-music/1092535832
@@ -1,0 +1,1 @@
+../../data/Serie/031/metadata.json

--- a/web/index/apple-music/1092537257
+++ b/web/index/apple-music/1092537257
@@ -1,0 +1,1 @@
+../../data/Serie/036/metadata.json

--- a/web/index/apple-music/1092537786
+++ b/web/index/apple-music/1092537786
@@ -1,0 +1,1 @@
+../../data/Serie/012/metadata.json

--- a/web/index/apple-music/1092537787
+++ b/web/index/apple-music/1092537787
@@ -1,0 +1,1 @@
+../../data/Serie/019/metadata.json

--- a/web/index/apple-music/1092537830
+++ b/web/index/apple-music/1092537830
@@ -1,0 +1,1 @@
+../../data/Serie/030/metadata.json

--- a/web/index/apple-music/1092538040
+++ b/web/index/apple-music/1092538040
@@ -1,0 +1,1 @@
+../../data/Serie/009/metadata.json

--- a/web/index/apple-music/1092538230
+++ b/web/index/apple-music/1092538230
@@ -1,0 +1,1 @@
+../../data/Serie/029/metadata.json

--- a/web/index/apple-music/1092538232
+++ b/web/index/apple-music/1092538232
@@ -1,0 +1,1 @@
+../../data/Serie/039/metadata.json

--- a/web/index/apple-music/1092538233
+++ b/web/index/apple-music/1092538233
@@ -1,0 +1,1 @@
+../../data/Serie/023/metadata.json

--- a/web/index/apple-music/1092538504
+++ b/web/index/apple-music/1092538504
@@ -1,0 +1,1 @@
+../../data/Serie/008/metadata.json

--- a/web/index/apple-music/1092538531
+++ b/web/index/apple-music/1092538531
@@ -1,0 +1,1 @@
+../../data/Serie/042/metadata.json

--- a/web/index/apple-music/1092538532
+++ b/web/index/apple-music/1092538532
@@ -1,0 +1,1 @@
+../../data/Spezial/High-Strung-Unter-Hochspannung/metadata.json

--- a/web/index/apple-music/1092538533
+++ b/web/index/apple-music/1092538533
@@ -1,0 +1,1 @@
+../../data/Serie/014/metadata.json

--- a/web/index/apple-music/1092538644
+++ b/web/index/apple-music/1092538644
@@ -1,0 +1,1 @@
+../../data/Serie/004/metadata.json

--- a/web/index/apple-music/1092539865
+++ b/web/index/apple-music/1092539865
@@ -1,0 +1,1 @@
+../../data/Serie/017/metadata.json

--- a/web/index/apple-music/1092539968
+++ b/web/index/apple-music/1092539968
@@ -1,0 +1,1 @@
+../../data/Serie/016/metadata.json

--- a/web/index/apple-music/1092541382
+++ b/web/index/apple-music/1092541382
@@ -1,0 +1,1 @@
+../../data/Serie/026/metadata.json

--- a/web/index/apple-music/1092541991
+++ b/web/index/apple-music/1092541991
@@ -1,0 +1,1 @@
+../../data/Serie/024/metadata.json

--- a/web/index/apple-music/1092542351
+++ b/web/index/apple-music/1092542351
@@ -1,0 +1,1 @@
+../../data/Serie/035/metadata.json

--- a/web/index/apple-music/1092546618
+++ b/web/index/apple-music/1092546618
@@ -1,0 +1,1 @@
+../../data/Kurzgeschichten/und-die-Geisterlampe/metadata.json

--- a/web/index/apple-music/1092548111
+++ b/web/index/apple-music/1092548111
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-dreiTag/metadata.json

--- a/web/index/apple-music/1092549930
+++ b/web/index/apple-music/1092549930
@@ -1,0 +1,1 @@
+../../data/Kurzgeschichten/Das-Raetsel-der-Sieben/metadata.json

--- a/web/index/apple-music/1092551507
+++ b/web/index/apple-music/1092551507
@@ -1,0 +1,1 @@
+../../data/Serie/033/metadata.json

--- a/web/index/apple-music/1110311863
+++ b/web/index/apple-music/1110311863
@@ -1,0 +1,1 @@
+../../data/Serie/052/metadata.json

--- a/web/index/apple-music/1110312706
+++ b/web/index/apple-music/1110312706
@@ -1,0 +1,1 @@
+../../data/Serie/051/metadata.json

--- a/web/index/apple-music/1110316053
+++ b/web/index/apple-music/1110316053
@@ -1,0 +1,1 @@
+../../data/Serie/053/metadata.json

--- a/web/index/apple-music/1110318637
+++ b/web/index/apple-music/1110318637
@@ -1,0 +1,1 @@
+../../data/Serie/055/metadata.json

--- a/web/index/apple-music/1110318678
+++ b/web/index/apple-music/1110318678
@@ -1,0 +1,1 @@
+../../data/Serie/054/metadata.json

--- a/web/index/apple-music/1110322633
+++ b/web/index/apple-music/1110322633
@@ -1,0 +1,1 @@
+../../data/Serie/058/metadata.json

--- a/web/index/apple-music/1110322732
+++ b/web/index/apple-music/1110322732
@@ -1,0 +1,1 @@
+../../data/Serie/057/metadata.json

--- a/web/index/apple-music/1110323229
+++ b/web/index/apple-music/1110323229
@@ -1,0 +1,1 @@
+../../data/Serie/056/metadata.json

--- a/web/index/apple-music/1110323285
+++ b/web/index/apple-music/1110323285
@@ -1,0 +1,1 @@
+../../data/Serie/059/metadata.json

--- a/web/index/apple-music/1110323342
+++ b/web/index/apple-music/1110323342
@@ -1,0 +1,1 @@
+../../data/Serie/060/metadata.json

--- a/web/index/apple-music/1110773048
+++ b/web/index/apple-music/1110773048
@@ -1,0 +1,1 @@
+../../data/Serie/061/metadata.json

--- a/web/index/apple-music/1110774403
+++ b/web/index/apple-music/1110774403
@@ -1,0 +1,1 @@
+../../data/Serie/062/metadata.json

--- a/web/index/apple-music/1110774478
+++ b/web/index/apple-music/1110774478
@@ -1,0 +1,1 @@
+../../data/Serie/064/metadata.json

--- a/web/index/apple-music/1110774845
+++ b/web/index/apple-music/1110774845
@@ -1,0 +1,1 @@
+../../data/Serie/063/metadata.json

--- a/web/index/apple-music/1110776310
+++ b/web/index/apple-music/1110776310
@@ -1,0 +1,1 @@
+../../data/Serie/065/metadata.json

--- a/web/index/apple-music/1110777991
+++ b/web/index/apple-music/1110777991
@@ -1,0 +1,1 @@
+../../data/Serie/066/metadata.json

--- a/web/index/apple-music/1110778079
+++ b/web/index/apple-music/1110778079
@@ -1,0 +1,1 @@
+../../data/Serie/067/metadata.json

--- a/web/index/apple-music/1110779156
+++ b/web/index/apple-music/1110779156
@@ -1,0 +1,1 @@
+../../data/Serie/068/metadata.json

--- a/web/index/apple-music/1110780549
+++ b/web/index/apple-music/1110780549
@@ -1,0 +1,1 @@
+../../data/Serie/069/metadata.json

--- a/web/index/apple-music/1110781480
+++ b/web/index/apple-music/1110781480
@@ -1,0 +1,1 @@
+../../data/Serie/070/metadata.json

--- a/web/index/apple-music/1112949182
+++ b/web/index/apple-music/1112949182
@@ -1,0 +1,1 @@
+../../data/Serie/071/metadata.json

--- a/web/index/apple-music/1112951262
+++ b/web/index/apple-music/1112951262
@@ -1,0 +1,1 @@
+../../data/Serie/072/metadata.json

--- a/web/index/apple-music/1112953470
+++ b/web/index/apple-music/1112953470
@@ -1,0 +1,1 @@
+../../data/Serie/074/metadata.json

--- a/web/index/apple-music/1112954575
+++ b/web/index/apple-music/1112954575
@@ -1,0 +1,1 @@
+../../data/Serie/073/metadata.json

--- a/web/index/apple-music/1112955599
+++ b/web/index/apple-music/1112955599
@@ -1,0 +1,1 @@
+../../data/Serie/075/metadata.json

--- a/web/index/apple-music/1112957080
+++ b/web/index/apple-music/1112957080
@@ -1,0 +1,1 @@
+../../data/Serie/077/metadata.json

--- a/web/index/apple-music/1112958296
+++ b/web/index/apple-music/1112958296
@@ -1,0 +1,1 @@
+../../data/Serie/076/metadata.json

--- a/web/index/apple-music/1112959233
+++ b/web/index/apple-music/1112959233
@@ -1,0 +1,1 @@
+../../data/Serie/078/metadata.json

--- a/web/index/apple-music/1112960657
+++ b/web/index/apple-music/1112960657
@@ -1,0 +1,1 @@
+../../data/Serie/080/metadata.json

--- a/web/index/apple-music/1112961664
+++ b/web/index/apple-music/1112961664
@@ -1,0 +1,1 @@
+../../data/Serie/079/metadata.json

--- a/web/index/apple-music/1112967082
+++ b/web/index/apple-music/1112967082
@@ -1,0 +1,1 @@
+../../data/Serie/083/metadata.json

--- a/web/index/apple-music/1112967184
+++ b/web/index/apple-music/1112967184
@@ -1,0 +1,1 @@
+../../data/Serie/085/metadata.json

--- a/web/index/apple-music/1112967702
+++ b/web/index/apple-music/1112967702
@@ -1,0 +1,1 @@
+../../data/Serie/081/metadata.json

--- a/web/index/apple-music/1112968659
+++ b/web/index/apple-music/1112968659
@@ -1,0 +1,1 @@
+../../data/Serie/084/metadata.json

--- a/web/index/apple-music/1112971448
+++ b/web/index/apple-music/1112971448
@@ -1,0 +1,1 @@
+../../data/Serie/082/metadata.json

--- a/web/index/apple-music/1112972302
+++ b/web/index/apple-music/1112972302
@@ -1,0 +1,1 @@
+../../data/Serie/087/metadata.json

--- a/web/index/apple-music/1112972382
+++ b/web/index/apple-music/1112972382
@@ -1,0 +1,1 @@
+../../data/Serie/086/metadata.json

--- a/web/index/apple-music/1112975061
+++ b/web/index/apple-music/1112975061
@@ -1,0 +1,1 @@
+../../data/Serie/089/metadata.json

--- a/web/index/apple-music/1112975108
+++ b/web/index/apple-music/1112975108
@@ -1,0 +1,1 @@
+../../data/Serie/088/metadata.json

--- a/web/index/apple-music/1112976055
+++ b/web/index/apple-music/1112976055
@@ -1,0 +1,1 @@
+../../data/Serie/090/metadata.json

--- a/web/index/apple-music/1112977101
+++ b/web/index/apple-music/1112977101
@@ -1,0 +1,1 @@
+../../data/Serie/091/metadata.json

--- a/web/index/apple-music/1112977700
+++ b/web/index/apple-music/1112977700
@@ -1,0 +1,1 @@
+../../data/Serie/092/metadata.json

--- a/web/index/apple-music/1112981466
+++ b/web/index/apple-music/1112981466
@@ -1,0 +1,1 @@
+../../data/Serie/093/metadata.json

--- a/web/index/apple-music/1112983262
+++ b/web/index/apple-music/1112983262
@@ -1,0 +1,1 @@
+../../data/Serie/094/metadata.json

--- a/web/index/apple-music/1112985296
+++ b/web/index/apple-music/1112985296
@@ -1,0 +1,1 @@
+../../data/Serie/095/metadata.json

--- a/web/index/apple-music/1112991670
+++ b/web/index/apple-music/1112991670
@@ -1,0 +1,1 @@
+../../data/Serie/097/metadata.json

--- a/web/index/apple-music/1112992823
+++ b/web/index/apple-music/1112992823
@@ -1,0 +1,1 @@
+../../data/Serie/096/metadata.json

--- a/web/index/apple-music/1112993619
+++ b/web/index/apple-music/1112993619
@@ -1,0 +1,1 @@
+../../data/Serie/099/metadata.json

--- a/web/index/apple-music/1112993706
+++ b/web/index/apple-music/1112993706
@@ -1,0 +1,1 @@
+../../data/Serie/098/metadata.json

--- a/web/index/apple-music/1112995195
+++ b/web/index/apple-music/1112995195
@@ -1,0 +1,1 @@
+../../data/Serie/101/metadata.json

--- a/web/index/apple-music/1112995814
+++ b/web/index/apple-music/1112995814
@@ -1,0 +1,1 @@
+../../data/Serie/102/metadata.json

--- a/web/index/apple-music/1112995942
+++ b/web/index/apple-music/1112995942
@@ -1,0 +1,1 @@
+../../data/Serie/103/metadata.json

--- a/web/index/apple-music/1112996544
+++ b/web/index/apple-music/1112996544
@@ -1,0 +1,1 @@
+../../data/Serie/105/metadata.json

--- a/web/index/apple-music/1112996835
+++ b/web/index/apple-music/1112996835
@@ -1,0 +1,1 @@
+../../data/Serie/100/metadata.json

--- a/web/index/apple-music/1112998433
+++ b/web/index/apple-music/1112998433
@@ -1,0 +1,1 @@
+../../data/Serie/104/metadata.json

--- a/web/index/apple-music/1115173891
+++ b/web/index/apple-music/1115173891
@@ -1,0 +1,1 @@
+../../data/Serie/106/metadata.json

--- a/web/index/apple-music/1115175534
+++ b/web/index/apple-music/1115175534
@@ -1,0 +1,1 @@
+../../data/Serie/107/metadata.json

--- a/web/index/apple-music/1115197863
+++ b/web/index/apple-music/1115197863
@@ -1,0 +1,1 @@
+../../data/Serie/109/metadata.json

--- a/web/index/apple-music/1115199675
+++ b/web/index/apple-music/1115199675
@@ -1,0 +1,1 @@
+../../data/Serie/110/metadata.json

--- a/web/index/apple-music/1115200110
+++ b/web/index/apple-music/1115200110
@@ -1,0 +1,1 @@
+../../data/Serie/111/metadata.json

--- a/web/index/apple-music/1115201471
+++ b/web/index/apple-music/1115201471
@@ -1,0 +1,1 @@
+../../data/Serie/112/metadata.json

--- a/web/index/apple-music/1115202256
+++ b/web/index/apple-music/1115202256
@@ -1,0 +1,1 @@
+../../data/Serie/113/metadata.json

--- a/web/index/apple-music/1115204879
+++ b/web/index/apple-music/1115204879
@@ -1,0 +1,1 @@
+../../data/Serie/114/metadata.json

--- a/web/index/apple-music/1115207494
+++ b/web/index/apple-music/1115207494
@@ -1,0 +1,1 @@
+../../data/Serie/108/metadata.json

--- a/web/index/apple-music/1115207538
+++ b/web/index/apple-music/1115207538
@@ -1,0 +1,1 @@
+../../data/Serie/115/metadata.json

--- a/web/index/apple-music/1144029104
+++ b/web/index/apple-music/1144029104
@@ -1,0 +1,1 @@
+../../data/Serie/118/metadata.json

--- a/web/index/apple-music/1144029397
+++ b/web/index/apple-music/1144029397
@@ -1,0 +1,1 @@
+../../data/Serie/120/metadata.json

--- a/web/index/apple-music/1144029626
+++ b/web/index/apple-music/1144029626
@@ -1,0 +1,1 @@
+../../data/Serie/117/metadata.json

--- a/web/index/apple-music/1144029965
+++ b/web/index/apple-music/1144029965
@@ -1,0 +1,1 @@
+../../data/Serie/116/metadata.json

--- a/web/index/apple-music/1144030186
+++ b/web/index/apple-music/1144030186
@@ -1,0 +1,1 @@
+../../data/Serie/119/metadata.json

--- a/web/index/apple-music/1146357190
+++ b/web/index/apple-music/1146357190
@@ -1,0 +1,1 @@
+../../data/Serie/123/metadata.json

--- a/web/index/apple-music/1146357252
+++ b/web/index/apple-music/1146357252
@@ -1,0 +1,1 @@
+../../data/Serie/121/metadata.json

--- a/web/index/apple-music/1146357253
+++ b/web/index/apple-music/1146357253
@@ -1,0 +1,1 @@
+../../data/Serie/124/metadata.json

--- a/web/index/apple-music/1146358292
+++ b/web/index/apple-music/1146358292
@@ -1,0 +1,1 @@
+../../data/Serie/122/metadata.json

--- a/web/index/apple-music/1146359675
+++ b/web/index/apple-music/1146359675
@@ -1,0 +1,1 @@
+../../data/Serie/125/metadata.json

--- a/web/index/apple-music/1148509989
+++ b/web/index/apple-music/1148509989
@@ -1,0 +1,1 @@
+../../data/Serie/128/metadata.json

--- a/web/index/apple-music/1148510004
+++ b/web/index/apple-music/1148510004
@@ -1,0 +1,1 @@
+../../data/Serie/129/metadata.json

--- a/web/index/apple-music/1148510023
+++ b/web/index/apple-music/1148510023
@@ -1,0 +1,1 @@
+../../data/Serie/130/metadata.json

--- a/web/index/apple-music/1148510489
+++ b/web/index/apple-music/1148510489
@@ -1,0 +1,1 @@
+../../data/Serie/126/metadata.json

--- a/web/index/apple-music/1148511050
+++ b/web/index/apple-music/1148511050
@@ -1,0 +1,1 @@
+../../data/Serie/127/metadata.json

--- a/web/index/apple-music/1148627701
+++ b/web/index/apple-music/1148627701
@@ -1,0 +1,1 @@
+../../data/Serie/131/metadata.json

--- a/web/index/apple-music/1148643722
+++ b/web/index/apple-music/1148643722
@@ -1,0 +1,1 @@
+../../data/Serie/132/metadata.json

--- a/web/index/apple-music/1148646414
+++ b/web/index/apple-music/1148646414
@@ -1,0 +1,1 @@
+../../data/Serie/133/metadata.json

--- a/web/index/apple-music/1148648763
+++ b/web/index/apple-music/1148648763
@@ -1,0 +1,1 @@
+../../data/Serie/134/metadata.json

--- a/web/index/apple-music/1148649918
+++ b/web/index/apple-music/1148649918
@@ -1,0 +1,1 @@
+../../data/Serie/135/metadata.json

--- a/web/index/apple-music/1148657349
+++ b/web/index/apple-music/1148657349
@@ -1,0 +1,1 @@
+../../data/Serie/137/metadata.json

--- a/web/index/apple-music/1148657366
+++ b/web/index/apple-music/1148657366
@@ -1,0 +1,1 @@
+../../data/Serie/136/metadata.json

--- a/web/index/apple-music/1148669353
+++ b/web/index/apple-music/1148669353
@@ -1,0 +1,1 @@
+../../data/Serie/138/metadata.json

--- a/web/index/apple-music/1148669725
+++ b/web/index/apple-music/1148669725
@@ -1,0 +1,1 @@
+../../data/Serie/139/metadata.json

--- a/web/index/apple-music/1148670271
+++ b/web/index/apple-music/1148670271
@@ -1,0 +1,1 @@
+../../data/Serie/140/metadata.json

--- a/web/index/apple-music/1148996010
+++ b/web/index/apple-music/1148996010
@@ -1,0 +1,1 @@
+../../data/Serie/141/metadata.json

--- a/web/index/apple-music/1148996011
+++ b/web/index/apple-music/1148996011
@@ -1,0 +1,1 @@
+../../data/Serie/142/metadata.json

--- a/web/index/apple-music/1148998456
+++ b/web/index/apple-music/1148998456
@@ -1,0 +1,1 @@
+../../data/Serie/143/metadata.json

--- a/web/index/apple-music/1148999592
+++ b/web/index/apple-music/1148999592
@@ -1,0 +1,1 @@
+../../data/Serie/146/metadata.json

--- a/web/index/apple-music/1148999599
+++ b/web/index/apple-music/1148999599
@@ -1,0 +1,1 @@
+../../data/Serie/145/metadata.json

--- a/web/index/apple-music/1149001066
+++ b/web/index/apple-music/1149001066
@@ -1,0 +1,1 @@
+../../data/Serie/147/metadata.json

--- a/web/index/apple-music/1149001129
+++ b/web/index/apple-music/1149001129
@@ -1,0 +1,1 @@
+../../data/Serie/148/metadata.json

--- a/web/index/apple-music/1149003866
+++ b/web/index/apple-music/1149003866
@@ -1,0 +1,1 @@
+../../data/Serie/149/metadata.json

--- a/web/index/apple-music/1149005753
+++ b/web/index/apple-music/1149005753
@@ -1,0 +1,1 @@
+../../data/Serie/151/metadata.json

--- a/web/index/apple-music/1149006848
+++ b/web/index/apple-music/1149006848
@@ -1,0 +1,1 @@
+../../data/Serie/153/metadata.json

--- a/web/index/apple-music/1149007296
+++ b/web/index/apple-music/1149007296
@@ -1,0 +1,1 @@
+../../data/Serie/152/metadata.json

--- a/web/index/apple-music/1149007411
+++ b/web/index/apple-music/1149007411
@@ -1,0 +1,1 @@
+../../data/Serie/150/metadata.json

--- a/web/index/apple-music/1149010695
+++ b/web/index/apple-music/1149010695
@@ -1,0 +1,1 @@
+../../data/Serie/154/metadata.json

--- a/web/index/apple-music/1149012184
+++ b/web/index/apple-music/1149012184
@@ -1,0 +1,1 @@
+../../data/Serie/155/metadata.json

--- a/web/index/apple-music/1149012208
+++ b/web/index/apple-music/1149012208
@@ -1,0 +1,1 @@
+../../data/Serie/156/metadata.json

--- a/web/index/apple-music/1149014146
+++ b/web/index/apple-music/1149014146
@@ -1,0 +1,1 @@
+../../data/Serie/157/metadata.json

--- a/web/index/apple-music/1149014175
+++ b/web/index/apple-music/1149014175
@@ -1,0 +1,1 @@
+../../data/Serie/158/metadata.json

--- a/web/index/apple-music/1149016169
+++ b/web/index/apple-music/1149016169
@@ -1,0 +1,1 @@
+../../data/Serie/159/metadata.json

--- a/web/index/apple-music/1149017354
+++ b/web/index/apple-music/1149017354
@@ -1,0 +1,1 @@
+../../data/Serie/160/metadata.json

--- a/web/index/apple-music/1149329426
+++ b/web/index/apple-music/1149329426
@@ -1,0 +1,1 @@
+../../data/Serie/161/metadata.json

--- a/web/index/apple-music/1149330399
+++ b/web/index/apple-music/1149330399
@@ -1,0 +1,1 @@
+../../data/Serie/162/metadata.json

--- a/web/index/apple-music/1149332439
+++ b/web/index/apple-music/1149332439
@@ -1,0 +1,1 @@
+../../data/Serie/163/metadata.json

--- a/web/index/apple-music/1149333141
+++ b/web/index/apple-music/1149333141
@@ -1,0 +1,1 @@
+../../data/Serie/164/metadata.json

--- a/web/index/apple-music/1149333942
+++ b/web/index/apple-music/1149333942
@@ -1,0 +1,1 @@
+../../data/Serie/165/metadata.json

--- a/web/index/apple-music/1149334526
+++ b/web/index/apple-music/1149334526
@@ -1,0 +1,1 @@
+../../data/Serie/166/metadata.json

--- a/web/index/apple-music/1149335077
+++ b/web/index/apple-music/1149335077
@@ -1,0 +1,1 @@
+../../data/Serie/167/metadata.json

--- a/web/index/apple-music/1149335801
+++ b/web/index/apple-music/1149335801
@@ -1,0 +1,1 @@
+../../data/Serie/168/metadata.json

--- a/web/index/apple-music/1149337256
+++ b/web/index/apple-music/1149337256
@@ -1,0 +1,1 @@
+../../data/Serie/169/metadata.json

--- a/web/index/apple-music/1149344576
+++ b/web/index/apple-music/1149344576
@@ -1,0 +1,1 @@
+../../data/Serie/175/metadata.json

--- a/web/index/apple-music/1149348842
+++ b/web/index/apple-music/1149348842
@@ -1,0 +1,1 @@
+../../data/Serie/174/metadata.json

--- a/web/index/apple-music/1149349243
+++ b/web/index/apple-music/1149349243
@@ -1,0 +1,1 @@
+../../data/Serie/176/metadata.json

--- a/web/index/apple-music/1149351738
+++ b/web/index/apple-music/1149351738
@@ -1,0 +1,1 @@
+../../data/Serie/181/metadata.json

--- a/web/index/apple-music/1149351939
+++ b/web/index/apple-music/1149351939
@@ -1,0 +1,1 @@
+../../data/Serie/182/metadata.json

--- a/web/index/apple-music/1149352111
+++ b/web/index/apple-music/1149352111
@@ -1,0 +1,1 @@
+../../data/Serie/180/metadata.json

--- a/web/index/apple-music/1149354207
+++ b/web/index/apple-music/1149354207
@@ -1,0 +1,1 @@
+../../data/Serie/177/metadata.json

--- a/web/index/apple-music/1149354238
+++ b/web/index/apple-music/1149354238
@@ -1,0 +1,1 @@
+../../data/Serie/173/metadata.json

--- a/web/index/apple-music/1149355884
+++ b/web/index/apple-music/1149355884
@@ -1,0 +1,1 @@
+../../data/Serie/178/metadata.json

--- a/web/index/apple-music/1149355993
+++ b/web/index/apple-music/1149355993
@@ -1,0 +1,1 @@
+../../data/Serie/183/metadata.json

--- a/web/index/apple-music/1149356212
+++ b/web/index/apple-music/1149356212
@@ -1,0 +1,1 @@
+../../data/Serie/179/metadata.json

--- a/web/index/apple-music/1149379770
+++ b/web/index/apple-music/1149379770
@@ -1,0 +1,1 @@
+../../data/Kurzgeschichten/und-der-Zeitgeist/metadata.json

--- a/web/index/apple-music/1149906410
+++ b/web/index/apple-music/1149906410
@@ -1,0 +1,1 @@
+../../data/Serie/170/metadata.json

--- a/web/index/apple-music/1149910943
+++ b/web/index/apple-music/1149910943
@@ -1,0 +1,1 @@
+../../data/Serie/172/metadata.json

--- a/web/index/apple-music/1149912131
+++ b/web/index/apple-music/1149912131
@@ -1,0 +1,1 @@
+../../data/Serie/171/metadata.json

--- a/web/index/apple-music/1156014250
+++ b/web/index/apple-music/1156014250
@@ -1,0 +1,1 @@
+../../data/Serie/144/metadata.json

--- a/web/index/apple-music/1174866876
+++ b/web/index/apple-music/1174866876
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-5-Advent/metadata.json

--- a/web/index/apple-music/1179325253
+++ b/web/index/apple-music/1179325253
@@ -1,0 +1,1 @@
+../../data/Serie/184/metadata.json

--- a/web/index/apple-music/1198202669
+++ b/web/index/apple-music/1198202669
@@ -1,0 +1,1 @@
+../../data/Serie/185/metadata.json

--- a/web/index/apple-music/1207830126
+++ b/web/index/apple-music/1207830126
@@ -1,0 +1,1 @@
+../../data/Serie/186/metadata.json

--- a/web/index/apple-music/1219257238
+++ b/web/index/apple-music/1219257238
@@ -1,0 +1,1 @@
+../../data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json

--- a/web/index/apple-music/1225246976
+++ b/web/index/apple-music/1225246976
@@ -1,0 +1,1 @@
+../../data/Serie/187/metadata.json

--- a/web/index/apple-music/1235580462
+++ b/web/index/apple-music/1235580462
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-Tornadojaeger/metadata.json

--- a/web/index/apple-music/1257760310
+++ b/web/index/apple-music/1257760310
@@ -1,0 +1,1 @@
+../../data/Serie/188/metadata.json

--- a/web/index/apple-music/1263882229
+++ b/web/index/apple-music/1263882229
@@ -1,0 +1,1 @@
+../../data/Spezial/und-das-kalte-Auge/metadata.json

--- a/web/index/apple-music/1294740417
+++ b/web/index/apple-music/1294740417
@@ -1,0 +1,1 @@
+../../data/Serie/189/metadata.json

--- a/web/index/apple-music/1295117431
+++ b/web/index/apple-music/1295117431
@@ -1,0 +1,1 @@
+../../data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json

--- a/web/index/apple-music/1318247066
+++ b/web/index/apple-music/1318247066
@@ -1,0 +1,1 @@
+../../data/Serie/190/metadata.json

--- a/web/index/apple-music/1333105792
+++ b/web/index/apple-music/1333105792
@@ -1,0 +1,1 @@
+../../data/Serie/191/metadata.json

--- a/web/index/apple-music/1349191008
+++ b/web/index/apple-music/1349191008
@@ -1,0 +1,1 @@
+../../data/Serie/192/metadata.json

--- a/web/index/apple-music/1400669710
+++ b/web/index/apple-music/1400669710
@@ -1,0 +1,1 @@
+../../data/Serie/193/metadata.json

--- a/web/index/apple-music/1417848434
+++ b/web/index/apple-music/1417848434
@@ -1,0 +1,1 @@
+../../data/Serie/194/metadata.json

--- a/web/index/apple-music/1436692770
+++ b/web/index/apple-music/1436692770
@@ -1,0 +1,1 @@
+../../data/Kurzgeschichten/und-der-schwarze-Tag/metadata.json

--- a/web/index/apple-music/1437362850
+++ b/web/index/apple-music/1437362850
@@ -1,0 +1,1 @@
+../../data/Serie/195/metadata.json

--- a/web/index/apple-music/1441757895
+++ b/web/index/apple-music/1441757895
@@ -1,0 +1,1 @@
+../../data/Serie/196/metadata.json

--- a/web/index/apple-music/1445830975
+++ b/web/index/apple-music/1445830975
@@ -1,0 +1,1 @@
+../../data/Serie/197/metadata.json

--- a/web/index/apple-music/1456265306
+++ b/web/index/apple-music/1456265306
@@ -1,0 +1,1 @@
+../../data/Spezial/und-die-schwarze-Katze/metadata.json

--- a/web/index/apple-music/1456265671
+++ b/web/index/apple-music/1456265671
@@ -1,0 +1,1 @@
+../../data/Serie/198/metadata.json

--- a/web/index/apple-music/1462260403
+++ b/web/index/apple-music/1462260403
@@ -1,0 +1,1 @@
+../../data/Serie/199/metadata.json

--- a/web/index/apple-music/1462398864
+++ b/web/index/apple-music/1462398864
@@ -1,0 +1,1 @@
+../../data/Serie/200/metadata.json

--- a/web/index/apple-music/1470374382
+++ b/web/index/apple-music/1470374382
@@ -1,0 +1,1 @@
+../../data/Serie/201/metadata.json

--- a/web/index/apple-music/1479540077
+++ b/web/index/apple-music/1479540077
@@ -1,0 +1,1 @@
+../../data/Serie/202/metadata.json

--- a/web/index/apple-music/1480675865
+++ b/web/index/apple-music/1480675865
@@ -1,0 +1,1 @@
+../../data/Spezial/und-das-versunkene-Schiff/metadata.json

--- a/web/index/apple-music/1488585423
+++ b/web/index/apple-music/1488585423
@@ -1,0 +1,1 @@
+../../data/Serie/203/metadata.json

--- a/web/index/apple-music/1492053303
+++ b/web/index/apple-music/1492053303
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json

--- a/web/index/apple-music/1494861137
+++ b/web/index/apple-music/1494861137
@@ -1,0 +1,1 @@
+../../data/Serie/204/metadata.json

--- a/web/index/apple-music/1501321342
+++ b/web/index/apple-music/1501321342
@@ -1,0 +1,1 @@
+../../data/Serie/205/metadata.json

--- a/web/index/apple-music/1508160053
+++ b/web/index/apple-music/1508160053
@@ -1,0 +1,1 @@
+../../data/Serie/206/metadata.json

--- a/web/index/apple-music/1520380006
+++ b/web/index/apple-music/1520380006
@@ -1,0 +1,1 @@
+../../data/Serie/207/metadata.json

--- a/web/index/apple-music/1529406670
+++ b/web/index/apple-music/1529406670
@@ -1,0 +1,1 @@
+../../data/Serie/208/metadata.json

--- a/web/index/apple-music/1529420801
+++ b/web/index/apple-music/1529420801
@@ -1,0 +1,1 @@
+../../data/Spezial/O-du-finstere/metadata.json

--- a/web/index/apple-music/1535920186
+++ b/web/index/apple-music/1535920186
@@ -1,0 +1,1 @@
+../../data/Spezial/und-das-Grab-der-Maya/metadata.json

--- a/web/index/apple-music/1543186727
+++ b/web/index/apple-music/1543186727
@@ -1,0 +1,1 @@
+../../data/Serie/209/metadata.json

--- a/web/index/apple-music/1555455044
+++ b/web/index/apple-music/1555455044
@@ -1,0 +1,1 @@
+../../data/Serie/210/metadata.json

--- a/web/index/apple-music/1569609366
+++ b/web/index/apple-music/1569609366
@@ -1,0 +1,1 @@
+../../data/Serie/211/metadata.json

--- a/web/index/apple-music/1575573696
+++ b/web/index/apple-music/1575573696
@@ -1,0 +1,1 @@
+../../data/Serie/212/metadata.json

--- a/web/index/apple-music/1585776843
+++ b/web/index/apple-music/1585776843
@@ -1,0 +1,1 @@
+../../data/Serie/213/metadata.json

--- a/web/index/apple-music/1593847687
+++ b/web/index/apple-music/1593847687
@@ -1,0 +1,1 @@
+../../data/Serie/214/metadata.json

--- a/web/index/apple-music/1606130509
+++ b/web/index/apple-music/1606130509
@@ -1,0 +1,1 @@
+../../data/Serie/215/metadata.json

--- a/web/index/apple-music/1612467355
+++ b/web/index/apple-music/1612467355
@@ -1,0 +1,1 @@
+../../data/Serie/216/metadata.json

--- a/web/index/apple-music/1683337919
+++ b/web/index/apple-music/1683337919
@@ -1,0 +1,1 @@
+../../data/Serie/220/metadata.json

--- a/web/index/apple-music/1683338209
+++ b/web/index/apple-music/1683338209
@@ -1,0 +1,1 @@
+../../data/Serie/218/metadata.json

--- a/web/index/apple-music/1683338536
+++ b/web/index/apple-music/1683338536
@@ -1,0 +1,1 @@
+../../data/Serie/217/metadata.json

--- a/web/index/apple-music/1683339377
+++ b/web/index/apple-music/1683339377
@@ -1,0 +1,1 @@
+../../data/Serie/219/metadata.json

--- a/web/index/apple-music/1695104461
+++ b/web/index/apple-music/1695104461
@@ -1,0 +1,1 @@
+../../data/Serie/221/metadata.json

--- a/web/index/apple-music/1695696461
+++ b/web/index/apple-music/1695696461
@@ -1,0 +1,1 @@
+../../data/Spezial/Eine-schreckliche-Bescherung/metadata.json

--- a/web/index/apple-music/1744386522
+++ b/web/index/apple-music/1744386522
@@ -1,0 +1,1 @@
+../../data/Serie/228/metadata.json

--- a/web/index/apple-music/1752443158
+++ b/web/index/apple-music/1752443158
@@ -1,0 +1,1 @@
+../../data/Serie/222/metadata.json

--- a/web/index/apple-music/1752449378
+++ b/web/index/apple-music/1752449378
@@ -1,0 +1,1 @@
+../../data/Serie/223/metadata.json

--- a/web/index/apple-music/1752449423
+++ b/web/index/apple-music/1752449423
@@ -1,0 +1,1 @@
+../../data/Serie/224/metadata.json

--- a/web/index/apple-music/1752449669
+++ b/web/index/apple-music/1752449669
@@ -1,0 +1,1 @@
+../../data/Serie/227/metadata.json

--- a/web/index/apple-music/1752449751
+++ b/web/index/apple-music/1752449751
@@ -1,0 +1,1 @@
+../../data/Serie/226/metadata.json

--- a/web/index/apple-music/1752450018
+++ b/web/index/apple-music/1752450018
@@ -1,0 +1,1 @@
+../../data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json

--- a/web/index/apple-music/1752450507
+++ b/web/index/apple-music/1752450507
@@ -1,0 +1,1 @@
+../../data/Serie/225/metadata.json

--- a/web/index/apple-music/452658930
+++ b/web/index/apple-music/452658930
@@ -1,0 +1,1 @@
+../../data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json

--- a/web/index/spotify/01i4iyB40EU7Qgd6EgKoZt
+++ b/web/index/spotify/01i4iyB40EU7Qgd6EgKoZt
@@ -1,0 +1,1 @@
+../../data/Serie/220/metadata.json

--- a/web/index/spotify/02MXdFaVMz0qQJjmivjI8g
+++ b/web/index/spotify/02MXdFaVMz0qQJjmivjI8g
@@ -1,0 +1,1 @@
+../../data/Serie/189/metadata.json

--- a/web/index/spotify/07EhJ6uxWcQQWKeXJ1e8Lb
+++ b/web/index/spotify/07EhJ6uxWcQQWKeXJ1e8Lb
@@ -1,0 +1,1 @@
+../../data/Serie/011/metadata.json

--- a/web/index/spotify/09Ckx1JLgPsQHHGuSIt2j3
+++ b/web/index/spotify/09Ckx1JLgPsQHHGuSIt2j3
@@ -1,0 +1,1 @@
+../../data/Serie/200/metadata.json

--- a/web/index/spotify/0AKPkUh4ElyZNipc0lZoiR
+++ b/web/index/spotify/0AKPkUh4ElyZNipc0lZoiR
@@ -1,0 +1,1 @@
+../../data/Serie/039/metadata.json

--- a/web/index/spotify/0AnyLaLPx339iGaxjqVfob
+++ b/web/index/spotify/0AnyLaLPx339iGaxjqVfob
@@ -1,0 +1,1 @@
+../../data/Serie/126/metadata.json

--- a/web/index/spotify/0CMsNalUakIcv6znyVLALr
+++ b/web/index/spotify/0CMsNalUakIcv6znyVLALr
@@ -1,0 +1,1 @@
+../../data/Serie/017/metadata.json

--- a/web/index/spotify/0F9ebKwTd5RNZZOu49lWuF
+++ b/web/index/spotify/0F9ebKwTd5RNZZOu49lWuF
@@ -1,0 +1,1 @@
+../../data/Serie/053/metadata.json

--- a/web/index/spotify/0FuC7q4bJG41g1naKBx4ot
+++ b/web/index/spotify/0FuC7q4bJG41g1naKBx4ot
@@ -1,0 +1,1 @@
+../../data/Serie/225/metadata.json

--- a/web/index/spotify/0GRoTtX1wI16M7GSnnN96R
+++ b/web/index/spotify/0GRoTtX1wI16M7GSnnN96R
@@ -1,0 +1,1 @@
+../../data/Serie/197/metadata.json

--- a/web/index/spotify/0Jh7gzQaOscoFndb3raq2l
+++ b/web/index/spotify/0Jh7gzQaOscoFndb3raq2l
@@ -1,0 +1,1 @@
+../../data/Serie/091/metadata.json

--- a/web/index/spotify/0LoesJ9VnJPrlvIDz4u4Xt
+++ b/web/index/spotify/0LoesJ9VnJPrlvIDz4u4Xt
@@ -1,0 +1,1 @@
+../../data/Serie/124/metadata.json

--- a/web/index/spotify/0TmWLedytkxVuP9b5Hqeqq
+++ b/web/index/spotify/0TmWLedytkxVuP9b5Hqeqq
@@ -1,0 +1,1 @@
+../../data/Serie/135/metadata.json

--- a/web/index/spotify/0WBhXS0uAYuL1sYb6vjYeS
+++ b/web/index/spotify/0WBhXS0uAYuL1sYb6vjYeS
@@ -1,0 +1,1 @@
+../../data/Serie/112/metadata.json

--- a/web/index/spotify/0aNqdp5ayuUNsOdUwu8x0b
+++ b/web/index/spotify/0aNqdp5ayuUNsOdUwu8x0b
@@ -1,0 +1,1 @@
+../../data/Serie/009/metadata.json

--- a/web/index/spotify/0bSrvyOjOzFoFJfx3uaFgk
+++ b/web/index/spotify/0bSrvyOjOzFoFJfx3uaFgk
@@ -1,0 +1,1 @@
+../../data/Serie/012/metadata.json

--- a/web/index/spotify/0biXUv1uGUaVsPcw8nAZCY
+++ b/web/index/spotify/0biXUv1uGUaVsPcw8nAZCY
@@ -1,0 +1,1 @@
+../../data/Serie/062/metadata.json

--- a/web/index/spotify/0mp5HVWlYinEYa7Y4Q2vau
+++ b/web/index/spotify/0mp5HVWlYinEYa7Y4Q2vau
@@ -1,0 +1,1 @@
+../../data/Serie/127/metadata.json

--- a/web/index/spotify/0oZaQfEwMWY2TfviD4fEdV
+++ b/web/index/spotify/0oZaQfEwMWY2TfviD4fEdV
@@ -1,0 +1,1 @@
+../../data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json

--- a/web/index/spotify/0pdXEEgKjfh4H0aZg4IOTS
+++ b/web/index/spotify/0pdXEEgKjfh4H0aZg4IOTS
@@ -1,0 +1,1 @@
+../../data/Serie/157/metadata.json

--- a/web/index/spotify/0q4FbI22wSMrzgWh5vgHi9
+++ b/web/index/spotify/0q4FbI22wSMrzgWh5vgHi9
@@ -1,0 +1,1 @@
+../../data/Serie/209/metadata.json

--- a/web/index/spotify/0sIRyuExi7jBQmOpHyyY78
+++ b/web/index/spotify/0sIRyuExi7jBQmOpHyyY78
@@ -1,0 +1,1 @@
+../../data/Serie/125/metadata.json

--- a/web/index/spotify/0tPetsUWuZIC0E85x6eVN5
+++ b/web/index/spotify/0tPetsUWuZIC0E85x6eVN5
@@ -1,0 +1,1 @@
+../../data/Serie/031/metadata.json

--- a/web/index/spotify/0tmMvsGyWRzVckCYgkvve3
+++ b/web/index/spotify/0tmMvsGyWRzVckCYgkvve3
@@ -1,0 +1,1 @@
+../../data/Serie/064/metadata.json

--- a/web/index/spotify/0w6Khy7kpqTXrEDITf0rZ0
+++ b/web/index/spotify/0w6Khy7kpqTXrEDITf0rZ0
@@ -1,0 +1,1 @@
+../../data/Serie/177/metadata.json

--- a/web/index/spotify/0xldqK4Ocdt8dwQSxUzt6x
+++ b/web/index/spotify/0xldqK4Ocdt8dwQSxUzt6x
@@ -1,0 +1,1 @@
+../../data/Serie/002/metadata.json

--- a/web/index/spotify/0zV9pnaXLuogDr6prsvb4M
+++ b/web/index/spotify/0zV9pnaXLuogDr6prsvb4M
@@ -1,0 +1,1 @@
+../../data/Serie/030/metadata.json

--- a/web/index/spotify/100ZHoBX994GlckxjoGpma
+++ b/web/index/spotify/100ZHoBX994GlckxjoGpma
@@ -1,0 +1,1 @@
+../../data/Serie/190/metadata.json

--- a/web/index/spotify/16dOhg07DVqoSxlS7ToLM5
+++ b/web/index/spotify/16dOhg07DVqoSxlS7ToLM5
@@ -1,0 +1,1 @@
+../../data/Serie/016/metadata.json

--- a/web/index/spotify/18xyskqkEGnVfVFhznkFIK
+++ b/web/index/spotify/18xyskqkEGnVfVFhznkFIK
@@ -1,0 +1,1 @@
+../../data/Serie/181/metadata.json

--- a/web/index/spotify/1Cta130Rwp5vH1ddfAChbU
+++ b/web/index/spotify/1Cta130Rwp5vH1ddfAChbU
@@ -1,0 +1,1 @@
+../../data/Serie/134/metadata.json

--- a/web/index/spotify/1DZAe0qMw8Pq9EPoX6gETA
+++ b/web/index/spotify/1DZAe0qMw8Pq9EPoX6gETA
@@ -1,0 +1,1 @@
+../../data/Serie/101/metadata.json

--- a/web/index/spotify/1Fg15cBLFliy6Kr60QqRan
+++ b/web/index/spotify/1Fg15cBLFliy6Kr60QqRan
@@ -1,0 +1,1 @@
+../../data/Serie/054/metadata.json

--- a/web/index/spotify/1GEzdjI5N25iuGjvypRscs
+++ b/web/index/spotify/1GEzdjI5N25iuGjvypRscs
@@ -1,0 +1,1 @@
+../../data/Serie/161/metadata.json

--- a/web/index/spotify/1GKXpMQRKEyZI8pL62VUIP
+++ b/web/index/spotify/1GKXpMQRKEyZI8pL62VUIP
@@ -1,0 +1,1 @@
+../../data/Serie/118/metadata.json

--- a/web/index/spotify/1K8kXLhNnHSdPvtUwf74DE
+++ b/web/index/spotify/1K8kXLhNnHSdPvtUwf74DE
@@ -1,0 +1,1 @@
+../../data/Serie/073/metadata.json

--- a/web/index/spotify/1KpVSqapKAUAtAepWWxPWs
+++ b/web/index/spotify/1KpVSqapKAUAtAepWWxPWs
@@ -1,0 +1,1 @@
+../../data/Serie/221/metadata.json

--- a/web/index/spotify/1KpWkUQaj5ECJsrb8SrPl4
+++ b/web/index/spotify/1KpWkUQaj5ECJsrb8SrPl4
@@ -1,0 +1,1 @@
+../../data/Serie/087/metadata.json

--- a/web/index/spotify/1OBHPhBUih26oQTqxLvJTQ
+++ b/web/index/spotify/1OBHPhBUih26oQTqxLvJTQ
@@ -1,0 +1,1 @@
+../../data/Serie/110/metadata.json

--- a/web/index/spotify/1WlRnNunbHpnRTTVkxMRnd
+++ b/web/index/spotify/1WlRnNunbHpnRTTVkxMRnd
@@ -1,0 +1,1 @@
+../../data/Serie/217/metadata.json

--- a/web/index/spotify/1cJ3fNx6K47p4eDFqhnvsA
+++ b/web/index/spotify/1cJ3fNx6K47p4eDFqhnvsA
@@ -1,0 +1,1 @@
+../../data/Serie/214/metadata.json

--- a/web/index/spotify/1imKVIfJIM0vKNymevqKjP
+++ b/web/index/spotify/1imKVIfJIM0vKNymevqKjP
@@ -1,0 +1,1 @@
+../../data/Serie/033/metadata.json

--- a/web/index/spotify/1juMQy6yZVmk9Za6HeiicB
+++ b/web/index/spotify/1juMQy6yZVmk9Za6HeiicB
@@ -1,0 +1,1 @@
+../../data/Serie/133/metadata.json

--- a/web/index/spotify/1lD4RdnibVS7QhtZqCal9E
+++ b/web/index/spotify/1lD4RdnibVS7QhtZqCal9E
@@ -1,0 +1,1 @@
+../../data/Serie/129/metadata.json

--- a/web/index/spotify/1nL3AddBvZ845zMyXRowgs
+++ b/web/index/spotify/1nL3AddBvZ845zMyXRowgs
@@ -1,0 +1,1 @@
+../../data/Kurzgeschichten/und-die-Geisterlampe/metadata.json

--- a/web/index/spotify/1qag2AiFcxXU1UaIgrDFff
+++ b/web/index/spotify/1qag2AiFcxXU1UaIgrDFff
@@ -1,0 +1,1 @@
+../../data/Serie/192/metadata.json

--- a/web/index/spotify/1qhlRmclvYWkrYkLnFxFZN
+++ b/web/index/spotify/1qhlRmclvYWkrYkLnFxFZN
@@ -1,0 +1,1 @@
+../../data/Serie/183/metadata.json

--- a/web/index/spotify/1rDYlXZy6vN4wqqQ6buqOr
+++ b/web/index/spotify/1rDYlXZy6vN4wqqQ6buqOr
@@ -1,0 +1,1 @@
+../../data/Serie/079/metadata.json

--- a/web/index/spotify/1yMMjH3tDN9GyXiADzTkL9
+++ b/web/index/spotify/1yMMjH3tDN9GyXiADzTkL9
@@ -1,0 +1,1 @@
+../../data/Serie/204/metadata.json

--- a/web/index/spotify/1yqICFWBL4l7fJkrFWvfWL
+++ b/web/index/spotify/1yqICFWBL4l7fJkrFWvfWL
@@ -1,0 +1,1 @@
+../../data/Serie/018/metadata.json

--- a/web/index/spotify/211IEWHi59nUsHx8li8G9r
+++ b/web/index/spotify/211IEWHi59nUsHx8li8G9r
@@ -1,0 +1,1 @@
+../../data/Serie/024/metadata.json

--- a/web/index/spotify/21pUsEhxssm6fvumGFmi35
+++ b/web/index/spotify/21pUsEhxssm6fvumGFmi35
@@ -1,0 +1,1 @@
+../../data/Serie/068/metadata.json

--- a/web/index/spotify/22soWryC08ctyMNb6NrMGD
+++ b/web/index/spotify/22soWryC08ctyMNb6NrMGD
@@ -1,0 +1,1 @@
+../../data/Serie/188/metadata.json

--- a/web/index/spotify/23wcElHGWpunC23ggr4PcW
+++ b/web/index/spotify/23wcElHGWpunC23ggr4PcW
@@ -1,0 +1,1 @@
+../../data/Serie/132/metadata.json

--- a/web/index/spotify/249qkyRcqMAoKJhXwrTYtE
+++ b/web/index/spotify/249qkyRcqMAoKJhXwrTYtE
@@ -1,0 +1,1 @@
+../../data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json

--- a/web/index/spotify/24bba3w45LGGm7ps3qonkc
+++ b/web/index/spotify/24bba3w45LGGm7ps3qonkc
@@ -1,0 +1,1 @@
+../../data/Serie/042/metadata.json

--- a/web/index/spotify/26M4ktHp3isOX6XJazAxPn
+++ b/web/index/spotify/26M4ktHp3isOX6XJazAxPn
@@ -1,0 +1,1 @@
+../../data/Serie/061/metadata.json

--- a/web/index/spotify/2AEzTekSWfyfzJH56jmhET
+++ b/web/index/spotify/2AEzTekSWfyfzJH56jmhET
@@ -1,0 +1,1 @@
+../../data/Kurzgeschichten/Das-Raetsel-der-Sieben/metadata.json

--- a/web/index/spotify/2ALDCHCHdawewN1sduWVQQ
+++ b/web/index/spotify/2ALDCHCHdawewN1sduWVQQ
@@ -1,0 +1,1 @@
+../../data/Serie/173/metadata.json

--- a/web/index/spotify/2AZ7zFBophWEIuBPjAG60I
+++ b/web/index/spotify/2AZ7zFBophWEIuBPjAG60I
@@ -1,0 +1,1 @@
+../../data/Serie/013/metadata.json

--- a/web/index/spotify/2AisAUu4deLpNi6g6qlTLC
+++ b/web/index/spotify/2AisAUu4deLpNi6g6qlTLC
@@ -1,0 +1,1 @@
+../../data/Serie/027/metadata.json

--- a/web/index/spotify/2BkEUZY7Da7bqlUjmMA2Cq
+++ b/web/index/spotify/2BkEUZY7Da7bqlUjmMA2Cq
@@ -1,0 +1,1 @@
+../../data/Serie/216/metadata.json

--- a/web/index/spotify/2Bxdn8Gn8vEy4UiTOc8cBK
+++ b/web/index/spotify/2Bxdn8Gn8vEy4UiTOc8cBK
@@ -1,0 +1,1 @@
+../../data/Spezial/High-Strung-Unter-Hochspannung/metadata.json

--- a/web/index/spotify/2CMXywsh8wVXXCmr2bLTZ6
+++ b/web/index/spotify/2CMXywsh8wVXXCmr2bLTZ6
@@ -1,0 +1,1 @@
+../../data/Serie/227/metadata.json

--- a/web/index/spotify/2F6VxgWbGCUpTU9ux6Dtbi
+++ b/web/index/spotify/2F6VxgWbGCUpTU9ux6Dtbi
@@ -1,0 +1,1 @@
+../../data/Serie/160/metadata.json

--- a/web/index/spotify/2GQjkF0ceIse6jVZkUuAQc
+++ b/web/index/spotify/2GQjkF0ceIse6jVZkUuAQc
@@ -1,0 +1,1 @@
+../../data/Serie/072/metadata.json

--- a/web/index/spotify/2ICtKWqLqMBTzi7UeByhKd
+++ b/web/index/spotify/2ICtKWqLqMBTzi7UeByhKd
@@ -1,0 +1,1 @@
+../../data/Serie/191/metadata.json

--- a/web/index/spotify/2IIw1KESZrJQBFdZQAWcKY
+++ b/web/index/spotify/2IIw1KESZrJQBFdZQAWcKY
@@ -1,0 +1,1 @@
+../../data/Serie/040/metadata.json

--- a/web/index/spotify/2IqfdlQamN3vCWN3CKLEVI
+++ b/web/index/spotify/2IqfdlQamN3vCWN3CKLEVI
@@ -1,0 +1,1 @@
+../../data/Serie/075/metadata.json

--- a/web/index/spotify/2L18qTB1EfS4FuBk2M6QwV
+++ b/web/index/spotify/2L18qTB1EfS4FuBk2M6QwV
@@ -1,0 +1,1 @@
+../../data/Serie/034/metadata.json

--- a/web/index/spotify/2NSreywe8UbWo7BJVY3Spk
+++ b/web/index/spotify/2NSreywe8UbWo7BJVY3Spk
@@ -1,0 +1,1 @@
+../../data/Serie/026/metadata.json

--- a/web/index/spotify/2REEfC6tVMiYv1eKMlGiOX
+++ b/web/index/spotify/2REEfC6tVMiYv1eKMlGiOX
@@ -1,0 +1,1 @@
+../../data/Serie/035/metadata.json

--- a/web/index/spotify/2RxTF6MhAVOtudVNOyHTQz
+++ b/web/index/spotify/2RxTF6MhAVOtudVNOyHTQz
@@ -1,0 +1,1 @@
+../../data/Serie/144/metadata.json

--- a/web/index/spotify/2Sw9FBHOoT6fBhYxHsRFxq
+++ b/web/index/spotify/2Sw9FBHOoT6fBhYxHsRFxq
@@ -1,0 +1,1 @@
+../../data/Serie/205/metadata.json

--- a/web/index/spotify/2WwOKZLpFWrvw3O9CISod1
+++ b/web/index/spotify/2WwOKZLpFWrvw3O9CISod1
@@ -1,0 +1,1 @@
+../../data/Serie/218/metadata.json

--- a/web/index/spotify/2bfJa4PRKVb7as86HZv8Df
+++ b/web/index/spotify/2bfJa4PRKVb7as86HZv8Df
@@ -1,0 +1,1 @@
+../../data/Serie/097/metadata.json

--- a/web/index/spotify/2dQYcaTRh5qEYk2oH7WoBC
+++ b/web/index/spotify/2dQYcaTRh5qEYk2oH7WoBC
@@ -1,0 +1,1 @@
+../../data/Serie/015/metadata.json

--- a/web/index/spotify/2dlgtHB8z7ZhSl1fsSb0Ic
+++ b/web/index/spotify/2dlgtHB8z7ZhSl1fsSb0Ic
@@ -1,0 +1,1 @@
+../../data/Serie/090/metadata.json

--- a/web/index/spotify/2eeodcwD9HXpcA2rvoFkIq
+++ b/web/index/spotify/2eeodcwD9HXpcA2rvoFkIq
@@ -1,0 +1,1 @@
+../../data/Serie/085/metadata.json

--- a/web/index/spotify/2erJcBofKBO6GFMqDPppsU
+++ b/web/index/spotify/2erJcBofKBO6GFMqDPppsU
@@ -1,0 +1,1 @@
+../../data/Serie/069/metadata.json

--- a/web/index/spotify/2koZEkq7vQnHjMP73gVXCo
+++ b/web/index/spotify/2koZEkq7vQnHjMP73gVXCo
@@ -1,0 +1,1 @@
+../../data/Serie/021/metadata.json

--- a/web/index/spotify/2oKngJQA5TdxF5QcP3uZEf
+++ b/web/index/spotify/2oKngJQA5TdxF5QcP3uZEf
@@ -1,0 +1,1 @@
+../../data/Serie/194/metadata.json

--- a/web/index/spotify/2qFuUJMx8w4VEO0Zdf8jFJ
+++ b/web/index/spotify/2qFuUJMx8w4VEO0Zdf8jFJ
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-5-Advent/metadata.json

--- a/web/index/spotify/2qcA1EqAoUsqxXqIivY6Zc
+++ b/web/index/spotify/2qcA1EqAoUsqxXqIivY6Zc
@@ -1,0 +1,1 @@
+../../data/Serie/059/metadata.json

--- a/web/index/spotify/2s5u6hCaMpTIvZtBRvQzha
+++ b/web/index/spotify/2s5u6hCaMpTIvZtBRvQzha
@@ -1,0 +1,1 @@
+../../data/Serie/081/metadata.json

--- a/web/index/spotify/2uOsf31oenHRd4DVxCSjn9
+++ b/web/index/spotify/2uOsf31oenHRd4DVxCSjn9
@@ -1,0 +1,1 @@
+../../data/Serie/148/metadata.json

--- a/web/index/spotify/2w902iYtkf0ipmTImyLlsL
+++ b/web/index/spotify/2w902iYtkf0ipmTImyLlsL
@@ -1,0 +1,1 @@
+../../data/Serie/004/metadata.json

--- a/web/index/spotify/2zHMeFNQQxKOmUgmppOjIM
+++ b/web/index/spotify/2zHMeFNQQxKOmUgmppOjIM
@@ -1,0 +1,1 @@
+../../data/Serie/212/metadata.json

--- a/web/index/spotify/35aU9bfmxPGdjiRA4JMuFd
+++ b/web/index/spotify/35aU9bfmxPGdjiRA4JMuFd
@@ -1,0 +1,1 @@
+../../data/Serie/147/metadata.json

--- a/web/index/spotify/39K0Sczt1mIbW33lB5RNer
+++ b/web/index/spotify/39K0Sczt1mIbW33lB5RNer
@@ -1,0 +1,1 @@
+../../data/Spezial/und-die-schwarze-Katze/metadata.json

--- a/web/index/spotify/39a7bHWZyWPxwukCHPrTly
+++ b/web/index/spotify/39a7bHWZyWPxwukCHPrTly
@@ -1,0 +1,1 @@
+../../data/Serie/196/metadata.json

--- a/web/index/spotify/39mWWzaUZp0AXyN9Vnp4od
+++ b/web/index/spotify/39mWWzaUZp0AXyN9Vnp4od
@@ -1,0 +1,1 @@
+../../data/Serie/045/metadata.json

--- a/web/index/spotify/3An657Q0wkVp4nIDg2zpcB
+++ b/web/index/spotify/3An657Q0wkVp4nIDg2zpcB
@@ -1,0 +1,1 @@
+../../data/Serie/164/metadata.json

--- a/web/index/spotify/3CMN8Y4kjoG4sFwlOEpfsV
+++ b/web/index/spotify/3CMN8Y4kjoG4sFwlOEpfsV
@@ -1,0 +1,1 @@
+../../data/Serie/077/metadata.json

--- a/web/index/spotify/3CZCwdMpj2jnjI43ZlnY5T
+++ b/web/index/spotify/3CZCwdMpj2jnjI43ZlnY5T
@@ -1,0 +1,1 @@
+../../data/Serie/088/metadata.json

--- a/web/index/spotify/3D9Jf4mdOBoeyrKpffYBvy
+++ b/web/index/spotify/3D9Jf4mdOBoeyrKpffYBvy
@@ -1,0 +1,1 @@
+../../data/Serie/146/metadata.json

--- a/web/index/spotify/3HgetGSMzg6bGM6b67YZcj
+++ b/web/index/spotify/3HgetGSMzg6bGM6b67YZcj
@@ -1,0 +1,1 @@
+../../data/Serie/123/metadata.json

--- a/web/index/spotify/3HxAtK23R2gFkW000mdaFT
+++ b/web/index/spotify/3HxAtK23R2gFkW000mdaFT
@@ -1,0 +1,1 @@
+../../data/Serie/140/metadata.json

--- a/web/index/spotify/3JJeehFIJTxhrltC6e44VT
+++ b/web/index/spotify/3JJeehFIJTxhrltC6e44VT
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-dreiTag/metadata.json

--- a/web/index/spotify/3JqJ2zIt3UzKug7onmbmAo
+++ b/web/index/spotify/3JqJ2zIt3UzKug7onmbmAo
@@ -1,0 +1,1 @@
+../../data/Serie/019/metadata.json

--- a/web/index/spotify/3NYWEuwAPt4PIJ4OeNxmzO
+++ b/web/index/spotify/3NYWEuwAPt4PIJ4OeNxmzO
@@ -1,0 +1,1 @@
+../../data/Serie/102/metadata.json

--- a/web/index/spotify/3O5STjjugoL5cNKfeRuBiU
+++ b/web/index/spotify/3O5STjjugoL5cNKfeRuBiU
@@ -1,0 +1,1 @@
+../../data/Serie/014/metadata.json

--- a/web/index/spotify/3Sv5tE8PcAlGY6Ys2ISQXF
+++ b/web/index/spotify/3Sv5tE8PcAlGY6Ys2ISQXF
@@ -1,0 +1,1 @@
+../../data/Serie/226/metadata.json

--- a/web/index/spotify/3TcIn19pVz5LXE8UleuLuX
+++ b/web/index/spotify/3TcIn19pVz5LXE8UleuLuX
@@ -1,0 +1,1 @@
+../../data/Serie/089/metadata.json

--- a/web/index/spotify/3UHj03eU7OnDuMVCTLbmcj
+++ b/web/index/spotify/3UHj03eU7OnDuMVCTLbmcj
@@ -1,0 +1,1 @@
+../../data/Serie/094/metadata.json

--- a/web/index/spotify/3XXYXmCEe185oHxigCRo97
+++ b/web/index/spotify/3XXYXmCEe185oHxigCRo97
@@ -1,0 +1,1 @@
+../../data/Serie/128/metadata.json

--- a/web/index/spotify/3bFvjy9IyWd7GrzN2dr0Hi
+++ b/web/index/spotify/3bFvjy9IyWd7GrzN2dr0Hi
@@ -1,0 +1,1 @@
+../../data/Serie/113/metadata.json

--- a/web/index/spotify/3bhsXwKIDwVK5LTkDCICp0
+++ b/web/index/spotify/3bhsXwKIDwVK5LTkDCICp0
@@ -1,0 +1,1 @@
+../../data/Serie/084/metadata.json

--- a/web/index/spotify/3egVVb6Zt0LdS6agBMGsiJ
+++ b/web/index/spotify/3egVVb6Zt0LdS6agBMGsiJ
@@ -1,0 +1,1 @@
+../../data/Spezial/und-das-kalte-Auge/metadata.json

--- a/web/index/spotify/3fotka2Hbq0N7V9KKWIDdw
+++ b/web/index/spotify/3fotka2Hbq0N7V9KKWIDdw
@@ -1,0 +1,1 @@
+../../data/Serie/056/metadata.json

--- a/web/index/spotify/3haGZZ8x7PyaGxiqcLmLf9
+++ b/web/index/spotify/3haGZZ8x7PyaGxiqcLmLf9
@@ -1,0 +1,1 @@
+../../data/Serie/099/metadata.json

--- a/web/index/spotify/3iWNsrEs9D0FFlKFfscdvL
+++ b/web/index/spotify/3iWNsrEs9D0FFlKFfscdvL
@@ -1,0 +1,1 @@
+../../data/Serie/047/metadata.json

--- a/web/index/spotify/3ieWqOL150wJOcft7iZHKZ
+++ b/web/index/spotify/3ieWqOL150wJOcft7iZHKZ
@@ -1,0 +1,1 @@
+../../data/Serie/210/metadata.json

--- a/web/index/spotify/3kBby5GJMI4U97XljKcPFD
+++ b/web/index/spotify/3kBby5GJMI4U97XljKcPFD
@@ -1,0 +1,1 @@
+../../data/Serie/107/metadata.json

--- a/web/index/spotify/3m7fR2wOkytZHq9m4QeBkB
+++ b/web/index/spotify/3m7fR2wOkytZHq9m4QeBkB
@@ -1,0 +1,1 @@
+../../data/Serie/137/metadata.json

--- a/web/index/spotify/3nGyW4ETDrDpInYEAQCyYS
+++ b/web/index/spotify/3nGyW4ETDrDpInYEAQCyYS
@@ -1,0 +1,1 @@
+../../data/Serie/007/metadata.json

--- a/web/index/spotify/3o2Gwvg8lqLNRnlV1v1s5K
+++ b/web/index/spotify/3o2Gwvg8lqLNRnlV1v1s5K
@@ -1,0 +1,1 @@
+../../data/Serie/222/metadata.json

--- a/web/index/spotify/3pXJh2A9gYzNt22rEIE5q7
+++ b/web/index/spotify/3pXJh2A9gYzNt22rEIE5q7
@@ -1,0 +1,1 @@
+../../data/Serie/052/metadata.json

--- a/web/index/spotify/3pbXIzVk7CA5VM2ltxu9TN
+++ b/web/index/spotify/3pbXIzVk7CA5VM2ltxu9TN
@@ -1,0 +1,1 @@
+../../data/Serie/195/metadata.json

--- a/web/index/spotify/3piMnopGsrEAKd1EZxsU3i
+++ b/web/index/spotify/3piMnopGsrEAKd1EZxsU3i
@@ -1,0 +1,1 @@
+../../data/Serie/116/metadata.json

--- a/web/index/spotify/3rxr4SLE2EG0EAlpSeI99o
+++ b/web/index/spotify/3rxr4SLE2EG0EAlpSeI99o
@@ -1,0 +1,1 @@
+../../data/Serie/117/metadata.json

--- a/web/index/spotify/3u0OSCwiOblOhm4dKjwLN5
+++ b/web/index/spotify/3u0OSCwiOblOhm4dKjwLN5
@@ -1,0 +1,1 @@
+../../data/Serie/151/metadata.json

--- a/web/index/spotify/3uFt95otJjaxH8o40tPtIS
+++ b/web/index/spotify/3uFt95otJjaxH8o40tPtIS
@@ -1,0 +1,1 @@
+../../data/Serie/158/metadata.json

--- a/web/index/spotify/3uggg8gNlh1kpBxLeOfFTV
+++ b/web/index/spotify/3uggg8gNlh1kpBxLeOfFTV
@@ -1,0 +1,1 @@
+../../data/Serie/154/metadata.json

--- a/web/index/spotify/3v4W4AFaI8uO7J88ojaSkS
+++ b/web/index/spotify/3v4W4AFaI8uO7J88ojaSkS
@@ -1,0 +1,1 @@
+../../data/Serie/108/metadata.json

--- a/web/index/spotify/3w5glP0mzKfTanzXpAjN27
+++ b/web/index/spotify/3w5glP0mzKfTanzXpAjN27
@@ -1,0 +1,1 @@
+../../data/Serie/178/metadata.json

--- a/web/index/spotify/3yofHdHiOLtVZlxWCZ4XBB
+++ b/web/index/spotify/3yofHdHiOLtVZlxWCZ4XBB
@@ -1,0 +1,1 @@
+../../data/Serie/083/metadata.json

--- a/web/index/spotify/427kScPIeUSfoNKCNercMC
+++ b/web/index/spotify/427kScPIeUSfoNKCNercMC
@@ -1,0 +1,1 @@
+../../data/Serie/166/metadata.json

--- a/web/index/spotify/451jKBwuSNrNgLlqEAZfra
+++ b/web/index/spotify/451jKBwuSNrNgLlqEAZfra
@@ -1,0 +1,1 @@
+../../data/Serie/223/metadata.json

--- a/web/index/spotify/48QVzskevXtA0KpJjXzvb1
+++ b/web/index/spotify/48QVzskevXtA0KpJjXzvb1
@@ -1,0 +1,1 @@
+../../data/Serie/043/metadata.json

--- a/web/index/spotify/4ADdmpObDUmBdvyJ9oNz5o
+++ b/web/index/spotify/4ADdmpObDUmBdvyJ9oNz5o
@@ -1,0 +1,1 @@
+../../data/Serie/103/metadata.json

--- a/web/index/spotify/4BZfSV9maCil4l4yftT74F
+++ b/web/index/spotify/4BZfSV9maCil4l4yftT74F
@@ -1,0 +1,1 @@
+../../data/Serie/213/metadata.json

--- a/web/index/spotify/4C4o7tHpT20QrdsvmI70uI
+++ b/web/index/spotify/4C4o7tHpT20QrdsvmI70uI
@@ -1,0 +1,1 @@
+../../data/Serie/098/metadata.json

--- a/web/index/spotify/4Exxckn0GwbhnGl6N4um2N
+++ b/web/index/spotify/4Exxckn0GwbhnGl6N4um2N
@@ -1,0 +1,1 @@
+../../data/Serie/202/metadata.json

--- a/web/index/spotify/4FxNfDSXqAg8N1D8NBtvZ5
+++ b/web/index/spotify/4FxNfDSXqAg8N1D8NBtvZ5
@@ -1,0 +1,1 @@
+../../data/Serie/201/metadata.json

--- a/web/index/spotify/4IZ7Lsm5le7HJPtaGLCrjO
+++ b/web/index/spotify/4IZ7Lsm5le7HJPtaGLCrjO
@@ -1,0 +1,1 @@
+../../data/Serie/179/metadata.json

--- a/web/index/spotify/4KEZWleMTT8lDaQDLgozFc
+++ b/web/index/spotify/4KEZWleMTT8lDaQDLgozFc
@@ -1,0 +1,1 @@
+../../data/Serie/095/metadata.json

--- a/web/index/spotify/4KXnXnpFRnQsjeZHpNC7X9
+++ b/web/index/spotify/4KXnXnpFRnQsjeZHpNC7X9
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-Super-Papagei-2004/metadata.json

--- a/web/index/spotify/4N9tvSjWfZXx3eHKblYEWQ
+++ b/web/index/spotify/4N9tvSjWfZXx3eHKblYEWQ
@@ -1,0 +1,1 @@
+../../data/Serie/001/metadata.json

--- a/web/index/spotify/4R24oyyqxGkczNpqWGCXBZ
+++ b/web/index/spotify/4R24oyyqxGkczNpqWGCXBZ
@@ -1,0 +1,1 @@
+../../data/Serie/036/metadata.json

--- a/web/index/spotify/4RZllDAKF3DeDz6jZJFXTa
+++ b/web/index/spotify/4RZllDAKF3DeDz6jZJFXTa
@@ -1,0 +1,1 @@
+../../data/Serie/109/metadata.json

--- a/web/index/spotify/4Y7Pxv7pzLmKVJowmBwOkd
+++ b/web/index/spotify/4Y7Pxv7pzLmKVJowmBwOkd
@@ -1,0 +1,1 @@
+../../data/Serie/143/metadata.json

--- a/web/index/spotify/4eX1wH67TDcYPZ1ZsjtPb6
+++ b/web/index/spotify/4eX1wH67TDcYPZ1ZsjtPb6
@@ -1,0 +1,1 @@
+../../data/Serie/106/metadata.json

--- a/web/index/spotify/4eorcDi9eRfsi7X0A91Z7u
+++ b/web/index/spotify/4eorcDi9eRfsi7X0A91Z7u
@@ -1,0 +1,1 @@
+../../data/Serie/131/metadata.json

--- a/web/index/spotify/4fv0pPN7ZjbUiejSTxTPZh
+++ b/web/index/spotify/4fv0pPN7ZjbUiejSTxTPZh
@@ -1,0 +1,1 @@
+../../data/Serie/163/metadata.json

--- a/web/index/spotify/4h75QQIxW1etThTuw6vWzg
+++ b/web/index/spotify/4h75QQIxW1etThTuw6vWzg
@@ -1,0 +1,1 @@
+../../data/Serie/010/metadata.json

--- a/web/index/spotify/4izJKxYT4fTwIZjoXNgkX7
+++ b/web/index/spotify/4izJKxYT4fTwIZjoXNgkX7
@@ -1,0 +1,1 @@
+../../data/Serie/165/metadata.json

--- a/web/index/spotify/4izXuApLzBWtWHrFqgcrxL
+++ b/web/index/spotify/4izXuApLzBWtWHrFqgcrxL
@@ -1,0 +1,1 @@
+../../data/Serie/080/metadata.json

--- a/web/index/spotify/4lLOJQU6QBH5cxmERE77La
+++ b/web/index/spotify/4lLOJQU6QBH5cxmERE77La
@@ -1,0 +1,1 @@
+../../data/Kurzgeschichten/und-der-Zeitgeist/metadata.json

--- a/web/index/spotify/4m6VlVOWfrUVhWWrueMo7p
+++ b/web/index/spotify/4m6VlVOWfrUVhWWrueMo7p
@@ -1,0 +1,1 @@
+../../data/Serie/193/metadata.json

--- a/web/index/spotify/4mlQEwk6I0XuksZCYTtatz
+++ b/web/index/spotify/4mlQEwk6I0XuksZCYTtatz
@@ -1,0 +1,1 @@
+../../data/Serie/070/metadata.json

--- a/web/index/spotify/4oH2GUWlSSsSgVkxyPVHX1
+++ b/web/index/spotify/4oH2GUWlSSsSgVkxyPVHX1
@@ -1,0 +1,1 @@
+../../data/Serie/055/metadata.json

--- a/web/index/spotify/4piiNuehCc4VjN8NBIcnRt
+++ b/web/index/spotify/4piiNuehCc4VjN8NBIcnRt
@@ -1,0 +1,1 @@
+../../data/Serie/198/metadata.json

--- a/web/index/spotify/4qbxSVpr3NxRjdIVC411ue
+++ b/web/index/spotify/4qbxSVpr3NxRjdIVC411ue
@@ -1,0 +1,1 @@
+../../data/Serie/176/metadata.json

--- a/web/index/spotify/4rCAnDrNJ96srnBEoA0ISj
+++ b/web/index/spotify/4rCAnDrNJ96srnBEoA0ISj
@@ -1,0 +1,1 @@
+../../data/Serie/159/metadata.json

--- a/web/index/spotify/4uF9MjchYgq5jjPi5x5YZy
+++ b/web/index/spotify/4uF9MjchYgq5jjPi5x5YZy
@@ -1,0 +1,1 @@
+../../data/Serie/086/metadata.json

--- a/web/index/spotify/4uggmrJ3Xpm1e2tcz6laze
+++ b/web/index/spotify/4uggmrJ3Xpm1e2tcz6laze
@@ -1,0 +1,1 @@
+../../data/Serie/175/metadata.json

--- a/web/index/spotify/4vj4Dq2q7fyvwY7UCj2vin
+++ b/web/index/spotify/4vj4Dq2q7fyvwY7UCj2vin
@@ -1,0 +1,1 @@
+../../data/Spezial/und-das-Grab-der-Maya/metadata.json

--- a/web/index/spotify/4zCPToY7AoTqvOKf4HRqAN
+++ b/web/index/spotify/4zCPToY7AoTqvOKf4HRqAN
@@ -1,0 +1,1 @@
+../../data/Serie/182/metadata.json

--- a/web/index/spotify/54eP8BYMR270sTqklv83V0
+++ b/web/index/spotify/54eP8BYMR270sTqklv83V0
@@ -1,0 +1,1 @@
+../../data/Serie/006/metadata.json

--- a/web/index/spotify/5B7w9vkfh979tEyzwkLk9k
+++ b/web/index/spotify/5B7w9vkfh979tEyzwkLk9k
@@ -1,0 +1,1 @@
+../../data/Serie/184/metadata.json

--- a/web/index/spotify/5GPTZKrD7eaCp9p6VOBuIN
+++ b/web/index/spotify/5GPTZKrD7eaCp9p6VOBuIN
@@ -1,0 +1,1 @@
+../../data/Serie/063/metadata.json

--- a/web/index/spotify/5Hafee7JOUqNVqtsrCtrTZ
+++ b/web/index/spotify/5Hafee7JOUqNVqtsrCtrTZ
@@ -1,0 +1,1 @@
+../../data/Serie/115/metadata.json

--- a/web/index/spotify/5HiWGQmaCRaxdaon49Iw9S
+++ b/web/index/spotify/5HiWGQmaCRaxdaon49Iw9S
@@ -1,0 +1,1 @@
+../../data/Serie/136/metadata.json

--- a/web/index/spotify/5IRxm1lo35PttzU8YLslZy
+++ b/web/index/spotify/5IRxm1lo35PttzU8YLslZy
@@ -1,0 +1,1 @@
+../../data/Serie/048/metadata.json

--- a/web/index/spotify/5JHijjtr65MjdNOnNvD3Ec
+++ b/web/index/spotify/5JHijjtr65MjdNOnNvD3Ec
@@ -1,0 +1,1 @@
+../../data/Serie/029/metadata.json

--- a/web/index/spotify/5KUXX8H2LNsuik46M5XLx0
+++ b/web/index/spotify/5KUXX8H2LNsuik46M5XLx0
@@ -1,0 +1,1 @@
+../../data/Serie/041/metadata.json

--- a/web/index/spotify/5L2KCw21QT3JKg1KKuqSeF
+++ b/web/index/spotify/5L2KCw21QT3JKg1KKuqSeF
@@ -1,0 +1,1 @@
+../../data/Serie/114/metadata.json

--- a/web/index/spotify/5PEHeYcUhz1Aq02ZB1pUgJ
+++ b/web/index/spotify/5PEHeYcUhz1Aq02ZB1pUgJ
@@ -1,0 +1,1 @@
+../../data/Serie/169/metadata.json

--- a/web/index/spotify/5RBu5WK95Q6BtWfA4o3Vgs
+++ b/web/index/spotify/5RBu5WK95Q6BtWfA4o3Vgs
@@ -1,0 +1,1 @@
+../../data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json

--- a/web/index/spotify/5RoL0jdWMoJ8KRFVOeFYtX
+++ b/web/index/spotify/5RoL0jdWMoJ8KRFVOeFYtX
@@ -1,0 +1,1 @@
+../../data/Serie/174/metadata.json

--- a/web/index/spotify/5W6dRiaeSVE7zUBYHbepak
+++ b/web/index/spotify/5W6dRiaeSVE7zUBYHbepak
@@ -1,0 +1,1 @@
+../../data/Serie/057/metadata.json

--- a/web/index/spotify/5YWM39RnabpxekZuHriTam
+++ b/web/index/spotify/5YWM39RnabpxekZuHriTam
@@ -1,0 +1,1 @@
+../../data/Serie/005/metadata.json

--- a/web/index/spotify/5iNeANVy4supl8HowB9V2h
+++ b/web/index/spotify/5iNeANVy4supl8HowB9V2h
@@ -1,0 +1,1 @@
+../../data/Serie/152/metadata.json

--- a/web/index/spotify/5ilbdbGu5eQRUIsbslyiLe
+++ b/web/index/spotify/5ilbdbGu5eQRUIsbslyiLe
@@ -1,0 +1,1 @@
+../../data/Serie/020/metadata.json

--- a/web/index/spotify/5iobM2gNVymvP8XqnRnHVR
+++ b/web/index/spotify/5iobM2gNVymvP8XqnRnHVR
@@ -1,0 +1,1 @@
+../../data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json

--- a/web/index/spotify/5kevid18ttcAPK1vk0kLtc
+++ b/web/index/spotify/5kevid18ttcAPK1vk0kLtc
@@ -1,0 +1,1 @@
+../../data/Serie/186/metadata.json

--- a/web/index/spotify/5l5CFSjzSdhbflqmplcTFX
+++ b/web/index/spotify/5l5CFSjzSdhbflqmplcTFX
@@ -1,0 +1,1 @@
+../../data/Serie/130/metadata.json

--- a/web/index/spotify/5u2wd0lYukcINw8dUFCREq
+++ b/web/index/spotify/5u2wd0lYukcINw8dUFCREq
@@ -1,0 +1,1 @@
+../../data/Spezial/Eine-schreckliche-Bescherung/metadata.json

--- a/web/index/spotify/5ub4r9Q0YVMrWuOEesu6dR
+++ b/web/index/spotify/5ub4r9Q0YVMrWuOEesu6dR
@@ -1,0 +1,1 @@
+../../data/Serie/096/metadata.json

--- a/web/index/spotify/61OtrnMm1lqoMgMRb1aw7g
+++ b/web/index/spotify/61OtrnMm1lqoMgMRb1aw7g
@@ -1,0 +1,1 @@
+../../data/Serie/003/metadata.json

--- a/web/index/spotify/623V90QowsF4WSqV3cHGKf
+++ b/web/index/spotify/623V90QowsF4WSqV3cHGKf
@@ -1,0 +1,1 @@
+../../data/Serie/155/metadata.json

--- a/web/index/spotify/62CKj2RCiWDDUtBWTn4KxQ
+++ b/web/index/spotify/62CKj2RCiWDDUtBWTn4KxQ
@@ -1,0 +1,1 @@
+../../data/Serie/170/metadata.json

--- a/web/index/spotify/62z7yW4RKhhuAp0RklmNvc
+++ b/web/index/spotify/62z7yW4RKhhuAp0RklmNvc
@@ -1,0 +1,1 @@
+../../data/Serie/065/metadata.json

--- a/web/index/spotify/67qFOAxbhNRHEIeOjQ9Zkp
+++ b/web/index/spotify/67qFOAxbhNRHEIeOjQ9Zkp
@@ -1,0 +1,1 @@
+../../data/Serie/023/metadata.json

--- a/web/index/spotify/68NWcgqeCQMZ3QcPJXBhzH
+++ b/web/index/spotify/68NWcgqeCQMZ3QcPJXBhzH
@@ -1,0 +1,1 @@
+../../data/Serie/122/metadata.json

--- a/web/index/spotify/69VLqtWA1bpguYRCFRAxQl
+++ b/web/index/spotify/69VLqtWA1bpguYRCFRAxQl
@@ -1,0 +1,1 @@
+../../data/Serie/074/metadata.json

--- a/web/index/spotify/6Anfub4AoVHg9bhJ7js0L0
+++ b/web/index/spotify/6Anfub4AoVHg9bhJ7js0L0
@@ -1,0 +1,1 @@
+../../data/Serie/172/metadata.json

--- a/web/index/spotify/6BxvBG51szGmlg5x3F1rHj
+++ b/web/index/spotify/6BxvBG51szGmlg5x3F1rHj
@@ -1,0 +1,1 @@
+../../data/Serie/207/metadata.json

--- a/web/index/spotify/6DKfjDIB1BSYRGAi2YJYm3
+++ b/web/index/spotify/6DKfjDIB1BSYRGAi2YJYm3
@@ -1,0 +1,1 @@
+../../data/Serie/050/metadata.json

--- a/web/index/spotify/6DWykdlgf60Mq02hPAGYVD
+++ b/web/index/spotify/6DWykdlgf60Mq02hPAGYVD
@@ -1,0 +1,1 @@
+../../data/Serie/058/metadata.json

--- a/web/index/spotify/6EEN6onzbHIOxnwUkGfKhv
+++ b/web/index/spotify/6EEN6onzbHIOxnwUkGfKhv
@@ -1,0 +1,1 @@
+../../data/Serie/071/metadata.json

--- a/web/index/spotify/6JNNLdq9ELeKENK3RmxLWQ
+++ b/web/index/spotify/6JNNLdq9ELeKENK3RmxLWQ
@@ -1,0 +1,1 @@
+../../data/Serie/044/metadata.json

--- a/web/index/spotify/6MRsf5IcfqJIogaNqtESnh
+++ b/web/index/spotify/6MRsf5IcfqJIogaNqtESnh
@@ -1,0 +1,1 @@
+../../data/Serie/008/metadata.json

--- a/web/index/spotify/6Mi4Smq7Fn8qNOg6Xnf0In
+++ b/web/index/spotify/6Mi4Smq7Fn8qNOg6Xnf0In
@@ -1,0 +1,1 @@
+../../data/Serie/105/metadata.json

--- a/web/index/spotify/6R4gnRHXKgw2cxneWgTiEL
+++ b/web/index/spotify/6R4gnRHXKgw2cxneWgTiEL
@@ -1,0 +1,1 @@
+../../data/Serie/037/metadata.json

--- a/web/index/spotify/6RDPGc2budsdTw1lj8f2O5
+++ b/web/index/spotify/6RDPGc2budsdTw1lj8f2O5
@@ -1,0 +1,1 @@
+../../data/Serie/076/metadata.json

--- a/web/index/spotify/6RJf8I60kNhnYxlnw7eTGv
+++ b/web/index/spotify/6RJf8I60kNhnYxlnw7eTGv
@@ -1,0 +1,1 @@
+../../data/Serie/139/metadata.json

--- a/web/index/spotify/6RXr8BmKNSK9Zk11k0I7Dl
+++ b/web/index/spotify/6RXr8BmKNSK9Zk11k0I7Dl
@@ -1,0 +1,1 @@
+../../data/Serie/025/metadata.json

--- a/web/index/spotify/6TjzBTmeDakBgh5NOGj1BC
+++ b/web/index/spotify/6TjzBTmeDakBgh5NOGj1BC
@@ -1,0 +1,1 @@
+../../data/Serie/145/metadata.json

--- a/web/index/spotify/6UN8m07SmIzyDe63H0oljL
+++ b/web/index/spotify/6UN8m07SmIzyDe63H0oljL
@@ -1,0 +1,1 @@
+../../data/Spezial/und-das-versunkene-Schiff/metadata.json

--- a/web/index/spotify/6WgRUQY49NRG6JT6dJ4xEq
+++ b/web/index/spotify/6WgRUQY49NRG6JT6dJ4xEq
@@ -1,0 +1,1 @@
+../../data/Serie/208/metadata.json

--- a/web/index/spotify/6YX4i7aMCYmn20zvAFM3lG
+++ b/web/index/spotify/6YX4i7aMCYmn20zvAFM3lG
@@ -1,0 +1,1 @@
+../../data/Serie/046/metadata.json

--- a/web/index/spotify/6YbaUGc6ZeR1YnDFGQJV8F
+++ b/web/index/spotify/6YbaUGc6ZeR1YnDFGQJV8F
@@ -1,0 +1,1 @@
+../../data/Serie/171/metadata.json

--- a/web/index/spotify/6cPgVsZ6TPyVIP9BHP5ty5
+++ b/web/index/spotify/6cPgVsZ6TPyVIP9BHP5ty5
@@ -1,0 +1,1 @@
+../../data/Serie/150/metadata.json

--- a/web/index/spotify/6d21lwV9Imn3ObWUyV1UN2
+++ b/web/index/spotify/6d21lwV9Imn3ObWUyV1UN2
@@ -1,0 +1,1 @@
+../../data/Serie/121/metadata.json

--- a/web/index/spotify/6d3Pavm0enVICdOvBEqxYA
+++ b/web/index/spotify/6d3Pavm0enVICdOvBEqxYA
@@ -1,0 +1,1 @@
+../../data/Serie/038/metadata.json

--- a/web/index/spotify/6ewdyVIW2LurJhYGU0UBAa
+++ b/web/index/spotify/6ewdyVIW2LurJhYGU0UBAa
@@ -1,0 +1,1 @@
+../../data/Serie/219/metadata.json

--- a/web/index/spotify/6fVTJQKJBku1yaOmZOnfwg
+++ b/web/index/spotify/6fVTJQKJBku1yaOmZOnfwg
@@ -1,0 +1,1 @@
+../../data/Serie/120/metadata.json

--- a/web/index/spotify/6gxj68DOHRSVlEM4xzwtRy
+++ b/web/index/spotify/6gxj68DOHRSVlEM4xzwtRy
@@ -1,0 +1,1 @@
+../../data/Serie/141/metadata.json

--- a/web/index/spotify/6joRNVLN69v3eSnxM86BSM
+++ b/web/index/spotify/6joRNVLN69v3eSnxM86BSM
@@ -1,0 +1,1 @@
+../../data/Serie/104/metadata.json

--- a/web/index/spotify/6lyjnz3h0CJ87CS7YvK3bT
+++ b/web/index/spotify/6lyjnz3h0CJ87CS7YvK3bT
@@ -1,0 +1,1 @@
+../../data/Serie/228/metadata.json

--- a/web/index/spotify/6qj4LD0zotutkIgEg9OvDj
+++ b/web/index/spotify/6qj4LD0zotutkIgEg9OvDj
@@ -1,0 +1,1 @@
+../../data/Serie/066/metadata.json

--- a/web/index/spotify/6t7Y1H4dUM0d4JycenVskN
+++ b/web/index/spotify/6t7Y1H4dUM0d4JycenVskN
@@ -1,0 +1,1 @@
+../../data/Serie/078/metadata.json

--- a/web/index/spotify/6tioH9PNiZbmUT54MsiX5k
+++ b/web/index/spotify/6tioH9PNiZbmUT54MsiX5k
@@ -1,0 +1,1 @@
+../../data/Serie/180/metadata.json

--- a/web/index/spotify/6uj8JeIgluMibSu8Divkbh
+++ b/web/index/spotify/6uj8JeIgluMibSu8Divkbh
@@ -1,0 +1,1 @@
+../../data/Serie/187/metadata.json

--- a/web/index/spotify/6zwBnyiy9Hy9TAser0DOuL
+++ b/web/index/spotify/6zwBnyiy9Hy9TAser0DOuL
@@ -1,0 +1,1 @@
+../../data/Serie/100/metadata.json

--- a/web/index/spotify/71kiy6INV3LzsCddpTZoHf
+++ b/web/index/spotify/71kiy6INV3LzsCddpTZoHf
@@ -1,0 +1,1 @@
+../../data/Serie/051/metadata.json

--- a/web/index/spotify/71moidSHTwJsc2N70axEce
+++ b/web/index/spotify/71moidSHTwJsc2N70axEce
@@ -1,0 +1,1 @@
+../../data/Serie/142/metadata.json

--- a/web/index/spotify/76M62o1rdKEqTN1JIbGdGV
+++ b/web/index/spotify/76M62o1rdKEqTN1JIbGdGV
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json

--- a/web/index/spotify/76pYNMMVZTiuNy3IoXcavU
+++ b/web/index/spotify/76pYNMMVZTiuNy3IoXcavU
@@ -1,0 +1,1 @@
+../../data/Serie/215/metadata.json

--- a/web/index/spotify/77aawQqgLQZxPb9kwSg0JR
+++ b/web/index/spotify/77aawQqgLQZxPb9kwSg0JR
@@ -1,0 +1,1 @@
+../../data/Serie/168/metadata.json

--- a/web/index/spotify/78wUIvkGT2CdWW0ngeEy8V
+++ b/web/index/spotify/78wUIvkGT2CdWW0ngeEy8V
@@ -1,0 +1,1 @@
+../../data/Serie/156/metadata.json

--- a/web/index/spotify/79Drf49yNdGLBzzHMGGmBz
+++ b/web/index/spotify/79Drf49yNdGLBzzHMGGmBz
@@ -1,0 +1,1 @@
+../../data/Serie/203/metadata.json

--- a/web/index/spotify/79enDMGQWH7LQ5weNB96g7
+++ b/web/index/spotify/79enDMGQWH7LQ5weNB96g7
@@ -1,0 +1,1 @@
+../../data/Serie/138/metadata.json

--- a/web/index/spotify/7Dbd2rya9glmBLVxclcU4d
+++ b/web/index/spotify/7Dbd2rya9glmBLVxclcU4d
@@ -1,0 +1,1 @@
+../../data/Serie/028/metadata.json

--- a/web/index/spotify/7Hjk98j1FSrHV5IHWmeeFh
+++ b/web/index/spotify/7Hjk98j1FSrHV5IHWmeeFh
@@ -1,0 +1,1 @@
+../../data/Serie/067/metadata.json

--- a/web/index/spotify/7JhdaReI98XYFrzb3jJPFa
+++ b/web/index/spotify/7JhdaReI98XYFrzb3jJPFa
@@ -1,0 +1,1 @@
+../../data/Serie/224/metadata.json

--- a/web/index/spotify/7K3VEzD1rm0dgUGBi1i5PW
+++ b/web/index/spotify/7K3VEzD1rm0dgUGBi1i5PW
@@ -1,0 +1,1 @@
+../../data/Serie/032/metadata.json

--- a/web/index/spotify/7K7dfMc3VwHOKtENI1BWTD
+++ b/web/index/spotify/7K7dfMc3VwHOKtENI1BWTD
@@ -1,0 +1,1 @@
+../../data/Serie/149/metadata.json

--- a/web/index/spotify/7a9rwqPkVdU4FC2cWFudVO
+++ b/web/index/spotify/7a9rwqPkVdU4FC2cWFudVO
@@ -1,0 +1,1 @@
+../../data/Serie/093/metadata.json

--- a/web/index/spotify/7b9OiVsktCZyldiAnjkVDx
+++ b/web/index/spotify/7b9OiVsktCZyldiAnjkVDx
@@ -1,0 +1,1 @@
+../../data/Serie/111/metadata.json

--- a/web/index/spotify/7bTKP2hU0LRks1bXN1R7ko
+++ b/web/index/spotify/7bTKP2hU0LRks1bXN1R7ko
@@ -1,0 +1,1 @@
+../../data/Serie/199/metadata.json

--- a/web/index/spotify/7beppYTqtHAEPKoXyodssF
+++ b/web/index/spotify/7beppYTqtHAEPKoXyodssF
@@ -1,0 +1,1 @@
+../../data/Serie/162/metadata.json

--- a/web/index/spotify/7cBoiWgh1bTMZmCwJE0eMu
+++ b/web/index/spotify/7cBoiWgh1bTMZmCwJE0eMu
@@ -1,0 +1,1 @@
+../../data/Serie/060/metadata.json

--- a/web/index/spotify/7eHh5PAxQBt5KBWzd3a10G
+++ b/web/index/spotify/7eHh5PAxQBt5KBWzd3a10G
@@ -1,0 +1,1 @@
+../../data/Serie/185/metadata.json

--- a/web/index/spotify/7ehMwTyKuIM4zdiltMxE4X
+++ b/web/index/spotify/7ehMwTyKuIM4zdiltMxE4X
@@ -1,0 +1,1 @@
+../../data/Kurzgeschichten/und-der-schwarze-Tag/metadata.json

--- a/web/index/spotify/7i50aK2wKvszWNnay4DtxP
+++ b/web/index/spotify/7i50aK2wKvszWNnay4DtxP
@@ -1,0 +1,1 @@
+../../data/Serie/022/metadata.json

--- a/web/index/spotify/7iysTnwaaFrPPWAuUyyi0c
+++ b/web/index/spotify/7iysTnwaaFrPPWAuUyyi0c
@@ -1,0 +1,1 @@
+../../data/Serie/082/metadata.json

--- a/web/index/spotify/7khAMIQlYBmW7mI9cphDhJ
+++ b/web/index/spotify/7khAMIQlYBmW7mI9cphDhJ
@@ -1,0 +1,1 @@
+../../data/Serie/206/metadata.json

--- a/web/index/spotify/7kskBahbrQWCOiaXKuoPjE
+++ b/web/index/spotify/7kskBahbrQWCOiaXKuoPjE
@@ -1,0 +1,1 @@
+../../data/Serie/167/metadata.json

--- a/web/index/spotify/7mH8vdj0TkiPO6fMHBCvYj
+++ b/web/index/spotify/7mH8vdj0TkiPO6fMHBCvYj
@@ -1,0 +1,1 @@
+../../data/Spezial/und-der-Tornadojaeger/metadata.json

--- a/web/index/spotify/7nxSEeJiQwI34VwnWT83C9
+++ b/web/index/spotify/7nxSEeJiQwI34VwnWT83C9
@@ -1,0 +1,1 @@
+../../data/Serie/153/metadata.json

--- a/web/index/spotify/7osWCNCcvGfqP31G7281iL
+++ b/web/index/spotify/7osWCNCcvGfqP31G7281iL
@@ -1,0 +1,1 @@
+../../data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json

--- a/web/index/spotify/7pZotNNAYOkeHNvJRKzYRk
+++ b/web/index/spotify/7pZotNNAYOkeHNvJRKzYRk
@@ -1,0 +1,1 @@
+../../data/Serie/211/metadata.json

--- a/web/index/spotify/7rPDg8NlFJ1a2HMTQvVaB2
+++ b/web/index/spotify/7rPDg8NlFJ1a2HMTQvVaB2
@@ -1,0 +1,1 @@
+../../data/Serie/119/metadata.json

--- a/web/index/spotify/7t2SteAH5OnLLC1ghTAmka
+++ b/web/index/spotify/7t2SteAH5OnLLC1ghTAmka
@@ -1,0 +1,1 @@
+../../data/Serie/049/metadata.json

--- a/web/index/spotify/7yMRFgR8FRyWwiLHzQQa2B
+++ b/web/index/spotify/7yMRFgR8FRyWwiLHzQQa2B
@@ -1,0 +1,1 @@
+../../data/Serie/092/metadata.json

--- a/web/index/spotify/7ynXpeQRwzqKiv8WVh7c7B
+++ b/web/index/spotify/7ynXpeQRwzqKiv8WVh7c7B
@@ -1,0 +1,1 @@
+../../data/Spezial/O-du-finstere/metadata.json


### PR DESCRIPTION
### Added web index for looking up JSON by Apple Music and Spotify IDs

* `http://v2.dreimetadaten.de/index/apple-music/<collection-id>`
* `http://v2.dreimetadaten.de/index/spotify/<album-id>`

e.g. http://v2.dreimetadaten.de/index/apple-music/1744386522 –> http://v2.dreimetadaten.de/data/Serie/228/metadata.json

Solves #36.