### PR TITLE
Fix rip log files and their model property names

### DIFF
--- a/code/dreimetadaten/Export/WebDataExporter.swift
+++ b/code/dreimetadaten/Export/WebDataExporter.swift
@@ -119,9 +119,9 @@ struct WebDataExporter {
 			// Check cover file
 			_ = try hörspiel.links?.cover.map(fileURL(for:))
 			
-			// Check XLD log file
+			// Check rip log file
 			try hörspiel.medien?.forEach {
-				_ = try $0.xld_log.map(fileURL(for:))
+				_ = try $0.ripLog.map(fileURL(for:))
 			}
 			
 			// Teile

--- a/code/dreimetadaten/MetadataModel/MetadataObjectModel.swift
+++ b/code/dreimetadaten/MetadataModel/MetadataObjectModel.swift
@@ -115,7 +115,7 @@ extension MetadataObjectModel {
 	
 	struct Medium: Codable {
 		var tracks: [Kapitel]
-		var xld_log: String?
+		var ripLog: String?
 	}
 	
 }
@@ -175,7 +175,7 @@ extension MetadataObjectModel {
 			"pseudonym",
 			
 			"tracks",
-			"xld_log",
+			"ripLog",
 			
 			"json",
 			"ffmetadata",
@@ -418,13 +418,13 @@ extension MetadataObjectModel {
 						}
 					return Medium(
 						tracks: tracks,
-						xld_log: medium.xldLog ? "" : nil
+						ripLog: medium.ripLog ? "" : nil
 					)
 				}
 			let multipleMedien = medien.count > 1
 			for index in medien.indices {
-				if medien[index].xld_log != nil {
-					medien[index].xld_log = "rip_log\(multipleMedien ? String(index+1) : "").txt"
+				if medien[index].ripLog != nil {
+					medien[index].ripLog = "rip_log\(multipleMedien ? String(index+1) : "").txt"
 				}
 			}
 			
@@ -510,7 +510,7 @@ extension MetadataObjectModel {
 				prepend(to: &hörspiel.links!.cover)
 			}
 			hörspiel.medien?.indices.forEach {
-				prepend(to: &hörspiel.medien![$0].xld_log)
+				prepend(to: &hörspiel.medien![$0].ripLog)
 			}
 			hörspiel.teile?.enumerated().forEach { (index, teil) in
 				apply(url: url.appendingPathComponent(String(teil.teilNummer)), to: teil)

--- a/code/dreimetadaten/MetadataModel/MetadataRelationalModel.swift
+++ b/code/dreimetadaten/MetadataModel/MetadataRelationalModel.swift
@@ -94,7 +94,7 @@ extension MetadataRelationalModel {
 		
 		var hörspielID: Hörspiel.ID
 		var position: UInt
-		var xldLog: Bool
+		var ripLog: Bool
 	}
 	
 	struct Track: Codable {
@@ -332,7 +332,7 @@ extension MetadataRelationalModel {
 				.notNull()
 			foreignKeyReference(t, to: Hörspiel.self)
 			positionColumn(t)
-			t.column("xldLog", .boolean)
+			t.column("ripLog", .boolean)
 				.notNull()
 			t.uniqueKey([Hörspiel.primaryKeyName, "position"])
 		}

--- a/code/dreimetadaten/Migrator.swift
+++ b/code/dreimetadaten/Migrator.swift
@@ -152,14 +152,14 @@ class Migrator {
 	
 	private func migrate(medium objectItem: MetadataObjectModel.Hörspiel, hörspielID: MetadataRelationalModel.Hörspiel.ID?, rootHörspielID: MetadataRelationalModel.Hörspiel.ID?) {
 		let newID = (relationalModel.medium.last?.mediumID ?? 0) + 1
-		let xldLog = objectItem.links?.xld_log != nil
+		let ripLog = objectItem.links?.xld_log != nil
 		let relationalItem: MetadataRelationalModel.Medium
 		if let objectTeil = objectItem as? MetadataObjectModel.Teil {
 			relationalItem = .init(
 				mediumID: newID,
 				hörspielID: rootHörspielID!,
 				position: objectTeil.teilNummer,
-				xldLog: xldLog
+				ripLog: ripLog
 			)
 		}
 		else {
@@ -167,7 +167,7 @@ class Migrator {
 				mediumID: newID,
 				hörspielID: hörspielID!,
 				position: 1,
-				xldLog: xldLog
+				ripLog: ripLog
 			)
 		}
 		relationalModel.medium.append(relationalItem)

--- a/metadata/db.sql
+++ b/metadata/db.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS "medium"(
   "mediumID" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   "hörspielID" INTEGER NOT NULL REFERENCES "hörspiel"("hörspielID") ON DELETE CASCADE ON UPDATE CASCADE,
   "position" INTEGER NOT NULL CHECK("position" > 0),
-  "xldLog" BOOLEAN NOT NULL,
+  "ripLog" BOOLEAN NOT NULL,
   UNIQUE("hörspielID", "position")
 );
 CREATE TABLE IF NOT EXISTS "track"(

--- a/metadata/json/DiE_DR3i.json
+++ b/metadata/json/DiE_DR3i.json
@@ -207,7 +207,7 @@
               "end" : 4302080
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -337,7 +337,7 @@
               "end" : 4828320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt"
         }
       ],
       "teile" : [
@@ -896,7 +896,7 @@
               "end" : 3918160
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -966,7 +966,7 @@
               "end" : 4075613
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log2.txt"
         }
       ]
     },
@@ -1162,7 +1162,7 @@
               "end" : 4634013
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/2/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/2/rip_log.txt"
         }
       ]
     },
@@ -1360,7 +1360,7 @@
               "end" : 4113813
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/3/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/3/rip_log.txt"
         }
       ]
     },
@@ -1551,7 +1551,7 @@
               "end" : 4747133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/4/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/4/rip_log.txt"
         }
       ]
     },
@@ -1725,7 +1725,7 @@
               "end" : 4409520
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/5/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/5/rip_log.txt"
         }
       ]
     },
@@ -1893,7 +1893,7 @@
               "end" : 3924760
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/6/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/6/rip_log.txt"
         }
       ]
     },
@@ -2078,7 +2078,7 @@
               "end" : 3920920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/7/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/7/rip_log.txt"
         }
       ]
     },
@@ -2242,7 +2242,7 @@
               "end" : 4627360
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/8/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/8/rip_log.txt"
         }
       ]
     }

--- a/metadata/json/Kurzgeschichten.json
+++ b/metadata/json/Kurzgeschichten.json
@@ -171,7 +171,7 @@
               "end" : 4017840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -196,7 +196,7 @@
               "end" : 2679040
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -221,7 +221,7 @@
               "end" : 3602480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -935,7 +935,7 @@
               "end" : 3073920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -970,7 +970,7 @@
               "end" : 2748267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -1020,7 +1020,7 @@
               "end" : 3898467
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -1673,7 +1673,7 @@
               "end" : 3652267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -1728,7 +1728,7 @@
               "end" : 4569373
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt"
         }
       ],
       "teile" : [
@@ -2307,7 +2307,7 @@
               "end" : 4096840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -2342,7 +2342,7 @@
               "end" : 3657040
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -2377,7 +2377,7 @@
               "end" : 3975307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt"
         }
       ],
       "teile" : [

--- a/metadata/json/Serie.json
+++ b/metadata/json/Serie.json
@@ -820,7 +820,7 @@
               "end" : 2960987
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/005/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/005/rip_log.txt"
         }
       ]
     },
@@ -1787,7 +1787,7 @@
               "end" : 2894907
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/011/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/011/rip_log.txt"
         }
       ]
     },
@@ -8002,7 +8002,7 @@
               "end" : 2670120
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/049/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/049/rip_log.txt"
         }
       ]
     },
@@ -8155,7 +8155,7 @@
               "end" : 3435173
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/050/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/050/rip_log.txt"
         }
       ]
     },
@@ -8296,7 +8296,7 @@
               "end" : 3270107
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/051/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/051/rip_log.txt"
         }
       ]
     },
@@ -8469,7 +8469,7 @@
               "end" : 3267773
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/052/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/052/rip_log.txt"
         }
       ]
     },
@@ -8630,7 +8630,7 @@
               "end" : 3203173
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/053/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/053/rip_log.txt"
         }
       ]
     },
@@ -8792,7 +8792,7 @@
               "end" : 3048040
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/054/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/054/rip_log.txt"
         }
       ]
     },
@@ -8957,7 +8957,7 @@
               "end" : 3056533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/055/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/055/rip_log.txt"
         }
       ]
     },
@@ -9122,7 +9122,7 @@
               "end" : 2967587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/056/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/056/rip_log.txt"
         }
       ]
     },
@@ -9279,7 +9279,7 @@
               "end" : 2605187
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/057/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/057/rip_log.txt"
         }
       ]
     },
@@ -9441,7 +9441,7 @@
               "end" : 2711893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/058/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/058/rip_log.txt"
         }
       ]
     },
@@ -9602,7 +9602,7 @@
               "end" : 2667307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/059/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/059/rip_log.txt"
         }
       ]
     },
@@ -9768,7 +9768,7 @@
               "end" : 2826880
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/060/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/060/rip_log.txt"
         }
       ]
     },
@@ -9933,7 +9933,7 @@
               "end" : 3569320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/061/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/061/rip_log.txt"
         }
       ]
     },
@@ -10098,7 +10098,7 @@
               "end" : 3563227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/062/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/062/rip_log.txt"
         }
       ]
     },
@@ -10264,7 +10264,7 @@
               "end" : 4014467
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/063/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/063/rip_log.txt"
         }
       ]
     },
@@ -10430,7 +10430,7 @@
               "end" : 3969547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/064/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/064/rip_log.txt"
         }
       ]
     },
@@ -10603,7 +10603,7 @@
               "end" : 3579173
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/065/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/065/rip_log.txt"
         }
       ]
     },
@@ -10760,7 +10760,7 @@
               "end" : 3555013
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/066/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/066/rip_log.txt"
         }
       ]
     },
@@ -10921,7 +10921,7 @@
               "end" : 3799320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/067/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/067/rip_log.txt"
         }
       ]
     },
@@ -11062,7 +11062,7 @@
               "end" : 3581227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/068/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/068/rip_log.txt"
         }
       ]
     },
@@ -11236,7 +11236,7 @@
               "end" : 3942387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/069/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/069/rip_log.txt"
         }
       ]
     },
@@ -11401,7 +11401,7 @@
               "end" : 3784293
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/070/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/070/rip_log.txt"
         }
       ]
     },
@@ -11579,7 +11579,7 @@
               "end" : 3994440
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/071/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/071/rip_log.txt"
         }
       ]
     },
@@ -11752,7 +11752,7 @@
               "end" : 3477893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/072/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/072/rip_log.txt"
         }
       ]
     },
@@ -11909,7 +11909,7 @@
               "end" : 3997320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/073/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/073/rip_log.txt"
         }
       ]
     },
@@ -12083,7 +12083,7 @@
               "end" : 4442107
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/074/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/074/rip_log.txt"
         }
       ]
     },
@@ -12236,7 +12236,7 @@
               "end" : 3339600
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/075/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/075/rip_log.txt"
         }
       ]
     },
@@ -12397,7 +12397,7 @@
               "end" : 4184827
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/076/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/076/rip_log.txt"
         }
       ]
     },
@@ -12547,7 +12547,7 @@
               "end" : 3559333
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/077/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/077/rip_log.txt"
         }
       ]
     },
@@ -12693,7 +12693,7 @@
               "end" : 3448987
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/078/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/078/rip_log.txt"
         }
       ]
     },
@@ -12865,7 +12865,7 @@
               "end" : 4612307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/079/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/079/rip_log.txt"
         }
       ]
     },
@@ -12983,7 +12983,7 @@
               "end" : 3560667
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/080/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/080/rip_log.txt"
         }
       ]
     },
@@ -13124,7 +13124,7 @@
               "end" : 2983827
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/081/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/081/rip_log.txt"
         }
       ]
     },
@@ -13249,7 +13249,7 @@
               "end" : 4199867
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/082/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/082/rip_log.txt"
         }
       ]
     },
@@ -13382,7 +13382,7 @@
               "end" : 3558427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/083/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/083/rip_log.txt"
         }
       ]
     },
@@ -13507,7 +13507,7 @@
               "end" : 3603107
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/084/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/084/rip_log.txt"
         }
       ]
     },
@@ -13640,7 +13640,7 @@
               "end" : 3562000
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/085/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/085/rip_log.txt"
         }
       ]
     },
@@ -13773,7 +13773,7 @@
               "end" : 3457213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/086/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/086/rip_log.txt"
         }
       ]
     },
@@ -13914,7 +13914,7 @@
               "end" : 3294627
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/087/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/087/rip_log.txt"
         }
       ]
     },
@@ -14075,7 +14075,7 @@
               "end" : 4496507
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/088/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/088/rip_log.txt"
         }
       ]
     },
@@ -14208,7 +14208,7 @@
               "end" : 3586347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/089/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/089/rip_log.txt"
         }
       ]
     },
@@ -14325,7 +14325,7 @@
               "end" : 3532947
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/090/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/090/rip_log.txt"
         }
       ]
     },
@@ -14446,7 +14446,7 @@
               "end" : 3597147
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/091/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/091/rip_log.txt"
         }
       ]
     },
@@ -14567,7 +14567,7 @@
               "end" : 3569347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/092/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/092/rip_log.txt"
         }
       ]
     },
@@ -14693,7 +14693,7 @@
               "end" : 3592133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/093/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/093/rip_log.txt"
         }
       ]
     },
@@ -14835,7 +14835,7 @@
               "end" : 3262720
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/094/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/094/rip_log.txt"
         }
       ]
     },
@@ -14964,7 +14964,7 @@
               "end" : 3603800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/095/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/095/rip_log.txt"
         }
       ]
     },
@@ -15121,7 +15121,7 @@
               "end" : 3191000
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/096/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/096/rip_log.txt"
         }
       ]
     },
@@ -15267,7 +15267,7 @@
               "end" : 4066453
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/097/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/097/rip_log.txt"
         }
       ]
     },
@@ -15433,7 +15433,7 @@
               "end" : 3772307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/098/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/098/rip_log.txt"
         }
       ]
     },
@@ -15602,7 +15602,7 @@
               "end" : 4573053
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/099/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/099/rip_log.txt"
         }
       ]
     },
@@ -15718,7 +15718,7 @@
               "end" : 3204573
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -15753,7 +15753,7 @@
               "end" : 3376800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -15788,7 +15788,7 @@
               "end" : 3410493
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -16236,7 +16236,7 @@
               "end" : 4313453
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/101/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/101/rip_log.txt"
         }
       ]
     },
@@ -16381,7 +16381,7 @@
               "end" : 3560680
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/102/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/102/rip_log.txt"
         }
       ]
     },
@@ -16535,7 +16535,7 @@
               "end" : 3810187
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/103/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/103/rip_log.txt"
         }
       ]
     },
@@ -16688,7 +16688,7 @@
               "end" : 4138120
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/104/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/104/rip_log.txt"
         }
       ]
     },
@@ -16837,7 +16837,7 @@
               "end" : 4545293
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/105/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/105/rip_log.txt"
         }
       ]
     },
@@ -17016,7 +17016,7 @@
               "end" : 4255213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/106/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/106/rip_log.txt"
         }
       ]
     },
@@ -17173,7 +17173,7 @@
               "end" : 3850840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/107/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/107/rip_log.txt"
         }
       ]
     },
@@ -17324,7 +17324,7 @@
               "end" : 4004480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/108/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/108/rip_log.txt"
         }
       ]
     },
@@ -17485,7 +17485,7 @@
               "end" : 4027533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/109/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/109/rip_log.txt"
         }
       ]
     },
@@ -17650,7 +17650,7 @@
               "end" : 3310573
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/110/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/110/rip_log.txt"
         }
       ]
     },
@@ -17883,7 +17883,7 @@
               "end" : 3906600
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/111/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/111/rip_log.txt"
         }
       ]
     },
@@ -18082,7 +18082,7 @@
               "end" : 3529667
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/112/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/112/rip_log.txt"
         }
       ]
     },
@@ -18291,7 +18291,7 @@
               "end" : 3607400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/113/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/113/rip_log.txt"
         }
       ]
     },
@@ -18484,7 +18484,7 @@
               "end" : 4150480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/114/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/114/rip_log.txt"
         }
       ]
     },
@@ -18720,7 +18720,7 @@
               "end" : 4200627
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/115/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/115/rip_log.txt"
         }
       ]
     },
@@ -18883,7 +18883,7 @@
               "end" : 3724893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/116/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/116/rip_log.txt"
         }
       ]
     },
@@ -19075,7 +19075,7 @@
               "end" : 3640027
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/117/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/117/rip_log.txt"
         }
       ]
     },
@@ -19294,7 +19294,7 @@
               "end" : 3996413
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/118/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/118/rip_log.txt"
         }
       ]
     },
@@ -19516,7 +19516,7 @@
               "end" : 4063440
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/119/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/119/rip_log.txt"
         }
       ]
     },
@@ -19691,7 +19691,7 @@
               "end" : 3528253
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/120/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/120/rip_log.txt"
         }
       ]
     },
@@ -19898,7 +19898,7 @@
               "end" : 3762347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/121/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/121/rip_log.txt"
         }
       ]
     },
@@ -20069,7 +20069,7 @@
               "end" : 3494760
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/122/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/122/rip_log.txt"
         }
       ]
     },
@@ -20244,7 +20244,7 @@
               "end" : 3677213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/123/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/123/rip_log.txt"
         }
       ]
     },
@@ -20459,7 +20459,7 @@
               "end" : 3990920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/124/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/124/rip_log.txt"
         }
       ]
     },
@@ -20651,7 +20651,7 @@
               "end" : 4488347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -20726,7 +20726,7 @@
               "end" : 4166213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -20811,7 +20811,7 @@
               "end" : 4464547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -21446,7 +21446,7 @@
               "end" : 3992933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/126/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/126/rip_log.txt"
         }
       ]
     },
@@ -21651,7 +21651,7 @@
               "end" : 4390653
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/127/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/127/rip_log.txt"
         }
       ]
     },
@@ -21844,7 +21844,7 @@
               "end" : 4412907
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/128/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/128/rip_log.txt"
         }
       ]
     },
@@ -22115,7 +22115,7 @@
               "end" : 4734387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/129/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/129/rip_log.txt"
         }
       ]
     },
@@ -22361,7 +22361,7 @@
               "end" : 4112560
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/130/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/130/rip_log.txt"
         }
       ]
     },
@@ -22532,7 +22532,7 @@
               "end" : 4242960
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/131/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/131/rip_log.txt"
         }
       ]
     },
@@ -22715,7 +22715,7 @@
               "end" : 3799387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/132/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/132/rip_log.txt"
         }
       ]
     },
@@ -22886,7 +22886,7 @@
               "end" : 3473893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/133/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/133/rip_log.txt"
         }
       ]
     },
@@ -23089,7 +23089,7 @@
               "end" : 4029587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/134/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/134/rip_log.txt"
         }
       ]
     },
@@ -23328,7 +23328,7 @@
               "end" : 4271013
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/135/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/135/rip_log.txt"
         }
       ]
     },
@@ -23543,7 +23543,7 @@
               "end" : 4117027
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/136/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/136/rip_log.txt"
         }
       ]
     },
@@ -23742,7 +23742,7 @@
               "end" : 4653507
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/137/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/137/rip_log.txt"
         }
       ]
     },
@@ -23933,7 +23933,7 @@
               "end" : 3987133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/138/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/138/rip_log.txt"
         }
       ]
     },
@@ -24155,7 +24155,7 @@
               "end" : 3860747
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/139/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/139/rip_log.txt"
         }
       ]
     },
@@ -24346,7 +24346,7 @@
               "end" : 4658533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/140/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/140/rip_log.txt"
         }
       ]
     },
@@ -24570,7 +24570,7 @@
               "end" : 3562347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/141/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/141/rip_log.txt"
         }
       ]
     },
@@ -24801,7 +24801,7 @@
               "end" : 3437227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/142/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/142/rip_log.txt"
         }
       ]
     },
@@ -24988,7 +24988,7 @@
               "end" : 3621920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/143/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/143/rip_log.txt"
         }
       ]
     },
@@ -25196,7 +25196,7 @@
               "end" : 4256000
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/144/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/144/rip_log.txt"
         }
       ]
     },
@@ -25393,7 +25393,7 @@
               "end" : 3722547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/145/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/145/rip_log.txt"
         }
       ]
     },
@@ -25655,7 +25655,7 @@
               "end" : 3430360
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/146/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/146/rip_log.txt"
         }
       ]
     },
@@ -25838,7 +25838,7 @@
               "end" : 3770533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/147/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/147/rip_log.txt"
         }
       ]
     },
@@ -26005,7 +26005,7 @@
               "end" : 4011933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/148/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/148/rip_log.txt"
         }
       ]
     },
@@ -26238,7 +26238,7 @@
               "end" : 3717773
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/149/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/149/rip_log.txt"
         }
       ]
     },
@@ -26466,7 +26466,7 @@
               "end" : 4055093
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -26551,7 +26551,7 @@
               "end" : 4100240
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -26611,7 +26611,7 @@
               "end" : 3763400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -27362,7 +27362,7 @@
               "end" : 3943307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/151/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/151/rip_log.txt"
         }
       ]
     },
@@ -27587,7 +27587,7 @@
               "end" : 3374867
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/152/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/152/rip_log.txt"
         }
       ]
     },
@@ -27798,7 +27798,7 @@
               "end" : 3243960
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/153/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/153/rip_log.txt"
         }
       ]
     },
@@ -28046,7 +28046,7 @@
               "end" : 4238587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/154/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/154/rip_log.txt"
         }
       ]
     },
@@ -28291,7 +28291,7 @@
               "end" : 4055280
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/155/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/155/rip_log.txt"
         }
       ]
     },
@@ -28526,7 +28526,7 @@
               "end" : 4331240
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/156/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/156/rip_log.txt"
         }
       ]
     },
@@ -28732,7 +28732,7 @@
               "end" : 4461093
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/157/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/157/rip_log.txt"
         }
       ]
     },
@@ -28959,7 +28959,7 @@
               "end" : 3396520
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/158/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/158/rip_log.txt"
         }
       ]
     },
@@ -29147,7 +29147,7 @@
               "end" : 3931427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/159/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/159/rip_log.txt"
         }
       ]
     },
@@ -29326,7 +29326,7 @@
               "end" : 3820387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/160/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/160/rip_log.txt"
         }
       ]
     },
@@ -29551,7 +29551,7 @@
               "end" : 4238493
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/161/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/161/rip_log.txt"
         }
       ]
     },
@@ -29742,7 +29742,7 @@
               "end" : 4365707
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/162/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/162/rip_log.txt"
         }
       ]
     },
@@ -29905,7 +29905,7 @@
               "end" : 4468413
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/163/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/163/rip_log.txt"
         }
       ]
     },
@@ -30092,7 +30092,7 @@
               "end" : 4125760
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/164/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/164/rip_log.txt"
         }
       ]
     },
@@ -30291,7 +30291,7 @@
               "end" : 4217360
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/165/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/165/rip_log.txt"
         }
       ]
     },
@@ -30446,7 +30446,7 @@
               "end" : 4063013
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/166/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/166/rip_log.txt"
         }
       ]
     },
@@ -30702,7 +30702,7 @@
               "end" : 4324213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/167/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/167/rip_log.txt"
         }
       ]
     },
@@ -30907,7 +30907,7 @@
               "end" : 4675973
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/168/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/168/rip_log.txt"
         }
       ]
     },
@@ -31101,7 +31101,7 @@
               "end" : 4910587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/169/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/169/rip_log.txt"
         }
       ]
     },
@@ -31320,7 +31320,7 @@
               "end" : 4816533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/170/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/170/rip_log.txt"
         }
       ]
     },
@@ -31533,7 +31533,7 @@
               "end" : 4040853
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/171/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/171/rip_log.txt"
         }
       ]
     },
@@ -31728,7 +31728,7 @@
               "end" : 4375213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/172/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/172/rip_log.txt"
         }
       ]
     },
@@ -31909,7 +31909,7 @@
               "end" : 4225213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/173/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/173/rip_log.txt"
         }
       ]
     },
@@ -32076,7 +32076,7 @@
               "end" : 3800827
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/174/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/174/rip_log.txt"
         }
       ]
     },
@@ -32296,7 +32296,7 @@
               "end" : 3648933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -32346,7 +32346,7 @@
               "end" : 3434200
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -32391,7 +32391,7 @@
               "end" : 4166493
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -33010,7 +33010,7 @@
               "end" : 4064107
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/176/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/176/rip_log.txt"
         }
       ]
     },
@@ -33181,7 +33181,7 @@
               "end" : 4121080
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/177/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/177/rip_log.txt"
         }
       ]
     },
@@ -33344,7 +33344,7 @@
               "end" : 3955933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/178/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/178/rip_log.txt"
         }
       ]
     },
@@ -33517,7 +33517,7 @@
               "end" : 4297960
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/179/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/179/rip_log.txt"
         }
       ]
     },
@@ -33678,7 +33678,7 @@
               "end" : 4667840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/180/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/180/rip_log.txt"
         }
       ]
     },
@@ -33855,7 +33855,7 @@
               "end" : 4413560
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/181/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/181/rip_log.txt"
         }
       ]
     },
@@ -34046,7 +34046,7 @@
               "end" : 4546493
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/182/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/182/rip_log.txt"
         }
       ]
     },
@@ -34231,7 +34231,7 @@
               "end" : 4566333
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/183/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/183/rip_log.txt"
         }
       ]
     },
@@ -34392,7 +34392,7 @@
               "end" : 4139387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/184/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/184/rip_log.txt"
         }
       ]
     },
@@ -34575,7 +34575,7 @@
               "end" : 3685613
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/185/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/185/rip_log.txt"
         }
       ]
     },
@@ -34748,7 +34748,7 @@
               "end" : 4356747
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/186/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/186/rip_log.txt"
         }
       ]
     },
@@ -34934,7 +34934,7 @@
               "end" : 4036133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/187/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/187/rip_log.txt"
         }
       ]
     },
@@ -35126,7 +35126,7 @@
               "end" : 4807547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/188/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/188/rip_log.txt"
         }
       ]
     },
@@ -35294,7 +35294,7 @@
               "end" : 3917560
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/189/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/189/rip_log.txt"
         }
       ]
     },
@@ -35430,7 +35430,7 @@
               "end" : 3834400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/190/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/190/rip_log.txt"
         }
       ]
     },
@@ -35582,7 +35582,7 @@
               "end" : 4266120
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/191/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/191/rip_log.txt"
         }
       ]
     },
@@ -35746,7 +35746,7 @@
               "end" : 4081427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/192/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/192/rip_log.txt"
         }
       ]
     },
@@ -35930,7 +35930,7 @@
               "end" : 4183227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/193/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/193/rip_log.txt"
         }
       ]
     },
@@ -36110,7 +36110,7 @@
               "end" : 4616840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/194/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/194/rip_log.txt"
         }
       ]
     },
@@ -36256,7 +36256,7 @@
               "end" : 4503053
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/195/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/195/rip_log.txt"
         }
       ]
     },
@@ -36416,7 +36416,7 @@
               "end" : 4728400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/196/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/196/rip_log.txt"
         }
       ]
     },
@@ -36611,7 +36611,7 @@
               "end" : 4190827
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/197/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/197/rip_log.txt"
         }
       ]
     },
@@ -36795,7 +36795,7 @@
               "end" : 4166400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/198/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/198/rip_log.txt"
         }
       ]
     },
@@ -36955,7 +36955,7 @@
               "end" : 4506587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/199/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/199/rip_log.txt"
         }
       ]
     },
@@ -37253,7 +37253,7 @@
               "end" : 4340627
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -37288,7 +37288,7 @@
               "end" : 4273520
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -37323,7 +37323,7 @@
               "end" : 4442693
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log3.txt"
         },
         {
           "tracks" : [
@@ -37358,7 +37358,7 @@
               "end" : 4655267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log4.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log4.txt"
         }
       ]
     },
@@ -37528,7 +37528,7 @@
               "end" : 4703027
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/201/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/201/rip_log.txt"
         }
       ]
     },
@@ -37666,7 +37666,7 @@
               "end" : 4568253
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/202/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/202/rip_log.txt"
         }
       ]
     },
@@ -37814,7 +37814,7 @@
               "end" : 4610333
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/203/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/203/rip_log.txt"
         }
       ]
     },
@@ -37946,7 +37946,7 @@
               "end" : 4144067
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/204/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/204/rip_log.txt"
         }
       ]
     },
@@ -38102,7 +38102,7 @@
               "end" : 4255120
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/205/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/205/rip_log.txt"
         }
       ]
     },
@@ -38234,7 +38234,7 @@
               "end" : 3762867
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/206/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/206/rip_log.txt"
         }
       ]
     },
@@ -38378,7 +38378,7 @@
               "end" : 3725680
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/207/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/207/rip_log.txt"
         }
       ]
     },
@@ -38538,7 +38538,7 @@
               "end" : 4250387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/208/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/208/rip_log.txt"
         }
       ]
     },
@@ -38688,7 +38688,7 @@
               "end" : 3596773
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/209/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/209/rip_log.txt"
         }
       ]
     },
@@ -38820,7 +38820,7 @@
               "end" : 3627267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/210/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/210/rip_log.txt"
         }
       ]
     },
@@ -38960,7 +38960,7 @@
               "end" : 4321973
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/211/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/211/rip_log.txt"
         }
       ]
     },
@@ -39110,7 +39110,7 @@
               "end" : 4395213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/212/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/212/rip_log.txt"
         }
       ]
     },
@@ -39276,7 +39276,7 @@
               "end" : 4378267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/213/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/213/rip_log.txt"
         }
       ]
     },
@@ -39424,7 +39424,7 @@
               "end" : 3938600
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/214/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/214/rip_log.txt"
         }
       ]
     },
@@ -39588,7 +39588,7 @@
               "end" : 3954893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/215/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/215/rip_log.txt"
         }
       ]
     },
@@ -39754,7 +39754,7 @@
               "end" : 3884267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/216/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/216/rip_log.txt"
         }
       ]
     },
@@ -39923,7 +39923,7 @@
               "end" : 4520653
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/217/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/217/rip_log.txt"
         }
       ]
     },
@@ -40092,7 +40092,7 @@
               "end" : 4372133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/218/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/218/rip_log.txt"
         }
       ]
     },
@@ -40261,7 +40261,7 @@
               "end" : 4189547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/219/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/219/rip_log.txt"
         }
       ]
     },
@@ -40442,7 +40442,7 @@
               "end" : 4446747
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/220/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/220/rip_log.txt"
         }
       ]
     },
@@ -40601,7 +40601,7 @@
               "end" : 3932520
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/221/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/221/rip_log.txt"
         }
       ]
     },
@@ -40770,7 +40770,7 @@
               "end" : 4615480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/222/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/222/rip_log.txt"
         }
       ]
     },
@@ -40944,7 +40944,7 @@
               "end" : 4799880
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/223/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/223/rip_log.txt"
         }
       ]
     },
@@ -41101,7 +41101,7 @@
               "end" : 4363613
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/224/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/224/rip_log.txt"
         }
       ]
     },
@@ -41326,7 +41326,7 @@
               "end" : 3077933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -41361,7 +41361,7 @@
               "end" : 3689613
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -41396,7 +41396,7 @@
               "end" : 3928907
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log3.txt"
         }
       ]
     },
@@ -41537,7 +41537,7 @@
               "end" : 4953600
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/226/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/226/rip_log.txt"
         }
       ]
     },
@@ -41678,7 +41678,7 @@
               "end" : 3870227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/227/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/227/rip_log.txt"
         }
       ]
     },
@@ -41823,7 +41823,7 @@
               "end" : 4761320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/228/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/228/rip_log.txt"
         }
       ]
     },

--- a/metadata/json/Spezial.json
+++ b/metadata/json/Spezial.json
@@ -199,7 +199,7 @@
               "end" : 3418440
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -229,7 +229,7 @@
               "end" : 1981684
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt"
         }
       ]
     },
@@ -498,7 +498,7 @@
               "end" : 4757160
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -563,7 +563,7 @@
               "end" : 3904933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -643,7 +643,7 @@
               "end" : 4416000
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -1443,7 +1443,7 @@
               "end" : 3675453
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt"
         }
       ]
     },
@@ -2020,7 +2020,7 @@
               "end" : 3498480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -2315,7 +2315,7 @@
               "end" : 4497427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt"
         }
       ]
     },
@@ -2485,7 +2485,7 @@
               "end" : 3170453
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt"
         }
       ]
     },
@@ -2732,7 +2732,7 @@
               "end" : 3369320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -2777,7 +2777,7 @@
               "end" : 2843747
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -2822,7 +2822,7 @@
               "end" : 4068240
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log3.txt"
         }
       ]
     },
@@ -3081,7 +3081,7 @@
               "end" : 3650720
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -3126,7 +3126,7 @@
               "end" : 2881880
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -3171,7 +3171,7 @@
               "end" : 3360800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt"
         }
       ]
     },
@@ -3419,7 +3419,7 @@
               "end" : 3271667
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -3464,7 +3464,7 @@
               "end" : 3143893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -3509,7 +3509,7 @@
               "end" : 3533293
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log3.txt"
         }
       ]
     },
@@ -3847,7 +3847,7 @@
               "end" : 4545373
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -3907,7 +3907,7 @@
               "end" : 4609387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt"
         }
       ]
     },
@@ -4168,7 +4168,7 @@
               "end" : 4319693
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -4213,7 +4213,7 @@
               "end" : 2885320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -4258,7 +4258,7 @@
               "end" : 5005253
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt"
         }
       ]
     },
@@ -4469,7 +4469,7 @@
               "end" : 2322920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -4504,7 +4504,7 @@
               "end" : 3059627
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt"
         }
       ]
     },
@@ -4716,7 +4716,7 @@
               "end" : 4300133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/rip_log.txt"
         }
       ]
     },
@@ -4928,7 +4928,7 @@
               "end" : 1989427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -4968,7 +4968,7 @@
               "end" : 3077053
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log2.txt"
         }
       ]
     },
@@ -5195,7 +5195,7 @@
               "end" : 2641800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -5230,7 +5230,7 @@
               "end" : 2675787
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log2.txt"
         }
       ]
     },
@@ -5442,7 +5442,7 @@
               "end" : 2852240
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -5487,7 +5487,7 @@
               "end" : 3273800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt"
         }
       ]
     },
@@ -5675,7 +5675,7 @@
               "end" : 3019707
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -5700,7 +5700,7 @@
               "end" : 2733640
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt"
         }
       ]
     },
@@ -5937,7 +5937,7 @@
               "end" : 3351587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -5992,7 +5992,7 @@
               "end" : 3418800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt"
         }
       ]
     }

--- a/metadata/tsv/medium.tsv
+++ b/metadata/tsv/medium.tsv
@@ -1,4 +1,4 @@
-mediumID	hörspielID	position	xldLog
+mediumID	hörspielID	position	ripLog
 1	1	1	false
 2	2	1	false
 3	3	1	false

--- a/web/data/DiE_DR3i.json
+++ b/web/data/DiE_DR3i.json
@@ -207,7 +207,7 @@
               "end" : 4302080
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -337,7 +337,7 @@
               "end" : 4828320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt"
         }
       ],
       "teile" : [
@@ -896,7 +896,7 @@
               "end" : 3918160
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -966,7 +966,7 @@
               "end" : 4075613
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log2.txt"
         }
       ]
     },
@@ -1162,7 +1162,7 @@
               "end" : 4634013
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/2/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/2/rip_log.txt"
         }
       ]
     },
@@ -1360,7 +1360,7 @@
               "end" : 4113813
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/3/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/3/rip_log.txt"
         }
       ]
     },
@@ -1551,7 +1551,7 @@
               "end" : 4747133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/4/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/4/rip_log.txt"
         }
       ]
     },
@@ -1725,7 +1725,7 @@
               "end" : 4409520
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/5/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/5/rip_log.txt"
         }
       ]
     },
@@ -1893,7 +1893,7 @@
               "end" : 3924760
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/6/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/6/rip_log.txt"
         }
       ]
     },
@@ -2078,7 +2078,7 @@
               "end" : 3920920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/7/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/7/rip_log.txt"
         }
       ]
     },
@@ -2242,7 +2242,7 @@
               "end" : 4627360
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/8/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/8/rip_log.txt"
         }
       ]
     }

--- a/web/data/DiE_DR3i/1/metadata.json
+++ b/web/data/DiE_DR3i/1/metadata.json
@@ -273,7 +273,7 @@
           "end" : 3918160
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -343,7 +343,7 @@
           "end" : 4075613
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/1/rip_log2.txt"
     }
   ]
 }

--- a/web/data/DiE_DR3i/1/rip_log1.txt
+++ b/web/data/DiE_DR3i/1/rip_log1.txt
@@ -48,7 +48,7 @@ AccurateRip Summary (DiscID: 0022ea7c-01534208-d40f500d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : 33095DB8
     CRC32 hash (skip zero)   : B6DBF586
     Statistics

--- a/web/data/DiE_DR3i/1/rip_log2.txt
+++ b/web/data/DiE_DR3i/1/rip_log2.txt
@@ -48,7 +48,7 @@ AccurateRip Summary (DiscID: 0021c4ee-0151620b-c40fec0d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : 2788B6EB
     CRC32 hash (skip zero)   : 61DB873A
     Statistics

--- a/web/data/DiE_DR3i/2/metadata.json
+++ b/web/data/DiE_DR3i/2/metadata.json
@@ -190,7 +190,7 @@
           "end" : 4634013
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/2/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/2/rip_log.txt"
     }
   ]
 }

--- a/web/data/DiE_DR3i/2/rip_log.txt
+++ b/web/data/DiE_DR3i/2/rip_log.txt
@@ -46,7 +46,7 @@ AccurateRip Summary (DiscID: 0022e591-0144b7bf-9a121a0c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : D6148BA5
     CRC32 hash (skip zero)   : A93701A5
     Statistics

--- a/web/data/DiE_DR3i/3/metadata.json
+++ b/web/data/DiE_DR3i/3/metadata.json
@@ -192,7 +192,7 @@
           "end" : 4113813
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/3/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/3/rip_log.txt"
     }
   ]
 }

--- a/web/data/DiE_DR3i/3/rip_log.txt
+++ b/web/data/DiE_DR3i/3/rip_log.txt
@@ -48,7 +48,7 @@ AccurateRip Summary (DiscID: 0020a5c4-01468df8-a210110d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : 7408F54A
     CRC32 hash (skip zero)   : 083A46EE
     Statistics

--- a/web/data/DiE_DR3i/4/metadata.json
+++ b/web/data/DiE_DR3i/4/metadata.json
@@ -185,7 +185,7 @@
           "end" : 4747133
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/4/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/4/rip_log.txt"
     }
   ]
 }

--- a/web/data/DiE_DR3i/4/rip_log.txt
+++ b/web/data/DiE_DR3i/4/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 002167a8-012246f5-b0128b0b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title(1).m4a
+    Filename : Unknown Title(1).m4a
     CRC32 hash               : 266B29FA
     CRC32 hash (skip zero)   : EED49E98
     Statistics

--- a/web/data/DiE_DR3i/5/metadata.json
+++ b/web/data/DiE_DR3i/5/metadata.json
@@ -168,7 +168,7 @@
           "end" : 4409520
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/5/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/5/rip_log.txt"
     }
   ]
 }

--- a/web/data/DiE_DR3i/5/rip_log.txt
+++ b/web/data/DiE_DR3i/5/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 001ec7c3-010b0917-8b11390b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : 7E1173D3
     CRC32 hash (skip zero)   : 1AE4F787
     Statistics

--- a/web/data/DiE_DR3i/6/metadata.json
+++ b/web/data/DiE_DR3i/6/metadata.json
@@ -162,7 +162,7 @@
           "end" : 3924760
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/6/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/6/rip_log.txt"
     }
   ]
 }

--- a/web/data/DiE_DR3i/6/rip_log.txt
+++ b/web/data/DiE_DR3i/6/rip_log.txt
@@ -42,7 +42,7 @@ AccurateRip Summary (DiscID: 0016f68b-00b77acd-890f540a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : 0F80180B
     CRC32 hash (skip zero)   : B992AF3A
     Statistics

--- a/web/data/DiE_DR3i/7/metadata.json
+++ b/web/data/DiE_DR3i/7/metadata.json
@@ -179,7 +179,7 @@
           "end" : 3920920
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/7/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/7/rip_log.txt"
     }
   ]
 }

--- a/web/data/DiE_DR3i/7/rip_log.txt
+++ b/web/data/DiE_DR3i/7/rip_log.txt
@@ -42,7 +42,7 @@ AccurateRip Summary (DiscID: 001a27f9-00d083f6-7b0f500a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/DiE DR3i und der kopflose Reiter .m4a
+    Filename : DiE DR3i und der kopflose Reiter .m4a
     CRC32 hash               : CA5F5823
     CRC32 hash (skip zero)   : 80369CDE
     Statistics

--- a/web/data/DiE_DR3i/8/metadata.json
+++ b/web/data/DiE_DR3i/8/metadata.json
@@ -158,7 +158,7 @@
           "end" : 4627360
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/8/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/8/rip_log.txt"
     }
   ]
 }

--- a/web/data/DiE_DR3i/8/rip_log.txt
+++ b/web/data/DiE_DR3i/8/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0017aac6-009f46cd-6e121108)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/DiE DR3i - Folge 8 ／ Der Jahrhundertstein.m4a
+    Filename : DiE DR3i - Folge 8 ／ Der Jahrhundertstein.m4a
     CRC32 hash               : 2CCFE234
     CRC32 hash (skip zero)   : 798E3E7C
     Statistics

--- a/web/data/DiE_DR3i/Hotel-Luxury-End/metadata.json
+++ b/web/data/DiE_DR3i/Hotel-Luxury-End/metadata.json
@@ -205,7 +205,7 @@
           "end" : 4302080
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -335,7 +335,7 @@
           "end" : 4828320
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt"
     }
   ],
   "teile" : [

--- a/web/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt
+++ b/web/data/DiE_DR3i/Hotel-Luxury-End/rip_log1.txt
@@ -77,7 +77,7 @@ AccurateRip Summary (DiscID: 0040578a-047484a4-6b10ce19)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : 4BDCD251
     CRC32 hash (skip zero)   : 12EA796B
     Statistics

--- a/web/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt
+++ b/web/data/DiE_DR3i/Hotel-Luxury-End/rip_log2.txt
@@ -77,7 +77,7 @@ AccurateRip Summary (DiscID: 0043cdf7-04bff26b-5e12dc19)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : 154C1341
     CRC32 hash (skip zero)   : ABCEEBAD
     Statistics

--- a/web/data/Kurzgeschichten.json
+++ b/web/data/Kurzgeschichten.json
@@ -171,7 +171,7 @@
               "end" : 4017840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -196,7 +196,7 @@
               "end" : 2679040
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -221,7 +221,7 @@
               "end" : 3602480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -935,7 +935,7 @@
               "end" : 3073920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -970,7 +970,7 @@
               "end" : 2748267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -1020,7 +1020,7 @@
               "end" : 3898467
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -1673,7 +1673,7 @@
               "end" : 3652267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -1728,7 +1728,7 @@
               "end" : 4569373
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt"
         }
       ],
       "teile" : [
@@ -2307,7 +2307,7 @@
               "end" : 4096840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -2342,7 +2342,7 @@
               "end" : 3657040
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -2377,7 +2377,7 @@
               "end" : 3975307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt"
         }
       ],
       "teile" : [

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/metadata.json
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/metadata.json
@@ -173,7 +173,7 @@
           "end" : 3073920
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -208,7 +208,7 @@
           "end" : 2748267
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -258,7 +258,7 @@
           "end" : 3898467
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt"
     }
   ],
   "teile" : [

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log1.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 000c8e9e-0043e9e8-600c0106)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Das Rätsel der Sieben - CD1.m4a
+    Filename : Das Rätsel der Sieben - CD1.m4a
     CRC32 hash               : E461C53A
     CRC32 hash (skip zero)   : 071E37D7
     Statistics

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log2.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 000b5547-003c129c-510abc06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Das Rätsel der Sieben - CD2.m4a
+    Filename : Das Rätsel der Sieben - CD2.m4a
     CRC32 hash               : 8C4692B7
     CRC32 hash (skip zero)   : 9DAA7687
     Statistics

--- a/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt
+++ b/web/data/Kurzgeschichten/Das-Raetsel-der-Sieben/rip_log3.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 00164f45-00a3fa0d-780f3a09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Das Rätsel der Sieben - CD3.m4a
+    Filename : Das Rätsel der Sieben - CD3.m4a
     CRC32 hash               : 35749B8E
     CRC32 hash (skip zero)   : 25AB3346
     Statistics

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/metadata.json
@@ -182,7 +182,7 @@
           "end" : 3652267
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -237,7 +237,7 @@
           "end" : 4569373
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt"
     }
   ],
   "teile" : [

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/rip_log1.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 000f2388-0069ed71-700e4408)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? und der Zeitgeist - CD1.m4a
+    Filename : Die Drei ??? und der Zeitgeist - CD1.m4a
     CRC32 hash               : 539C38C6
     CRC32 hash (skip zero)   : 99AC75DD
     Statistics

--- a/web/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt
+++ b/web/data/Kurzgeschichten/und-der-Zeitgeist/rip_log2.txt
@@ -42,7 +42,7 @@ AccurateRip Summary (DiscID: 001f2e38-00f4febd-8a11d90a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? und der Zeitgeist - CD2.m4a
+    Filename : Die Drei ??? und der Zeitgeist - CD2.m4a
     CRC32 hash               : FEA73B70
     CRC32 hash (skip zero)   : 657B34DB
     Statistics

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/metadata.json
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/metadata.json
@@ -180,7 +180,7 @@
           "end" : 4096840
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -215,7 +215,7 @@
           "end" : 3657040
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -250,7 +250,7 @@
           "end" : 3975307
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt"
     }
   ],
   "teile" : [

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log1.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 00111e18-005aa834-58100006)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - und der schwarze Tag (Sechs Kurzgeschichten)  - CD1.m4a
+    Filename : Die Drei ??? - und der schwarze Tag (Sechs Kurzgeschichten)  - CD1.m4a
     CRC32 hash               : 33D49D69
     CRC32 hash (skip zero)   : 38002016
     Statistics

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log2.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 000ec44d-004f14ba-420e4906)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - und der schwarze Tag (Sechs Kurzgeschichten)  - CD2.m4a
+    Filename : Die Drei ??? - und der schwarze Tag (Sechs Kurzgeschichten)  - CD2.m4a
     CRC32 hash               : ABA23056
     CRC32 hash (skip zero)   : B960B4DD
     Statistics

--- a/web/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt
+++ b/web/data/Kurzgeschichten/und-der-schwarze-Tag/rip_log3.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 0010a254-00577929-550f8706)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - und der schwarze Tag (Sechs Kurzgeschichten)  - CD3.m4a
+    Filename : Die Drei ??? - und der schwarze Tag (Sechs Kurzgeschichten)  - CD3.m4a
     CRC32 hash               : EA8B4228
     CRC32 hash (skip zero)   : EEE87F03
     Statistics

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/metadata.json
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/metadata.json
@@ -169,7 +169,7 @@
           "end" : 4017840
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -194,7 +194,7 @@
           "end" : 2679040
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -219,7 +219,7 @@
           "end" : 3602480
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt"
     }
   ],
   "teile" : [

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/rip_log1.txt
@@ -35,7 +35,7 @@ AccurateRip Summary (DiscID: 000af549-002bd54f-2f0fb104)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/und die Geisterlampe.m4a
+    Filename : und die Geisterlampe.m4a
     CRC32 hash               : 0A3C9148
     CRC32 hash (skip zero)   : CC2D4951
     Statistics

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/rip_log2.txt
@@ -35,7 +35,7 @@ AccurateRip Summary (DiscID: 000777e9-001e0805-370a7704)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/und die Geisterlampe(1).m4a
+    Filename : und die Geisterlampe(1).m4a
     CRC32 hash               : 654D64B3
     CRC32 hash (skip zero)   : 5CFA3CAC
     Statistics

--- a/web/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt
+++ b/web/data/Kurzgeschichten/und-die-Geisterlampe/rip_log3.txt
@@ -35,7 +35,7 @@ AccurateRip Summary (DiscID: 000ab32a-002a349f-270e1204)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/und die Geisterlampe(2).m4a
+    Filename : und die Geisterlampe(2).m4a
     CRC32 hash               : 7B44882E
     CRC32 hash (skip zero)   : BC2C6CDC
     Statistics

--- a/web/data/Serie.json
+++ b/web/data/Serie.json
@@ -820,7 +820,7 @@
               "end" : 2960987
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/005/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/005/rip_log.txt"
         }
       ]
     },
@@ -1787,7 +1787,7 @@
               "end" : 2894907
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/011/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/011/rip_log.txt"
         }
       ]
     },
@@ -8002,7 +8002,7 @@
               "end" : 2670120
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/049/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/049/rip_log.txt"
         }
       ]
     },
@@ -8155,7 +8155,7 @@
               "end" : 3435173
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/050/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/050/rip_log.txt"
         }
       ]
     },
@@ -8296,7 +8296,7 @@
               "end" : 3270107
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/051/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/051/rip_log.txt"
         }
       ]
     },
@@ -8469,7 +8469,7 @@
               "end" : 3267773
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/052/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/052/rip_log.txt"
         }
       ]
     },
@@ -8630,7 +8630,7 @@
               "end" : 3203173
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/053/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/053/rip_log.txt"
         }
       ]
     },
@@ -8792,7 +8792,7 @@
               "end" : 3048040
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/054/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/054/rip_log.txt"
         }
       ]
     },
@@ -8957,7 +8957,7 @@
               "end" : 3056533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/055/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/055/rip_log.txt"
         }
       ]
     },
@@ -9122,7 +9122,7 @@
               "end" : 2967587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/056/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/056/rip_log.txt"
         }
       ]
     },
@@ -9279,7 +9279,7 @@
               "end" : 2605187
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/057/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/057/rip_log.txt"
         }
       ]
     },
@@ -9441,7 +9441,7 @@
               "end" : 2711893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/058/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/058/rip_log.txt"
         }
       ]
     },
@@ -9602,7 +9602,7 @@
               "end" : 2667307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/059/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/059/rip_log.txt"
         }
       ]
     },
@@ -9768,7 +9768,7 @@
               "end" : 2826880
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/060/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/060/rip_log.txt"
         }
       ]
     },
@@ -9933,7 +9933,7 @@
               "end" : 3569320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/061/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/061/rip_log.txt"
         }
       ]
     },
@@ -10098,7 +10098,7 @@
               "end" : 3563227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/062/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/062/rip_log.txt"
         }
       ]
     },
@@ -10264,7 +10264,7 @@
               "end" : 4014467
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/063/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/063/rip_log.txt"
         }
       ]
     },
@@ -10430,7 +10430,7 @@
               "end" : 3969547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/064/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/064/rip_log.txt"
         }
       ]
     },
@@ -10603,7 +10603,7 @@
               "end" : 3579173
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/065/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/065/rip_log.txt"
         }
       ]
     },
@@ -10760,7 +10760,7 @@
               "end" : 3555013
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/066/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/066/rip_log.txt"
         }
       ]
     },
@@ -10921,7 +10921,7 @@
               "end" : 3799320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/067/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/067/rip_log.txt"
         }
       ]
     },
@@ -11062,7 +11062,7 @@
               "end" : 3581227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/068/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/068/rip_log.txt"
         }
       ]
     },
@@ -11236,7 +11236,7 @@
               "end" : 3942387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/069/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/069/rip_log.txt"
         }
       ]
     },
@@ -11401,7 +11401,7 @@
               "end" : 3784293
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/070/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/070/rip_log.txt"
         }
       ]
     },
@@ -11579,7 +11579,7 @@
               "end" : 3994440
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/071/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/071/rip_log.txt"
         }
       ]
     },
@@ -11752,7 +11752,7 @@
               "end" : 3477893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/072/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/072/rip_log.txt"
         }
       ]
     },
@@ -11909,7 +11909,7 @@
               "end" : 3997320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/073/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/073/rip_log.txt"
         }
       ]
     },
@@ -12083,7 +12083,7 @@
               "end" : 4442107
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/074/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/074/rip_log.txt"
         }
       ]
     },
@@ -12236,7 +12236,7 @@
               "end" : 3339600
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/075/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/075/rip_log.txt"
         }
       ]
     },
@@ -12397,7 +12397,7 @@
               "end" : 4184827
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/076/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/076/rip_log.txt"
         }
       ]
     },
@@ -12547,7 +12547,7 @@
               "end" : 3559333
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/077/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/077/rip_log.txt"
         }
       ]
     },
@@ -12693,7 +12693,7 @@
               "end" : 3448987
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/078/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/078/rip_log.txt"
         }
       ]
     },
@@ -12865,7 +12865,7 @@
               "end" : 4612307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/079/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/079/rip_log.txt"
         }
       ]
     },
@@ -12983,7 +12983,7 @@
               "end" : 3560667
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/080/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/080/rip_log.txt"
         }
       ]
     },
@@ -13124,7 +13124,7 @@
               "end" : 2983827
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/081/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/081/rip_log.txt"
         }
       ]
     },
@@ -13249,7 +13249,7 @@
               "end" : 4199867
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/082/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/082/rip_log.txt"
         }
       ]
     },
@@ -13382,7 +13382,7 @@
               "end" : 3558427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/083/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/083/rip_log.txt"
         }
       ]
     },
@@ -13507,7 +13507,7 @@
               "end" : 3603107
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/084/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/084/rip_log.txt"
         }
       ]
     },
@@ -13640,7 +13640,7 @@
               "end" : 3562000
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/085/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/085/rip_log.txt"
         }
       ]
     },
@@ -13773,7 +13773,7 @@
               "end" : 3457213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/086/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/086/rip_log.txt"
         }
       ]
     },
@@ -13914,7 +13914,7 @@
               "end" : 3294627
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/087/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/087/rip_log.txt"
         }
       ]
     },
@@ -14075,7 +14075,7 @@
               "end" : 4496507
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/088/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/088/rip_log.txt"
         }
       ]
     },
@@ -14208,7 +14208,7 @@
               "end" : 3586347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/089/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/089/rip_log.txt"
         }
       ]
     },
@@ -14325,7 +14325,7 @@
               "end" : 3532947
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/090/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/090/rip_log.txt"
         }
       ]
     },
@@ -14446,7 +14446,7 @@
               "end" : 3597147
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/091/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/091/rip_log.txt"
         }
       ]
     },
@@ -14567,7 +14567,7 @@
               "end" : 3569347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/092/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/092/rip_log.txt"
         }
       ]
     },
@@ -14693,7 +14693,7 @@
               "end" : 3592133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/093/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/093/rip_log.txt"
         }
       ]
     },
@@ -14835,7 +14835,7 @@
               "end" : 3262720
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/094/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/094/rip_log.txt"
         }
       ]
     },
@@ -14964,7 +14964,7 @@
               "end" : 3603800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/095/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/095/rip_log.txt"
         }
       ]
     },
@@ -15121,7 +15121,7 @@
               "end" : 3191000
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/096/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/096/rip_log.txt"
         }
       ]
     },
@@ -15267,7 +15267,7 @@
               "end" : 4066453
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/097/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/097/rip_log.txt"
         }
       ]
     },
@@ -15433,7 +15433,7 @@
               "end" : 3772307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/098/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/098/rip_log.txt"
         }
       ]
     },
@@ -15602,7 +15602,7 @@
               "end" : 4573053
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/099/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/099/rip_log.txt"
         }
       ]
     },
@@ -15718,7 +15718,7 @@
               "end" : 3204573
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -15753,7 +15753,7 @@
               "end" : 3376800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -15788,7 +15788,7 @@
               "end" : 3410493
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -16236,7 +16236,7 @@
               "end" : 4313453
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/101/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/101/rip_log.txt"
         }
       ]
     },
@@ -16381,7 +16381,7 @@
               "end" : 3560680
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/102/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/102/rip_log.txt"
         }
       ]
     },
@@ -16535,7 +16535,7 @@
               "end" : 3810187
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/103/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/103/rip_log.txt"
         }
       ]
     },
@@ -16688,7 +16688,7 @@
               "end" : 4138120
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/104/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/104/rip_log.txt"
         }
       ]
     },
@@ -16837,7 +16837,7 @@
               "end" : 4545293
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/105/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/105/rip_log.txt"
         }
       ]
     },
@@ -17016,7 +17016,7 @@
               "end" : 4255213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/106/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/106/rip_log.txt"
         }
       ]
     },
@@ -17173,7 +17173,7 @@
               "end" : 3850840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/107/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/107/rip_log.txt"
         }
       ]
     },
@@ -17324,7 +17324,7 @@
               "end" : 4004480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/108/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/108/rip_log.txt"
         }
       ]
     },
@@ -17485,7 +17485,7 @@
               "end" : 4027533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/109/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/109/rip_log.txt"
         }
       ]
     },
@@ -17650,7 +17650,7 @@
               "end" : 3310573
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/110/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/110/rip_log.txt"
         }
       ]
     },
@@ -17883,7 +17883,7 @@
               "end" : 3906600
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/111/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/111/rip_log.txt"
         }
       ]
     },
@@ -18082,7 +18082,7 @@
               "end" : 3529667
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/112/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/112/rip_log.txt"
         }
       ]
     },
@@ -18291,7 +18291,7 @@
               "end" : 3607400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/113/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/113/rip_log.txt"
         }
       ]
     },
@@ -18484,7 +18484,7 @@
               "end" : 4150480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/114/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/114/rip_log.txt"
         }
       ]
     },
@@ -18720,7 +18720,7 @@
               "end" : 4200627
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/115/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/115/rip_log.txt"
         }
       ]
     },
@@ -18883,7 +18883,7 @@
               "end" : 3724893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/116/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/116/rip_log.txt"
         }
       ]
     },
@@ -19075,7 +19075,7 @@
               "end" : 3640027
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/117/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/117/rip_log.txt"
         }
       ]
     },
@@ -19294,7 +19294,7 @@
               "end" : 3996413
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/118/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/118/rip_log.txt"
         }
       ]
     },
@@ -19516,7 +19516,7 @@
               "end" : 4063440
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/119/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/119/rip_log.txt"
         }
       ]
     },
@@ -19691,7 +19691,7 @@
               "end" : 3528253
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/120/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/120/rip_log.txt"
         }
       ]
     },
@@ -19898,7 +19898,7 @@
               "end" : 3762347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/121/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/121/rip_log.txt"
         }
       ]
     },
@@ -20069,7 +20069,7 @@
               "end" : 3494760
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/122/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/122/rip_log.txt"
         }
       ]
     },
@@ -20244,7 +20244,7 @@
               "end" : 3677213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/123/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/123/rip_log.txt"
         }
       ]
     },
@@ -20459,7 +20459,7 @@
               "end" : 3990920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/124/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/124/rip_log.txt"
         }
       ]
     },
@@ -20651,7 +20651,7 @@
               "end" : 4488347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -20726,7 +20726,7 @@
               "end" : 4166213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -20811,7 +20811,7 @@
               "end" : 4464547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -21446,7 +21446,7 @@
               "end" : 3992933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/126/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/126/rip_log.txt"
         }
       ]
     },
@@ -21651,7 +21651,7 @@
               "end" : 4390653
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/127/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/127/rip_log.txt"
         }
       ]
     },
@@ -21844,7 +21844,7 @@
               "end" : 4412907
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/128/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/128/rip_log.txt"
         }
       ]
     },
@@ -22115,7 +22115,7 @@
               "end" : 4734387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/129/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/129/rip_log.txt"
         }
       ]
     },
@@ -22361,7 +22361,7 @@
               "end" : 4112560
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/130/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/130/rip_log.txt"
         }
       ]
     },
@@ -22532,7 +22532,7 @@
               "end" : 4242960
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/131/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/131/rip_log.txt"
         }
       ]
     },
@@ -22715,7 +22715,7 @@
               "end" : 3799387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/132/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/132/rip_log.txt"
         }
       ]
     },
@@ -22886,7 +22886,7 @@
               "end" : 3473893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/133/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/133/rip_log.txt"
         }
       ]
     },
@@ -23089,7 +23089,7 @@
               "end" : 4029587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/134/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/134/rip_log.txt"
         }
       ]
     },
@@ -23328,7 +23328,7 @@
               "end" : 4271013
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/135/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/135/rip_log.txt"
         }
       ]
     },
@@ -23543,7 +23543,7 @@
               "end" : 4117027
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/136/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/136/rip_log.txt"
         }
       ]
     },
@@ -23742,7 +23742,7 @@
               "end" : 4653507
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/137/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/137/rip_log.txt"
         }
       ]
     },
@@ -23933,7 +23933,7 @@
               "end" : 3987133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/138/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/138/rip_log.txt"
         }
       ]
     },
@@ -24155,7 +24155,7 @@
               "end" : 3860747
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/139/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/139/rip_log.txt"
         }
       ]
     },
@@ -24346,7 +24346,7 @@
               "end" : 4658533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/140/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/140/rip_log.txt"
         }
       ]
     },
@@ -24570,7 +24570,7 @@
               "end" : 3562347
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/141/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/141/rip_log.txt"
         }
       ]
     },
@@ -24801,7 +24801,7 @@
               "end" : 3437227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/142/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/142/rip_log.txt"
         }
       ]
     },
@@ -24988,7 +24988,7 @@
               "end" : 3621920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/143/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/143/rip_log.txt"
         }
       ]
     },
@@ -25196,7 +25196,7 @@
               "end" : 4256000
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/144/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/144/rip_log.txt"
         }
       ]
     },
@@ -25393,7 +25393,7 @@
               "end" : 3722547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/145/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/145/rip_log.txt"
         }
       ]
     },
@@ -25655,7 +25655,7 @@
               "end" : 3430360
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/146/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/146/rip_log.txt"
         }
       ]
     },
@@ -25838,7 +25838,7 @@
               "end" : 3770533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/147/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/147/rip_log.txt"
         }
       ]
     },
@@ -26005,7 +26005,7 @@
               "end" : 4011933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/148/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/148/rip_log.txt"
         }
       ]
     },
@@ -26238,7 +26238,7 @@
               "end" : 3717773
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/149/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/149/rip_log.txt"
         }
       ]
     },
@@ -26466,7 +26466,7 @@
               "end" : 4055093
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -26551,7 +26551,7 @@
               "end" : 4100240
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -26611,7 +26611,7 @@
               "end" : 3763400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -27362,7 +27362,7 @@
               "end" : 3943307
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/151/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/151/rip_log.txt"
         }
       ]
     },
@@ -27587,7 +27587,7 @@
               "end" : 3374867
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/152/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/152/rip_log.txt"
         }
       ]
     },
@@ -27798,7 +27798,7 @@
               "end" : 3243960
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/153/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/153/rip_log.txt"
         }
       ]
     },
@@ -28046,7 +28046,7 @@
               "end" : 4238587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/154/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/154/rip_log.txt"
         }
       ]
     },
@@ -28291,7 +28291,7 @@
               "end" : 4055280
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/155/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/155/rip_log.txt"
         }
       ]
     },
@@ -28526,7 +28526,7 @@
               "end" : 4331240
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/156/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/156/rip_log.txt"
         }
       ]
     },
@@ -28732,7 +28732,7 @@
               "end" : 4461093
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/157/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/157/rip_log.txt"
         }
       ]
     },
@@ -28959,7 +28959,7 @@
               "end" : 3396520
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/158/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/158/rip_log.txt"
         }
       ]
     },
@@ -29147,7 +29147,7 @@
               "end" : 3931427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/159/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/159/rip_log.txt"
         }
       ]
     },
@@ -29326,7 +29326,7 @@
               "end" : 3820387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/160/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/160/rip_log.txt"
         }
       ]
     },
@@ -29551,7 +29551,7 @@
               "end" : 4238493
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/161/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/161/rip_log.txt"
         }
       ]
     },
@@ -29742,7 +29742,7 @@
               "end" : 4365707
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/162/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/162/rip_log.txt"
         }
       ]
     },
@@ -29905,7 +29905,7 @@
               "end" : 4468413
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/163/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/163/rip_log.txt"
         }
       ]
     },
@@ -30092,7 +30092,7 @@
               "end" : 4125760
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/164/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/164/rip_log.txt"
         }
       ]
     },
@@ -30291,7 +30291,7 @@
               "end" : 4217360
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/165/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/165/rip_log.txt"
         }
       ]
     },
@@ -30446,7 +30446,7 @@
               "end" : 4063013
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/166/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/166/rip_log.txt"
         }
       ]
     },
@@ -30702,7 +30702,7 @@
               "end" : 4324213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/167/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/167/rip_log.txt"
         }
       ]
     },
@@ -30907,7 +30907,7 @@
               "end" : 4675973
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/168/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/168/rip_log.txt"
         }
       ]
     },
@@ -31101,7 +31101,7 @@
               "end" : 4910587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/169/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/169/rip_log.txt"
         }
       ]
     },
@@ -31320,7 +31320,7 @@
               "end" : 4816533
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/170/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/170/rip_log.txt"
         }
       ]
     },
@@ -31533,7 +31533,7 @@
               "end" : 4040853
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/171/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/171/rip_log.txt"
         }
       ]
     },
@@ -31728,7 +31728,7 @@
               "end" : 4375213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/172/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/172/rip_log.txt"
         }
       ]
     },
@@ -31909,7 +31909,7 @@
               "end" : 4225213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/173/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/173/rip_log.txt"
         }
       ]
     },
@@ -32076,7 +32076,7 @@
               "end" : 3800827
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/174/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/174/rip_log.txt"
         }
       ]
     },
@@ -32296,7 +32296,7 @@
               "end" : 3648933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -32346,7 +32346,7 @@
               "end" : 3434200
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -32391,7 +32391,7 @@
               "end" : 4166493
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -33010,7 +33010,7 @@
               "end" : 4064107
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/176/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/176/rip_log.txt"
         }
       ]
     },
@@ -33181,7 +33181,7 @@
               "end" : 4121080
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/177/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/177/rip_log.txt"
         }
       ]
     },
@@ -33344,7 +33344,7 @@
               "end" : 3955933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/178/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/178/rip_log.txt"
         }
       ]
     },
@@ -33517,7 +33517,7 @@
               "end" : 4297960
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/179/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/179/rip_log.txt"
         }
       ]
     },
@@ -33678,7 +33678,7 @@
               "end" : 4667840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/180/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/180/rip_log.txt"
         }
       ]
     },
@@ -33855,7 +33855,7 @@
               "end" : 4413560
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/181/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/181/rip_log.txt"
         }
       ]
     },
@@ -34046,7 +34046,7 @@
               "end" : 4546493
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/182/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/182/rip_log.txt"
         }
       ]
     },
@@ -34231,7 +34231,7 @@
               "end" : 4566333
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/183/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/183/rip_log.txt"
         }
       ]
     },
@@ -34392,7 +34392,7 @@
               "end" : 4139387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/184/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/184/rip_log.txt"
         }
       ]
     },
@@ -34575,7 +34575,7 @@
               "end" : 3685613
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/185/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/185/rip_log.txt"
         }
       ]
     },
@@ -34748,7 +34748,7 @@
               "end" : 4356747
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/186/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/186/rip_log.txt"
         }
       ]
     },
@@ -34934,7 +34934,7 @@
               "end" : 4036133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/187/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/187/rip_log.txt"
         }
       ]
     },
@@ -35126,7 +35126,7 @@
               "end" : 4807547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/188/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/188/rip_log.txt"
         }
       ]
     },
@@ -35294,7 +35294,7 @@
               "end" : 3917560
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/189/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/189/rip_log.txt"
         }
       ]
     },
@@ -35430,7 +35430,7 @@
               "end" : 3834400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/190/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/190/rip_log.txt"
         }
       ]
     },
@@ -35582,7 +35582,7 @@
               "end" : 4266120
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/191/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/191/rip_log.txt"
         }
       ]
     },
@@ -35746,7 +35746,7 @@
               "end" : 4081427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/192/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/192/rip_log.txt"
         }
       ]
     },
@@ -35930,7 +35930,7 @@
               "end" : 4183227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/193/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/193/rip_log.txt"
         }
       ]
     },
@@ -36110,7 +36110,7 @@
               "end" : 4616840
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/194/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/194/rip_log.txt"
         }
       ]
     },
@@ -36256,7 +36256,7 @@
               "end" : 4503053
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/195/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/195/rip_log.txt"
         }
       ]
     },
@@ -36416,7 +36416,7 @@
               "end" : 4728400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/196/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/196/rip_log.txt"
         }
       ]
     },
@@ -36611,7 +36611,7 @@
               "end" : 4190827
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/197/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/197/rip_log.txt"
         }
       ]
     },
@@ -36795,7 +36795,7 @@
               "end" : 4166400
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/198/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/198/rip_log.txt"
         }
       ]
     },
@@ -36955,7 +36955,7 @@
               "end" : 4506587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/199/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/199/rip_log.txt"
         }
       ]
     },
@@ -37253,7 +37253,7 @@
               "end" : 4340627
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -37288,7 +37288,7 @@
               "end" : 4273520
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -37323,7 +37323,7 @@
               "end" : 4442693
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log3.txt"
         },
         {
           "tracks" : [
@@ -37358,7 +37358,7 @@
               "end" : 4655267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log4.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log4.txt"
         }
       ]
     },
@@ -37528,7 +37528,7 @@
               "end" : 4703027
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/201/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/201/rip_log.txt"
         }
       ]
     },
@@ -37666,7 +37666,7 @@
               "end" : 4568253
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/202/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/202/rip_log.txt"
         }
       ]
     },
@@ -37814,7 +37814,7 @@
               "end" : 4610333
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/203/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/203/rip_log.txt"
         }
       ]
     },
@@ -37946,7 +37946,7 @@
               "end" : 4144067
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/204/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/204/rip_log.txt"
         }
       ]
     },
@@ -38102,7 +38102,7 @@
               "end" : 4255120
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/205/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/205/rip_log.txt"
         }
       ]
     },
@@ -38234,7 +38234,7 @@
               "end" : 3762867
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/206/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/206/rip_log.txt"
         }
       ]
     },
@@ -38378,7 +38378,7 @@
               "end" : 3725680
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/207/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/207/rip_log.txt"
         }
       ]
     },
@@ -38538,7 +38538,7 @@
               "end" : 4250387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/208/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/208/rip_log.txt"
         }
       ]
     },
@@ -38688,7 +38688,7 @@
               "end" : 3596773
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/209/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/209/rip_log.txt"
         }
       ]
     },
@@ -38820,7 +38820,7 @@
               "end" : 3627267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/210/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/210/rip_log.txt"
         }
       ]
     },
@@ -38960,7 +38960,7 @@
               "end" : 4321973
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/211/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/211/rip_log.txt"
         }
       ]
     },
@@ -39110,7 +39110,7 @@
               "end" : 4395213
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/212/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/212/rip_log.txt"
         }
       ]
     },
@@ -39276,7 +39276,7 @@
               "end" : 4378267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/213/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/213/rip_log.txt"
         }
       ]
     },
@@ -39424,7 +39424,7 @@
               "end" : 3938600
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/214/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/214/rip_log.txt"
         }
       ]
     },
@@ -39588,7 +39588,7 @@
               "end" : 3954893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/215/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/215/rip_log.txt"
         }
       ]
     },
@@ -39754,7 +39754,7 @@
               "end" : 3884267
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/216/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/216/rip_log.txt"
         }
       ]
     },
@@ -39923,7 +39923,7 @@
               "end" : 4520653
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/217/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/217/rip_log.txt"
         }
       ]
     },
@@ -40092,7 +40092,7 @@
               "end" : 4372133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/218/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/218/rip_log.txt"
         }
       ]
     },
@@ -40261,7 +40261,7 @@
               "end" : 4189547
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/219/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/219/rip_log.txt"
         }
       ]
     },
@@ -40442,7 +40442,7 @@
               "end" : 4446747
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/220/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/220/rip_log.txt"
         }
       ]
     },
@@ -40601,7 +40601,7 @@
               "end" : 3932520
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/221/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/221/rip_log.txt"
         }
       ]
     },
@@ -40770,7 +40770,7 @@
               "end" : 4615480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/222/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/222/rip_log.txt"
         }
       ]
     },
@@ -40944,7 +40944,7 @@
               "end" : 4799880
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/223/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/223/rip_log.txt"
         }
       ]
     },
@@ -41101,7 +41101,7 @@
               "end" : 4363613
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/224/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/224/rip_log.txt"
         }
       ]
     },
@@ -41326,7 +41326,7 @@
               "end" : 3077933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -41361,7 +41361,7 @@
               "end" : 3689613
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -41396,7 +41396,7 @@
               "end" : 3928907
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log3.txt"
         }
       ]
     },
@@ -41537,7 +41537,7 @@
               "end" : 4953600
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/226/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/226/rip_log.txt"
         }
       ]
     },
@@ -41678,7 +41678,7 @@
               "end" : 3870227
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/227/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/227/rip_log.txt"
         }
       ]
     },
@@ -41823,7 +41823,7 @@
               "end" : 4761320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Serie/228/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Serie/228/rip_log.txt"
         }
       ]
     },

--- a/web/data/Serie/005/metadata.json
+++ b/web/data/Serie/005/metadata.json
@@ -155,7 +155,7 @@
           "end" : 2960987
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/005/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/005/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/005/rip_log.txt
+++ b/web/data/Serie/005/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 000edcc7-0063b050-550b9008)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Unknown Title.m4a
+    Filename : Unknown Title.m4a
     CRC32 hash               : D97BE047
     CRC32 hash (skip zero)   : ED52248E
     Statistics

--- a/web/data/Serie/011/metadata.json
+++ b/web/data/Serie/011/metadata.json
@@ -139,7 +139,7 @@
           "end" : 2894907
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/011/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/011/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/011/rip_log.txt
+++ b/web/data/Serie/011/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 000ece0f-00635901-650b4e08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Folge 11： Das Gespensterschloss.m4a
+    Filename : Folge 11： Das Gespensterschloss.m4a
     CRC32 hash               : 0CF777C6
     CRC32 hash (skip zero)   : 5904CB76
     Statistics

--- a/web/data/Serie/049/metadata.json
+++ b/web/data/Serie/049/metadata.json
@@ -148,7 +148,7 @@
           "end" : 2670120
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/049/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/049/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/049/rip_log.txt
+++ b/web/data/Serie/049/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 000df3e4-005cc761-5e0a6e08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/049／und die Comic-Diebe.m4a
+    Filename : 049／und die Comic-Diebe.m4a
     CRC32 hash               : BDB649A6
     CRC32 hash (skip zero)   : 8E9F3D5A
     Statistics

--- a/web/data/Serie/050/metadata.json
+++ b/web/data/Serie/050/metadata.json
@@ -147,7 +147,7 @@
           "end" : 3435173
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/050/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/050/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/050/rip_log.txt
+++ b/web/data/Serie/050/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 00123e21-00788f51-6a0d6b08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/050／und der verschwundene Filmstar.m4a
+    Filename : 050／und der verschwundene Filmstar.m4a
     CRC32 hash               : 1541FADF
     CRC32 hash (skip zero)   : 22495DA2
     Statistics

--- a/web/data/Serie/051/metadata.json
+++ b/web/data/Serie/051/metadata.json
@@ -135,7 +135,7 @@
           "end" : 3270107
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/051/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/051/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/051/rip_log.txt
+++ b/web/data/Serie/051/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0011ae73-0074e6a2-690cc608)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/051／und der riskante Ritt.m4a
+    Filename : 051／und der riskante Ritt.m4a
     CRC32 hash               : 47F880E0
     CRC32 hash (skip zero)   : 904CE8B8
     Statistics

--- a/web/data/Serie/052/metadata.json
+++ b/web/data/Serie/052/metadata.json
@@ -167,7 +167,7 @@
           "end" : 3267773
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/052/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/052/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/052/rip_log.txt
+++ b/web/data/Serie/052/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0011a5f5-0074b46d-6a0cc308)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/052／und die Musikpiraten.m4a
+    Filename : 052／und die Musikpiraten.m4a
     CRC32 hash               : E9C934B1
     CRC32 hash (skip zero)   : E9071926
     Statistics

--- a/web/data/Serie/053/metadata.json
+++ b/web/data/Serie/053/metadata.json
@@ -155,7 +155,7 @@
           "end" : 3203173
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/053/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/053/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/053/rip_log.txt
+++ b/web/data/Serie/053/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0010fcdd-0070d52f-6a0c8308)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/053／und die Automafia.m4a
+    Filename : 053／und die Automafia.m4a
     CRC32 hash               : 9FBA3318
     CRC32 hash (skip zero)   : 136E8AAC
     Statistics

--- a/web/data/Serie/054/metadata.json
+++ b/web/data/Serie/054/metadata.json
@@ -156,7 +156,7 @@
           "end" : 3048040
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/054/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/054/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/054/rip_log.txt
+++ b/web/data/Serie/054/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 000f532e-0067007b-680be808)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/054／Gefahr im Verzug.m4a
+    Filename : 054／Gefahr im Verzug.m4a
     CRC32 hash               : 11459FBA
     CRC32 hash (skip zero)   : FA0BE816
     Statistics

--- a/web/data/Serie/055/metadata.json
+++ b/web/data/Serie/055/metadata.json
@@ -159,7 +159,7 @@
           "end" : 3056533
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/055/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/055/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/055/rip_log.txt
+++ b/web/data/Serie/055/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00112abe-0070a74b-5e0bf008)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/055／Gekaufte Spieler.m4a
+    Filename : 055／Gekaufte Spieler.m4a
     CRC32 hash               : ACFF5951
     CRC32 hash (skip zero)   : 119A8882
     Statistics

--- a/web/data/Serie/056/metadata.json
+++ b/web/data/Serie/056/metadata.json
@@ -159,7 +159,7 @@
           "end" : 2967587
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/056/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/056/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/056/rip_log.txt
+++ b/web/data/Serie/056/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 000f0892-00641007-640b9708)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/056／Angriff der Computer-Viren.m4a
+    Filename : 056／Angriff der Computer-Viren.m4a
     CRC32 hash               : D5B8B5CB
     CRC32 hash (skip zero)   : C6F915C8
     Statistics

--- a/web/data/Serie/057/metadata.json
+++ b/web/data/Serie/057/metadata.json
@@ -151,7 +151,7 @@
           "end" : 2605187
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/057/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/057/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/057/rip_log.txt
+++ b/web/data/Serie/057/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 000da06c-005a82a6-620a2d08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/057／Tatort Zirkus.m4a
+    Filename : 057／Tatort Zirkus.m4a
     CRC32 hash               : 175E88AF
     CRC32 hash (skip zero)   : 2EE94E7D
     Statistics

--- a/web/data/Serie/058/metadata.json
+++ b/web/data/Serie/058/metadata.json
@@ -156,7 +156,7 @@
           "end" : 2711893
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/058/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/058/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/058/rip_log.txt
+++ b/web/data/Serie/058/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 000e45b0-005e38ba-580a9708)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/058／und der verrückte Maler.m4a
+    Filename : 058／und der verrückte Maler.m4a
     CRC32 hash               : C9658616
     CRC32 hash (skip zero)   : E26AD6F0
     Statistics

--- a/web/data/Serie/059/metadata.json
+++ b/web/data/Serie/059/metadata.json
@@ -155,7 +155,7 @@
           "end" : 2667307
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/059/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/059/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/059/rip_log.txt
+++ b/web/data/Serie/059/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 000dbd0b-005bed0f-580a6b08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/059／Giftiges Wasser.m4a
+    Filename : 059／Giftiges Wasser.m4a
     CRC32 hash               : 231F7B34
     CRC32 hash (skip zero)   : B35269C2
     Statistics

--- a/web/data/Serie/060/metadata.json
+++ b/web/data/Serie/060/metadata.json
@@ -160,7 +160,7 @@
           "end" : 2826880
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/060/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/060/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/060/rip_log.txt
+++ b/web/data/Serie/060/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 000ee778-0062efd0-5e0b0a08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/060／Dopingmixer.m4a
+    Filename : 060／Dopingmixer.m4a
     CRC32 hash               : B25CA781
     CRC32 hash (skip zero)   : D4C7D38A
     Statistics

--- a/web/data/Serie/061/metadata.json
+++ b/web/data/Serie/061/metadata.json
@@ -159,7 +159,7 @@
           "end" : 3569320
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/061/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/061/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/061/rip_log.txt
+++ b/web/data/Serie/061/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 00138668-00802561-810df108)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/061／und die Rache des Tigers.m4a
+    Filename : 061／und die Rache des Tigers.m4a
     CRC32 hash               : 3A5A12C9
     CRC32 hash (skip zero)   : BEFCF8CA
     Statistics

--- a/web/data/Serie/062/metadata.json
+++ b/web/data/Serie/062/metadata.json
@@ -159,7 +159,7 @@
           "end" : 3563227
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/062/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/062/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/062/rip_log.txt
+++ b/web/data/Serie/062/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 0012d807-007e55d8-7e0deb08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/062／Spuk im Hotel.m4a
+    Filename : 062／Spuk im Hotel.m4a
     CRC32 hash               : 6A2984D4
     CRC32 hash (skip zero)   : 10DE7EC8
     Statistics

--- a/web/data/Serie/063/metadata.json
+++ b/web/data/Serie/063/metadata.json
@@ -160,7 +160,7 @@
           "end" : 4014467
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/063/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/063/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/063/rip_log.txt
+++ b/web/data/Serie/063/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 00144a0f-00880dbf-5c0fae08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/063／Fußball-Gangster.m4a
+    Filename : 063／Fußball-Gangster.m4a
     CRC32 hash               : 54E2B1BD
     CRC32 hash (skip zero)   : D22FB8B4
     Statistics

--- a/web/data/Serie/064/metadata.json
+++ b/web/data/Serie/064/metadata.json
@@ -160,7 +160,7 @@
           "end" : 3969547
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/064/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/064/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/064/rip_log.txt
+++ b/web/data/Serie/064/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00173ded-009632b1-7d0f8108)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/064／Geisterstadt.m4a
+    Filename : 064／Geisterstadt.m4a
     CRC32 hash               : 45C138AC
     CRC32 hash (skip zero)   : 8336EF55
     Statistics

--- a/web/data/Serie/065/metadata.json
+++ b/web/data/Serie/065/metadata.json
@@ -167,7 +167,7 @@
           "end" : 3579173
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/065/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/065/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/065/rip_log.txt
+++ b/web/data/Serie/065/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 001244e4-007993a4-840dfb08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/065／Diamantenschmuggel.m4a
+    Filename : 065／Diamantenschmuggel.m4a
     CRC32 hash               : 3B5E2A19
     CRC32 hash (skip zero)   : A193899A
     Statistics

--- a/web/data/Serie/066/metadata.json
+++ b/web/data/Serie/066/metadata.json
@@ -151,7 +151,7 @@
           "end" : 3555013
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/066/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/066/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/066/rip_log.txt
+++ b/web/data/Serie/066/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0013bc03-007e7663-790de308)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/066／und die Schattenmänner.m4a
+    Filename : 066／und die Schattenmänner.m4a
     CRC32 hash               : 232B3D9B
     CRC32 hash (skip zero)   : 684BD7F7
     Statistics

--- a/web/data/Serie/067/metadata.json
+++ b/web/data/Serie/067/metadata.json
@@ -155,7 +155,7 @@
           "end" : 3799320
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/067/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/067/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/067/rip_log.txt
+++ b/web/data/Serie/067/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 00135a81-0081c0c6-670ed708)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/067 - Und das Geheimnis der Särge.m4a
+    Filename : 067 - Und das Geheimnis der Särge.m4a
     CRC32 hash               : 5E5D74D4
     CRC32 hash (skip zero)   : B73D106F
     Statistics

--- a/web/data/Serie/068/metadata.json
+++ b/web/data/Serie/068/metadata.json
@@ -135,7 +135,7 @@
           "end" : 3581227
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/068/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/068/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/068/rip_log.txt
+++ b/web/data/Serie/068/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00133305-007f78e6-820dfd08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/068 - und der Schatz im Bergsee.m4a
+    Filename : 068 - und der Schatz im Bergsee.m4a
     CRC32 hash               : AA088ECE
     CRC32 hash (skip zero)   : 6C731A51
     Statistics

--- a/web/data/Serie/069/metadata.json
+++ b/web/data/Serie/069/metadata.json
@@ -168,7 +168,7 @@
           "end" : 3942387
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/069/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/069/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/069/rip_log.txt
+++ b/web/data/Serie/069/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0014d136-008a954b-660f6608)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/069 - Späte Rache.m4a
+    Filename : 069 - Späte Rache.m4a
     CRC32 hash               : 4F43998F
     CRC32 hash (skip zero)   : 581240E4
     Statistics

--- a/web/data/Serie/070/metadata.json
+++ b/web/data/Serie/070/metadata.json
@@ -159,7 +159,7 @@
           "end" : 3784293
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/070/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/070/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/070/rip_log.txt
+++ b/web/data/Serie/070/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0014bcf8-00870604-6f0ec808)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/070 - Schüsse aus dem Dunkel.m4a
+    Filename : 070 - Schüsse aus dem Dunkel.m4a
     CRC32 hash               : 0987FE79
     CRC32 hash (skip zero)   : 716B8EAB
     Statistics

--- a/web/data/Serie/071/metadata.json
+++ b/web/data/Serie/071/metadata.json
@@ -172,7 +172,7 @@
           "end" : 3994440
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/071/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/071/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/071/rip_log.txt
+++ b/web/data/Serie/071/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 00153777-008a6dcd-6f0f9a08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/071 - Die verschwundene Seglerin.m4a
+    Filename : 071 - Die verschwundene Seglerin.m4a
     CRC32 hash               : 15276E08
     CRC32 hash (skip zero)   : 237F3655
     Statistics

--- a/web/data/Serie/072/metadata.json
+++ b/web/data/Serie/072/metadata.json
@@ -167,7 +167,7 @@
           "end" : 3477893
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/072/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/072/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/072/rip_log.txt
+++ b/web/data/Serie/072/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 0012b88b-00796af2-710d9508)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/072／Dreckiger Deal.m4a
+    Filename : 072／Dreckiger Deal.m4a
     CRC32 hash               : F9E6E408
     CRC32 hash (skip zero)   : 17936244
     Statistics

--- a/web/data/Serie/073/metadata.json
+++ b/web/data/Serie/073/metadata.json
@@ -151,7 +151,7 @@
           "end" : 3997320
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/073/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/073/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/073/rip_log.txt
+++ b/web/data/Serie/073/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 001595fa-008eeba1-590f9d08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/073 - Poltergeist.m4a
+    Filename : 073 - Poltergeist.m4a
     CRC32 hash               : A0DE3761
     CRC32 hash (skip zero)   : 4E095DBF
     Statistics

--- a/web/data/Serie/074/metadata.json
+++ b/web/data/Serie/074/metadata.json
@@ -168,7 +168,7 @@
           "end" : 4442107
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/074/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/074/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/074/rip_log.txt
+++ b/web/data/Serie/074/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00154a26-008fd31a-6c115a08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/074 - Das Brennende Schwert.m4a
+    Filename : 074 - Das Brennende Schwert.m4a
     CRC32 hash               : 848F761C
     CRC32 hash (skip zero)   : 4EF97042
     Statistics

--- a/web/data/Serie/075/metadata.json
+++ b/web/data/Serie/075/metadata.json
@@ -147,7 +147,7 @@
           "end" : 3339600
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/075/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/075/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/075/rip_log.txt
+++ b/web/data/Serie/075/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 001177bd-00748aad-660d0b08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/075／Die Spur des Raben.m4a
+    Filename : 075／Die Spur des Raben.m4a
     CRC32 hash               : 0E877B62
     CRC32 hash (skip zero)   : CBF4A815
     Statistics

--- a/web/data/Serie/076/metadata.json
+++ b/web/data/Serie/076/metadata.json
@@ -155,7 +155,7 @@
           "end" : 4184827
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/076/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/076/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/076/rip_log.txt
+++ b/web/data/Serie/076/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 0016a497-0095c56c-7c105808)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/(076) Stimmen aus dem Nichts.m4a
+    Filename : (076) Stimmen aus dem Nichts.m4a
     CRC32 hash               : 11FF28B1
     CRC32 hash (skip zero)   : F8AB7749
     Statistics

--- a/web/data/Serie/077/metadata.json
+++ b/web/data/Serie/077/metadata.json
@@ -144,7 +144,7 @@
           "end" : 3559333
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/077/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/077/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/077/rip_log.txt
+++ b/web/data/Serie/077/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 000e6a72-004cd718-400de706)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/077 - Pistenteufel.m4a
+    Filename : 077 - Pistenteufel.m4a
     CRC32 hash               : 8E170517
     CRC32 hash (skip zero)   : 3DBE19C5
     Statistics

--- a/web/data/Serie/078/metadata.json
+++ b/web/data/Serie/078/metadata.json
@@ -140,7 +140,7 @@
           "end" : 3448987
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/078/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/078/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/078/rip_log.txt
+++ b/web/data/Serie/078/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 000e1a1e-004b8d64-510d7806)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/078 - Das leere Grab.m4a
+    Filename : 078 - Das leere Grab.m4a
     CRC32 hash               : 49CD7DAF
     CRC32 hash (skip zero)   : 12AB1E14
     Statistics

--- a/web/data/Serie/079/metadata.json
+++ b/web/data/Serie/079/metadata.json
@@ -166,7 +166,7 @@
           "end" : 4612307
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/079/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/079/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/079/rip_log.txt
+++ b/web/data/Serie/079/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 00181cb8-00a08225-6d120408)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Vol. 079. - (1998) - Im Bann Des Voodoo - Die drei Fragezeichen.m4a
+    Filename : Vol. 079. - (1998) - Im Bann Des Voodoo - Die drei Fragezeichen.m4a
     CRC32 hash               : BD4A1580
     CRC32 hash (skip zero)   : A24216F6
     Statistics

--- a/web/data/Serie/080/metadata.json
+++ b/web/data/Serie/080/metadata.json
@@ -112,7 +112,7 @@
           "end" : 3560667
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/080/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/080/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/080/rip_log.txt
+++ b/web/data/Serie/080/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 000e0e7e-004b27b7-410de806)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/080／Geheimakte Ufo.m4a
+    Filename : 080／Geheimakte Ufo.m4a
     CRC32 hash               : 4045BE0D
     CRC32 hash (skip zero)   : 00384EBD
     Statistics

--- a/web/data/Serie/081/metadata.json
+++ b/web/data/Serie/081/metadata.json
@@ -135,7 +135,7 @@
           "end" : 2983827
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/081/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/081/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/081/rip_log.txt
+++ b/web/data/Serie/081/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 000c1e49-00408ba7-490ba706)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/81 - Verdeckte Fouls.m4a
+    Filename : 81 - Verdeckte Fouls.m4a
     CRC32 hash               : 033C088A
     CRC32 hash (skip zero)   : 9332ADDF
     Statistics

--- a/web/data/Serie/082/metadata.json
+++ b/web/data/Serie/082/metadata.json
@@ -119,7 +119,7 @@
           "end" : 4199867
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/082/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/082/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/082/rip_log.txt
+++ b/web/data/Serie/082/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 001080fd-0058f3d4-4f106706)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/082／Die Karten des Bösen.m4a
+    Filename : 082／Die Karten des Bösen.m4a
     CRC32 hash               : 089F4209
     CRC32 hash (skip zero)   : 20D83B3F
     Statistics

--- a/web/data/Serie/083/metadata.json
+++ b/web/data/Serie/083/metadata.json
@@ -127,7 +127,7 @@
           "end" : 3558427
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/083/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/083/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/083/rip_log.txt
+++ b/web/data/Serie/083/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000e3052-004bace3-420de606)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/083／Meuterei auf hoher See.m4a
+    Filename : 083／Meuterei auf hoher See.m4a
     CRC32 hash               : 09DFEF49
     CRC32 hash (skip zero)   : 8F94F3C2
     Statistics

--- a/web/data/Serie/084/metadata.json
+++ b/web/data/Serie/084/metadata.json
@@ -119,7 +119,7 @@
           "end" : 3603107
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/084/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/084/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/084/rip_log.txt
+++ b/web/data/Serie/084/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000e471d-004c0a16-470e1306)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/084／Musik des Teufels.m4a
+    Filename : 084／Musik des Teufels.m4a
     CRC32 hash               : F8B74063
     CRC32 hash (skip zero)   : F177D1C2
     Statistics

--- a/web/data/Serie/085/metadata.json
+++ b/web/data/Serie/085/metadata.json
@@ -127,7 +127,7 @@
           "end" : 3562000
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/085/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/085/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/085/rip_log.txt
+++ b/web/data/Serie/085/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000cfd62-0046b6fd-5d0dea06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/085 - Feuerturm.m4a
+    Filename : 085 - Feuerturm.m4a
     CRC32 hash               : AE484FED
     CRC32 hash (skip zero)   : 3CB525EE
     Statistics

--- a/web/data/Serie/086/metadata.json
+++ b/web/data/Serie/086/metadata.json
@@ -127,7 +127,7 @@
           "end" : 3457213
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/086/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/086/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/086/rip_log.txt
+++ b/web/data/Serie/086/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000d99d4-00484dee-430d8106)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/086 - Nacht In Angst.m4a
+    Filename : 086 - Nacht In Angst.m4a
     CRC32 hash               : C1969356
     CRC32 hash (skip zero)   : B7EC4553
     Statistics

--- a/web/data/Serie/087/metadata.json
+++ b/web/data/Serie/087/metadata.json
@@ -135,7 +135,7 @@
           "end" : 3294627
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/087/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/087/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/087/rip_log.txt
+++ b/web/data/Serie/087/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000d3ab0-004703ac-540cde06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/087 - Wolfsgesicht.m4a
+    Filename : 087 - Wolfsgesicht.m4a
     CRC32 hash               : 4FF7757F
     CRC32 hash (skip zero)   : 16539456
     Statistics

--- a/web/data/Serie/088/metadata.json
+++ b/web/data/Serie/088/metadata.json
@@ -155,7 +155,7 @@
           "end" : 4496507
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/088/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/088/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/088/rip_log.txt
+++ b/web/data/Serie/088/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 0010e673-005b9939-42119006)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/088／Vampir im Internet.m4a
+    Filename : 088／Vampir im Internet.m4a
     CRC32 hash               : A5E5776B
     CRC32 hash (skip zero)   : 9713C681
     Statistics

--- a/web/data/Serie/089/metadata.json
+++ b/web/data/Serie/089/metadata.json
@@ -127,7 +127,7 @@
           "end" : 3586347
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/089/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/089/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/089/rip_log.txt
+++ b/web/data/Serie/089/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000d864a-0048ccd1-4f0e0206)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/089／Tödliche Spur.m4a
+    Filename : 089／Tödliche Spur.m4a
     CRC32 hash               : AAE8E97C
     CRC32 hash (skip zero)   : E30C9527
     Statistics

--- a/web/data/Serie/090/metadata.json
+++ b/web/data/Serie/090/metadata.json
@@ -111,7 +111,7 @@
           "end" : 3532947
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/090/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/090/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/090/rip_log.txt
+++ b/web/data/Serie/090/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000d9410-00491c65-460dcc06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/090／Der Feuerteufel.m4a
+    Filename : 090／Der Feuerteufel.m4a
     CRC32 hash               : 0F667343
     CRC32 hash (skip zero)   : BA2AA6E4
     Statistics

--- a/web/data/Serie/091/metadata.json
+++ b/web/data/Serie/091/metadata.json
@@ -115,7 +115,7 @@
           "end" : 3597147
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/091/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/091/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/091/rip_log.txt
+++ b/web/data/Serie/091/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000df949-004a9c79-510e0d06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/091／Labyrinth der Götter.m4a
+    Filename : 091／Labyrinth der Götter.m4a
     CRC32 hash               : D97511B3
     CRC32 hash (skip zero)   : BD0A8B89
     Statistics

--- a/web/data/Serie/092/metadata.json
+++ b/web/data/Serie/092/metadata.json
@@ -115,7 +115,7 @@
           "end" : 3569347
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/092/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/092/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/092/rip_log.txt
+++ b/web/data/Serie/092/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000eb357-004e1837-590df106)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/092／Todesflug.m4a
+    Filename : 092／Todesflug.m4a
     CRC32 hash               : 462A7831
     CRC32 hash (skip zero)   : 382924CC
     Statistics

--- a/web/data/Serie/093/metadata.json
+++ b/web/data/Serie/093/metadata.json
@@ -120,7 +120,7 @@
           "end" : 3592133
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/093/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/093/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/093/rip_log.txt
+++ b/web/data/Serie/093/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000d761d-004776ff-3e0e0806)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/093／und das Geisterschiff.m4a
+    Filename : 093／und das Geisterschiff.m4a
     CRC32 hash               : AAD18910
     CRC32 hash (skip zero)   : 920C2EDC
     Statistics

--- a/web/data/Serie/094/metadata.json
+++ b/web/data/Serie/094/metadata.json
@@ -136,7 +136,7 @@
           "end" : 3262720
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/094/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/094/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/094/rip_log.txt
+++ b/web/data/Serie/094/rip_log.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 000e04ff-00495b26-580cbe06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/094／Das schwarze Monster.m4a
+    Filename : 094／Das schwarze Monster.m4a
     CRC32 hash               : 6F0E5774
     CRC32 hash (skip zero)   : 9A64EFFE
     Statistics

--- a/web/data/Serie/095/metadata.json
+++ b/web/data/Serie/095/metadata.json
@@ -123,7 +123,7 @@
           "end" : 3603800
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/095/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/095/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/095/rip_log.txt
+++ b/web/data/Serie/095/rip_log.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000e8e1a-004d837d-580e1306)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/095／Botschaft von Geisterhand.m4a
+    Filename : 095／Botschaft von Geisterhand.m4a
     CRC32 hash               : BA8664E9
     CRC32 hash (skip zero)   : CBBC6A6F
     Statistics

--- a/web/data/Serie/096/metadata.json
+++ b/web/data/Serie/096/metadata.json
@@ -151,7 +151,7 @@
           "end" : 3191000
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/096/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/096/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/096/rip_log.txt
+++ b/web/data/Serie/096/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00105f71-006e79e1-5f0c7708)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/096／und der rote Rächer.m4a
+    Filename : 096／und der rote Rächer.m4a
     CRC32 hash               : 7D333392
     CRC32 hash (skip zero)   : F08FC578
     Statistics

--- a/web/data/Serie/097/metadata.json
+++ b/web/data/Serie/097/metadata.json
@@ -140,7 +140,7 @@
           "end" : 4066453
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/097/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/097/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/097/rip_log.txt
+++ b/web/data/Serie/097/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00156eeb-008e55d2-660fe208)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/097／Insektenstachel.m4a
+    Filename : 097／Insektenstachel.m4a
     CRC32 hash               : 09DC8FE8
     CRC32 hash (skip zero)   : 81D76A10
     Statistics

--- a/web/data/Serie/098/metadata.json
+++ b/web/data/Serie/098/metadata.json
@@ -160,7 +160,7 @@
           "end" : 3772307
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/098/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/098/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/098/rip_log.txt
+++ b/web/data/Serie/098/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00139aef-00825c6a-7c0ebc08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/098／Tal des Schreckens.m4a
+    Filename : 098／Tal des Schreckens.m4a
     CRC32 hash               : C2C68BC8
     CRC32 hash (skip zero)   : D9067793
     Statistics

--- a/web/data/Serie/099/metadata.json
+++ b/web/data/Serie/099/metadata.json
@@ -163,7 +163,7 @@
           "end" : 4573053
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/099/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/099/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/099/rip_log.txt
+++ b/web/data/Serie/099/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0016c671-009948b3-5611dd08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/099／Rufmord.m4a
+    Filename : 099／Rufmord.m4a
     CRC32 hash               : E85F0164
     CRC32 hash (skip zero)   : 301C28F6
     Statistics

--- a/web/data/Serie/100/metadata.json
+++ b/web/data/Serie/100/metadata.json
@@ -110,7 +110,7 @@
           "end" : 3204573
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -145,7 +145,7 @@
           "end" : 3376800
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -180,7 +180,7 @@
           "end" : 3410493
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/100/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/100/rip_log3.txt"
     }
   ],
   "teile" : [

--- a/web/data/Serie/100/rip_log1.txt
+++ b/web/data/Serie/100/rip_log1.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000cbcc3-00440f3c-450c8406)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/100 - (A) - Toteninsel - Das Rätsel der Sphinx.m4a
+    Filename : 100 - (A) - Toteninsel - Das Rätsel der Sphinx.m4a
     CRC32 hash               : 244C4DA7
     CRC32 hash (skip zero)   : AEB9DE5A
     Statistics

--- a/web/data/Serie/100/rip_log2.txt
+++ b/web/data/Serie/100/rip_log2.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000d6e91-004824ae-4f0d3006)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/100 - (B) - Toteninsel - Das vergessene Volk.m4a
+    Filename : 100 - (B) - Toteninsel - Das vergessene Volk.m4a
     CRC32 hash               : E7F706A7
     CRC32 hash (skip zero)   : EE5303DB
     Statistics

--- a/web/data/Serie/100/rip_log3.txt
+++ b/web/data/Serie/100/rip_log3.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000d6069-00476c3d-460d5206)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/100C - Toteninsel - Der Fluch der Gräber.m4a
+    Filename : 100C - Toteninsel - Der Fluch der Gräber.m4a
     CRC32 hash               : 3CA8DA15
     CRC32 hash (skip zero)   : E0F97795
     Statistics

--- a/web/data/Serie/101/metadata.json
+++ b/web/data/Serie/101/metadata.json
@@ -151,7 +151,7 @@
           "end" : 4313453
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/101/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/101/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/101/rip_log.txt
+++ b/web/data/Serie/101/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 001459ff-00891fd9-8810d908)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei Fragezeichen： Folge 101 - Das Hexen-Handy.m4a
+    Filename : Die Drei Fragezeichen： Folge 101 - Das Hexen-Handy.m4a
     CRC32 hash               : BD4F2C9E
     CRC32 hash (skip zero)   : BE4A55D4
     Statistics

--- a/web/data/Serie/102/metadata.json
+++ b/web/data/Serie/102/metadata.json
@@ -139,7 +139,7 @@
           "end" : 3560680
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/102/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/102/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/102/rip_log.txt
+++ b/web/data/Serie/102/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0011e134-0077de24-610de808)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/102／Doppelte Täuschung.m4a
+    Filename : 102／Doppelte Täuschung.m4a
     CRC32 hash               : ACED829D
     CRC32 hash (skip zero)   : 215369E2
     Statistics

--- a/web/data/Serie/103/metadata.json
+++ b/web/data/Serie/103/metadata.json
@@ -148,7 +148,7 @@
           "end" : 3810187
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/103/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/103/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/103/rip_log.txt
+++ b/web/data/Serie/103/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 00149fe6-0088ca14-560ee208)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/103／Das Erbe des Meisterdiebes.m4a
+    Filename : 103／Das Erbe des Meisterdiebes.m4a
     CRC32 hash               : 9AD8C4AD
     CRC32 hash (skip zero)   : 85313F3E
     Statistics

--- a/web/data/Serie/104/metadata.json
+++ b/web/data/Serie/104/metadata.json
@@ -147,7 +147,7 @@
           "end" : 4138120
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/104/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/104/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/104/rip_log.txt
+++ b/web/data/Serie/104/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 00149011-00884fdc-62102a08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/104／Gift per e-mail.m4a
+    Filename : 104／Gift per e-mail.m4a
     CRC32 hash               : 70663071
     CRC32 hash (skip zero)   : 5C0F8695
     Statistics

--- a/web/data/Serie/105/metadata.json
+++ b/web/data/Serie/105/metadata.json
@@ -143,7 +143,7 @@
           "end" : 4545293
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/105/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/105/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/105/rip_log.txt
+++ b/web/data/Serie/105/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0017bb2f-009c1689-7a11c108)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/105／Der Nebelberg.m4a
+    Filename : 105／Der Nebelberg.m4a
     CRC32 hash               : 24932518
     CRC32 hash (skip zero)   : 85612E8E
     Statistics

--- a/web/data/Serie/106/metadata.json
+++ b/web/data/Serie/106/metadata.json
@@ -173,7 +173,7 @@
           "end" : 4255213
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/106/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/106/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/106/rip_log.txt
+++ b/web/data/Serie/106/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0015b2f5-00903f55-65109f08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/106／Der Mann ohne Kopf.m4a
+    Filename : 106／Der Mann ohne Kopf.m4a
     CRC32 hash               : 1A5E9858
     CRC32 hash (skip zero)   : F1F92049
     Statistics

--- a/web/data/Serie/107/metadata.json
+++ b/web/data/Serie/107/metadata.json
@@ -151,7 +151,7 @@
           "end" : 3850840
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/107/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/107/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/107/rip_log.txt
+++ b/web/data/Serie/107/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00145cb9-00853ef0-710f0a08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/107 - und der Schatz der Mönche.m4a
+    Filename : 107 - und der Schatz der Mönche.m4a
     CRC32 hash               : F669678C
     CRC32 hash (skip zero)   : AE42BF85
     Statistics

--- a/web/data/Serie/108/metadata.json
+++ b/web/data/Serie/108/metadata.json
@@ -145,7 +145,7 @@
           "end" : 4004480
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/108/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/108/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/108/rip_log.txt
+++ b/web/data/Serie/108/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 0015d03b-00a078bd-790fa409)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/3F 108 - Die sieben Tore.m4a
+    Filename : 3F 108 - Die sieben Tore.m4a
     CRC32 hash               : 39730D25
     CRC32 hash (skip zero)   : 75462B04
     Statistics

--- a/web/data/Serie/109/metadata.json
+++ b/web/data/Serie/109/metadata.json
@@ -155,7 +155,7 @@
           "end" : 4027533
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/109/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/109/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/109/rip_log.txt
+++ b/web/data/Serie/109/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00162d42-008ee0d9-870fbb08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/109 - Gefährliches Quiz.m4a
+    Filename : 109 - Gefährliches Quiz.m4a
     CRC32 hash               : CB788D18
     CRC32 hash (skip zero)   : 494C4024
     Statistics

--- a/web/data/Serie/110/metadata.json
+++ b/web/data/Serie/110/metadata.json
@@ -159,7 +159,7 @@
           "end" : 3310573
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/110/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/110/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/110/rip_log.txt
+++ b/web/data/Serie/110/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0012c350-007a867e-650cee08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/110 - Panik im Park.m4a
+    Filename : 110 - Panik im Park.m4a
     CRC32 hash               : 4042BA0A
     CRC32 hash (skip zero)   : 41BD09C5
     Statistics

--- a/web/data/Serie/111/metadata.json
+++ b/web/data/Serie/111/metadata.json
@@ -227,7 +227,7 @@
           "end" : 3906600
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/111/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/111/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/111/rip_log.txt
+++ b/web/data/Serie/111/rip_log.txt
@@ -56,7 +56,7 @@ AccurateRip Summary (DiscID: 001f5f16-0155d1a0-ae0f420e)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/111 - Die drei Fragezeichen - Die Höhle des Grauens.m4a
+    Filename : 111 - Die drei Fragezeichen - Die Höhle des Grauens.m4a
     CRC32 hash               : CD6EB9BB
     CRC32 hash (skip zero)   : 1C130960
     Statistics

--- a/web/data/Serie/112/metadata.json
+++ b/web/data/Serie/112/metadata.json
@@ -193,7 +193,7 @@
           "end" : 3529667
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/112/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/112/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/112/rip_log.txt
+++ b/web/data/Serie/112/rip_log.txt
@@ -48,7 +48,7 @@ AccurateRip Summary (DiscID: 00198e89-0103aaa5-b70dc90d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/112 - Schlucht der Dämonen.m4a
+    Filename : 112 - Schlucht der Dämonen.m4a
     CRC32 hash               : 12BCC323
     CRC32 hash (skip zero)   : 57C289E9
     Statistics

--- a/web/data/Serie/113/metadata.json
+++ b/web/data/Serie/113/metadata.json
@@ -203,7 +203,7 @@
           "end" : 3607400
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/113/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/113/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/113/rip_log.txt
+++ b/web/data/Serie/113/rip_log.txt
@@ -50,7 +50,7 @@ AccurateRip Summary (DiscID: 001eee7c-01468e34-b10e170e)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/113 - Das Auge Des Drachen.m4a
+    Filename : 113 - Das Auge Des Drachen.m4a
     CRC32 hash               : 98DED279
     CRC32 hash (skip zero)   : 4CFB21A6
     Statistics

--- a/web/data/Serie/114/metadata.json
+++ b/web/data/Serie/114/metadata.json
@@ -187,7 +187,7 @@
           "end" : 4150480
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/114/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/114/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/114/rip_log.txt
+++ b/web/data/Serie/114/rip_log.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 001dea57-011573b9-b810360c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/114 - Die Villa der Toten.m4a
+    Filename : 114 - Die Villa der Toten.m4a
     CRC32 hash               : DE82DAAB
     CRC32 hash (skip zero)   : 274F0937
     Statistics

--- a/web/data/Serie/115/metadata.json
+++ b/web/data/Serie/115/metadata.json
@@ -230,7 +230,7 @@
           "end" : 4200627
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/115/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/115/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/115/rip_log.txt
+++ b/web/data/Serie/115/rip_log.txt
@@ -57,7 +57,7 @@ AccurateRip Summary (DiscID: 001ff055-016f59d9-de10680f)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/115 Auf tödlichem Kurs.m4a
+    Filename : 115 Auf tödlichem Kurs.m4a
     CRC32 hash               : 4CAC931F
     CRC32 hash (skip zero)   : 24231C64
     Statistics

--- a/web/data/Serie/116/metadata.json
+++ b/web/data/Serie/116/metadata.json
@@ -157,7 +157,7 @@
           "end" : 3724893
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/116/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/116/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/116/rip_log.txt
+++ b/web/data/Serie/116/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 0017fc0f-00aab350-780e8c09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/116 - Codename： Cobra.m4a
+    Filename : 116 - Codename： Cobra.m4a
     CRC32 hash               : 18AC230A
     CRC32 hash (skip zero)   : 07A5D93B
     Statistics

--- a/web/data/Serie/117/metadata.json
+++ b/web/data/Serie/117/metadata.json
@@ -186,7 +186,7 @@
           "end" : 3640027
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/117/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/117/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/117/rip_log.txt
+++ b/web/data/Serie/117/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 001cc3ff-00f06451-9c0e380b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/117 - Der finstere Rivale.m4a
+    Filename : 117 - Der finstere Rivale.m4a
     CRC32 hash               : D92A3A15
     CRC32 hash (skip zero)   : F67FF3FC
     Statistics

--- a/web/data/Serie/118/metadata.json
+++ b/web/data/Serie/118/metadata.json
@@ -213,7 +213,7 @@
           "end" : 3996413
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/118/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/118/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/118/rip_log.txt
+++ b/web/data/Serie/118/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 001bf049-011706e7-ba0f9c0d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/118 - Das düstere Vermächtnis.m4a
+    Filename : 118 - Das düstere Vermächtnis.m4a
     CRC32 hash               : BCA2B9E4
     CRC32 hash (skip zero)   : CE10E6C2
     Statistics

--- a/web/data/Serie/119/metadata.json
+++ b/web/data/Serie/119/metadata.json
@@ -216,7 +216,7 @@
           "end" : 4063440
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/119/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/119/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/119/rip_log.txt
+++ b/web/data/Serie/119/rip_log.txt
@@ -55,7 +55,7 @@ AccurateRip Summary (DiscID: 0020c98f-01621ec6-c70fdf0e)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/119 der geheime Schlüssel.m4a
+    Filename : 119 der geheime Schlüssel.m4a
     CRC32 hash               : BFD0CD63
     CRC32 hash (skip zero)   : 808668A5
     Statistics

--- a/web/data/Serie/120/metadata.json
+++ b/web/data/Serie/120/metadata.json
@@ -169,7 +169,7 @@
           "end" : 3528253
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/120/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/120/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/120/rip_log.txt
+++ b/web/data/Serie/120/rip_log.txt
@@ -49,7 +49,7 @@ AccurateRip Summary (DiscID: 001953a0-00db3ff7-a90dc80b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/120／Der schwarze Skorpion.m4a
+    Filename : 120／Der schwarze Skorpion.m4a
     CRC32 hash               : E46C4268
     CRC32 hash (skip zero)   : B8DE7525
     Statistics

--- a/web/data/Serie/121/metadata.json
+++ b/web/data/Serie/121/metadata.json
@@ -201,7 +201,7 @@
           "end" : 3762347
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/121/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/121/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/121/rip_log.txt
+++ b/web/data/Serie/121/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 0018b528-00fc8515-a30eb20d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? Nr. 121 - Spur Ins Nichts.m4a
+    Filename : Die drei ??? Nr. 121 - Spur Ins Nichts.m4a
     CRC32 hash               : 3EF1CA44
     CRC32 hash (skip zero)   : AE661BF2
     Statistics

--- a/web/data/Serie/122/metadata.json
+++ b/web/data/Serie/122/metadata.json
@@ -165,7 +165,7 @@
           "end" : 3494760
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/122/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/122/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/122/rip_log.txt
+++ b/web/data/Serie/122/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 0017d24e-00a8d0e6-750da609)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/122 - Und Der Geisterzug.m4a
+    Filename : 122 - Und Der Geisterzug.m4a
     CRC32 hash               : 28B41250
     CRC32 hash (skip zero)   : BEA36EE7
     Statistics

--- a/web/data/Serie/123/metadata.json
+++ b/web/data/Serie/123/metadata.json
@@ -169,7 +169,7 @@
           "end" : 3677213
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/123/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/123/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/123/rip_log.txt
+++ b/web/data/Serie/123/rip_log.txt
@@ -49,7 +49,7 @@ AccurateRip Summary (DiscID: 001a8e8c-00e25e1b-9f0e5d0b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/123／Fußballfieber.m4a
+    Filename : 123／Fußballfieber.m4a
     CRC32 hash               : 27607ED6
     CRC32 hash (skip zero)   : 74C2BDC8
     Statistics

--- a/web/data/Serie/124/metadata.json
+++ b/web/data/Serie/124/metadata.json
@@ -209,7 +209,7 @@
           "end" : 3990920
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/124/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/124/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/124/rip_log.txt
+++ b/web/data/Serie/124/rip_log.txt
@@ -57,7 +57,7 @@ AccurateRip Summary (DiscID: 00274a5b-01a4407c-d70f960f)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Folge 124 Geister-Canyon.m4a
+    Filename : Folge 124 Geister-Canyon.m4a
     CRC32 hash               : 31BB1497
     CRC32 hash (skip zero)   : 27C4CD4E
     Statistics

--- a/web/data/Serie/125/metadata.json
+++ b/web/data/Serie/125/metadata.json
@@ -186,7 +186,7 @@
           "end" : 4488347
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -261,7 +261,7 @@
           "end" : 4166213
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -346,7 +346,7 @@
           "end" : 4464547
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/125/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/125/rip_log3.txt"
     }
   ],
   "teile" : [

--- a/web/data/Serie/125/rip_log1.txt
+++ b/web/data/Serie/125/rip_log1.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 0023d296-013f1197-c811880c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/125／Feuermond.m4a
+    Filename : 125／Feuermond.m4a
     CRC32 hash               : C96D6DC1
     CRC32 hash (skip zero)   : 35FE1C40
     Statistics

--- a/web/data/Serie/125/rip_log2.txt
+++ b/web/data/Serie/125/rip_log2.txt
@@ -55,7 +55,7 @@ AccurateRip Summary (DiscID: 00216ccf-016321b4-c610460e)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/125 B.m4a
+    Filename : 125 B.m4a
     CRC32 hash               : 7A3AD461
     CRC32 hash (skip zero)   : 3652B35C
     Statistics

--- a/web/data/Serie/125/rip_log3.txt
+++ b/web/data/Serie/125/rip_log3.txt
@@ -59,7 +59,7 @@ AccurateRip Summary (DiscID: 002a0dbf-02049add-fa117010)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/125 C -Feuermond- Die Nacht der Schatten.m4a
+    Filename : 125 C -Feuermond- Die Nacht der Schatten.m4a
     CRC32 hash               : 749390FD
     CRC32 hash (skip zero)   : 745A8583
     Statistics

--- a/web/data/Serie/126/metadata.json
+++ b/web/data/Serie/126/metadata.json
@@ -177,7 +177,7 @@
           "end" : 3992933
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/126/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/126/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/126/rip_log.txt
+++ b/web/data/Serie/126/rip_log.txt
@@ -49,7 +49,7 @@ AccurateRip Summary (DiscID: 001c08ef-00edbd92-920f980b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/126 Schrecken aus dem Moor.m4a
+    Filename : 126 Schrecken aus dem Moor.m4a
     CRC32 hash               : DA6357C8
     CRC32 hash (skip zero)   : E202D68C
     Statistics

--- a/web/data/Serie/127/metadata.json
+++ b/web/data/Serie/127/metadata.json
@@ -199,7 +199,7 @@
           "end" : 4390653
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/127/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/127/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/127/rip_log.txt
+++ b/web/data/Serie/127/rip_log.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 001fff79-012c8754-aa11260c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/127 Schwarze Madonna.m4a
+    Filename : 127 Schwarze Madonna.m4a
     CRC32 hash               : AA18FEFF
     CRC32 hash (skip zero)   : BD02A05F
     Statistics

--- a/web/data/Serie/128/metadata.json
+++ b/web/data/Serie/128/metadata.json
@@ -187,7 +187,7 @@
           "end" : 4412907
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/128/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/128/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/128/rip_log.txt
+++ b/web/data/Serie/128/rip_log.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 00255ec9-014cbbf5-9b113c0c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/128／Schatten über Hollywood.m4a
+    Filename : 128／Schatten über Hollywood.m4a
     CRC32 hash               : 988326C0
     CRC32 hash (skip zero)   : 9513D794
     Statistics

--- a/web/data/Serie/129/metadata.json
+++ b/web/data/Serie/129/metadata.json
@@ -265,7 +265,7 @@
           "end" : 4734387
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/129/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/129/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/129/rip_log.txt
+++ b/web/data/Serie/129/rip_log.txt
@@ -61,7 +61,7 @@ AccurateRip Summary (DiscID: 0031b2b6-0269f05a-ea127e11)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/129 SMS aus dem Grab.m4a
+    Filename : 129 SMS aus dem Grab.m4a
     CRC32 hash               : E9F3618D
     CRC32 hash (skip zero)   : D504F130
     Statistics

--- a/web/data/Serie/130/metadata.json
+++ b/web/data/Serie/130/metadata.json
@@ -240,7 +240,7 @@
           "end" : 4112560
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/130/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/130/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/130/rip_log.txt
+++ b/web/data/Serie/130/rip_log.txt
@@ -59,7 +59,7 @@ AccurateRip Summary (DiscID: 002b90a0-01e85616-ee101010)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/130 Der Fluch Des Drachen.m4a
+    Filename : 130 Der Fluch Des Drachen.m4a
     CRC32 hash               : DF633859
     CRC32 hash (skip zero)   : 0291AD14
     Statistics

--- a/web/data/Serie/131/metadata.json
+++ b/web/data/Serie/131/metadata.json
@@ -165,7 +165,7 @@
           "end" : 4242960
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/131/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/131/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/131/rip_log.txt
+++ b/web/data/Serie/131/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 001aab3f-00c10624-8b109209)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/131 - Haus des Schreckens.m4a
+    Filename : 131 - Haus des Schreckens.m4a
     CRC32 hash               : E2A69B5C
     CRC32 hash (skip zero)   : 49E8C4B2
     Statistics

--- a/web/data/Serie/132/metadata.json
+++ b/web/data/Serie/132/metadata.json
@@ -177,7 +177,7 @@
           "end" : 3799387
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/132/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/132/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/132/rip_log.txt
+++ b/web/data/Serie/132/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 00128ed6-008bcd32-7f0ed709)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/132 Spuk im Netz.m4a
+    Filename : 132 Spuk im Netz.m4a
     CRC32 hash               : DF352BDA
     CRC32 hash (skip zero)   : B699ACE4
     Statistics

--- a/web/data/Serie/133/metadata.json
+++ b/web/data/Serie/133/metadata.json
@@ -165,7 +165,7 @@
           "end" : 3473893
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/133/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/133/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/133/rip_log.txt
+++ b/web/data/Serie/133/rip_log.txt
@@ -46,7 +46,7 @@ AccurateRip Summary (DiscID: 000f564b-007440f5-730d9109)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/133 - Fels der Dämonen.m4a
+    Filename : 133 - Fels der Dämonen.m4a
     CRC32 hash               : 490A89B3
     CRC32 hash (skip zero)   : F4E935F6
     Statistics

--- a/web/data/Serie/134/metadata.json
+++ b/web/data/Serie/134/metadata.json
@@ -197,7 +197,7 @@
           "end" : 4029587
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/134/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/134/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/134/rip_log.txt
+++ b/web/data/Serie/134/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 00207b55-013e118b-b50fbd0d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/134／ der tote Mönch.m4a
+    Filename : 134／ der tote Mönch.m4a
     CRC32 hash               : 7862EB28
     CRC32 hash (skip zero)   : 2C87F5DC
     Statistics

--- a/web/data/Serie/135/metadata.json
+++ b/web/data/Serie/135/metadata.json
@@ -233,7 +233,7 @@
           "end" : 4271013
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/135/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/135/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/135/rip_log.txt
+++ b/web/data/Serie/135/rip_log.txt
@@ -61,7 +61,7 @@ AccurateRip Summary (DiscID: 0029dea1-0213f0c1-d310af11)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/135／Fluch des Piraten.m4a
+    Filename : 135／Fluch des Piraten.m4a
     CRC32 hash               : 6008C6B6
     CRC32 hash (skip zero)   : 83ABB9A0
     Statistics

--- a/web/data/Serie/136/metadata.json
+++ b/web/data/Serie/136/metadata.json
@@ -209,7 +209,7 @@
           "end" : 4117027
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/136/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/136/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/136/rip_log.txt
+++ b/web/data/Serie/136/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 00202b2b-0145b5af-aa10150d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/136 - und das versunkene Dorf.m4a
+    Filename : 136 - und das versunkene Dorf.m4a
     CRC32 hash               : 2B10AFF5
     CRC32 hash (skip zero)   : 2CBB0595
     Statistics

--- a/web/data/Serie/137/metadata.json
+++ b/web/data/Serie/137/metadata.json
@@ -193,7 +193,7 @@
           "end" : 4653507
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/137/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/137/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/137/rip_log.txt
+++ b/web/data/Serie/137/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 00266ce7-0179e702-bc122d0d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/137 Pfad der Angst.m4a
+    Filename : 137 Pfad der Angst.m4a
     CRC32 hash               : 802FD85D
     CRC32 hash (skip zero)   : 2276287E
     Statistics

--- a/web/data/Serie/138/metadata.json
+++ b/web/data/Serie/138/metadata.json
@@ -185,7 +185,7 @@
           "end" : 3987133
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/138/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/138/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/138/rip_log.txt
+++ b/web/data/Serie/138/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 001c053c-011cdf4c-a00f930d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/138 - Die Geheime Treppe.m4a
+    Filename : 138 - Die Geheime Treppe.m4a
     CRC32 hash               : 258A0F11
     CRC32 hash (skip zero)   : EBC36BDB
     Statistics

--- a/web/data/Serie/139/metadata.json
+++ b/web/data/Serie/139/metadata.json
@@ -216,7 +216,7 @@
           "end" : 3860747
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/139/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/139/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/139/rip_log.txt
+++ b/web/data/Serie/139/rip_log.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 001afe50-01013b39-a10f140c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/139／Das Geheimnis der Diva.m4a
+    Filename : 139／Das Geheimnis der Diva.m4a
     CRC32 hash               : FD2171C8
     CRC32 hash (skip zero)   : A6D533DD
     Statistics

--- a/web/data/Serie/140/metadata.json
+++ b/web/data/Serie/140/metadata.json
@@ -185,7 +185,7 @@
           "end" : 4658533
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/140/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/140/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/140/rip_log.txt
+++ b/web/data/Serie/140/rip_log.txt
@@ -50,7 +50,7 @@ AccurateRip Summary (DiscID: 001e41c8-0106b0ab-a112320b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Folge 140： Stadt Der Vampire.m4a
+    Filename : Folge 140： Stadt Der Vampire.m4a
     CRC32 hash               : 2C5807F5
     CRC32 hash (skip zero)   : 4A31291F
     Statistics

--- a/web/data/Serie/141/metadata.json
+++ b/web/data/Serie/141/metadata.json
@@ -218,7 +218,7 @@
           "end" : 3562347
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/141/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/141/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/141/rip_log.txt
+++ b/web/data/Serie/141/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 001c3275-010f4e1f-ad0dea0d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/141／...und die Fußball-Falle.m4a
+    Filename : 141／...und die Fußball-Falle.m4a
     CRC32 hash               : DB0FA2DA
     CRC32 hash (skip zero)   : 7906E162
     Statistics

--- a/web/data/Serie/142/metadata.json
+++ b/web/data/Serie/142/metadata.json
@@ -225,7 +225,7 @@
           "end" : 3437227
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/142/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/142/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/142/rip_log.txt
+++ b/web/data/Serie/142/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 001aed65-01097f31-a80d6d0d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/142／Tödliches Eis.m4a
+    Filename : 142／Tödliches Eis.m4a
     CRC32 hash               : E001189C
     CRC32 hash (skip zero)   : 3CC232D8
     Statistics

--- a/web/data/Serie/143/metadata.json
+++ b/web/data/Serie/143/metadata.json
@@ -181,7 +181,7 @@
           "end" : 3621920
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/143/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/143/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/143/rip_log.txt
+++ b/web/data/Serie/143/rip_log.txt
@@ -49,7 +49,7 @@ AccurateRip Summary (DiscID: 00183968-00d2b173-a50e250b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/143／...und die Poker-Hölle.m4a
+    Filename : 143／...und die Poker-Hölle.m4a
     CRC32 hash               : E7917061
     CRC32 hash (skip zero)   : A27A4A0C
     Statistics

--- a/web/data/Serie/144/metadata.json
+++ b/web/data/Serie/144/metadata.json
@@ -202,7 +202,7 @@
           "end" : 4256000
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/144/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/144/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/144/rip_log.txt
+++ b/web/data/Serie/144/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 001ef823-01350db8-9910a00d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 144 - Zwillinge der Finsternis.m4a
+    Filename : Die Drei ??? - Folge 144 - Zwillinge der Finsternis.m4a
     CRC32 hash               : B29CE4D7
     CRC32 hash (skip zero)   : 6FAA501B
     Statistics

--- a/web/data/Serie/145/metadata.json
+++ b/web/data/Serie/145/metadata.json
@@ -191,7 +191,7 @@
           "end" : 3722547
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/145/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/145/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/145/rip_log.txt
+++ b/web/data/Serie/145/rip_log.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 0016987b-00da38ac-9c0e8a0c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/145 - und die Rache der Samurai.m4a
+    Filename : 145 - und die Rache der Samurai.m4a
     CRC32 hash               : 6C23B4EA
     CRC32 hash (skip zero)   : 5C33EA15
     Statistics

--- a/web/data/Serie/146/metadata.json
+++ b/web/data/Serie/146/metadata.json
@@ -256,7 +256,7 @@
           "end" : 3430360
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/146/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/146/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/146/rip_log.txt
+++ b/web/data/Serie/146/rip_log.txt
@@ -59,7 +59,7 @@ AccurateRip Summary (DiscID: 00230fe4-019464d3-e10d6610)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/146 - Der Biss der Bestie.m4a
+    Filename : 146 - Der Biss der Bestie.m4a
     CRC32 hash               : 7E8758A3
     CRC32 hash (skip zero)   : BE5F866A
     Statistics

--- a/web/data/Serie/147/metadata.json
+++ b/web/data/Serie/147/metadata.json
@@ -177,7 +177,7 @@
           "end" : 3770533
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/147/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/147/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/147/rip_log.txt
+++ b/web/data/Serie/147/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 0015e665-009bad5d-7c0eba09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/147 - Grusel auf Campbell Castle.m4a
+    Filename : 147 - Grusel auf Campbell Castle.m4a
     CRC32 hash               : E90DE855
     CRC32 hash (skip zero)   : 964E7EB2
     Statistics

--- a/web/data/Serie/148/metadata.json
+++ b/web/data/Serie/148/metadata.json
@@ -161,7 +161,7 @@
           "end" : 4011933
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/148/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/148/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/148/rip_log.txt
+++ b/web/data/Serie/148/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 001a00dd-00b6e37f-8b0fab09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/148 - Und die feurige Flut.m4a
+    Filename : 148 - Und die feurige Flut.m4a
     CRC32 hash               : 62966CDF
     CRC32 hash (skip zero)   : E451E816
     Statistics

--- a/web/data/Serie/149/metadata.json
+++ b/web/data/Serie/149/metadata.json
@@ -227,7 +227,7 @@
           "end" : 3717773
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/149/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/149/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/149/rip_log.txt
+++ b/web/data/Serie/149/rip_log.txt
@@ -55,7 +55,7 @@ AccurateRip Summary (DiscID: 00219407-01636b6e-da0e850e)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/149 - Der namenlose Gegner.m4a
+    Filename : 149 - Der namenlose Gegner.m4a
     CRC32 hash               : 10C030AB
     CRC32 hash (skip zero)   : 164B0815
     Statistics

--- a/web/data/Serie/150/metadata.json
+++ b/web/data/Serie/150/metadata.json
@@ -222,7 +222,7 @@
           "end" : 4055093
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -307,7 +307,7 @@
           "end" : 4100240
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -367,7 +367,7 @@
           "end" : 3763400
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/150/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/150/rip_log3.txt"
     }
   ],
   "teile" : [

--- a/web/data/Serie/150/rip_log1.txt
+++ b/web/data/Serie/150/rip_log1.txt
@@ -50,7 +50,7 @@ AccurateRip Summary (DiscID: 00250ae4-017d6343-dc0fd70e)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/150／Geisterbucht - Disc A： Rashuras Schatz.m4a
+    Filename : 150／Geisterbucht - Disc A： Rashuras Schatz.m4a
     CRC32 hash               : A2B4237C
     CRC32 hash (skip zero)   : 8E4C241D
     Statistics

--- a/web/data/Serie/150/rip_log2.txt
+++ b/web/data/Serie/150/rip_log2.txt
@@ -54,7 +54,7 @@ AccurateRip Summary (DiscID: 0027ffa5-01e32271-d4100410)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/150／Geisterbucht.m4a
+    Filename : 150／Geisterbucht.m4a
     CRC32 hash               : 15E41DFF
     CRC32 hash (skip zero)   : 9ECCB016
     Statistics

--- a/web/data/Serie/150/rip_log3.txt
+++ b/web/data/Serie/150/rip_log3.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 0018d971-00d91923-940eb30b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Folge 150： Geisterbucht [Disc 3].m4a
+    Filename : Folge 150： Geisterbucht [Disc 3].m4a
     CRC32 hash               : C66470AB
     CRC32 hash (skip zero)   : A2847870
     Statistics

--- a/web/data/Serie/151/metadata.json
+++ b/web/data/Serie/151/metadata.json
@@ -263,7 +263,7 @@
           "end" : 3943307
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/151/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/151/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/151/rip_log.txt
+++ b/web/data/Serie/151/rip_log.txt
@@ -59,7 +59,7 @@ AccurateRip Summary (DiscID: 00242ee6-01b9191b-e70f6710)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/151／ Schwarze Sonne.m4a
+    Filename : 151／ Schwarze Sonne.m4a
     CRC32 hash               : 75D50769
     CRC32 hash (skip zero)   : 882FAFB9
     Statistics

--- a/web/data/Serie/152/metadata.json
+++ b/web/data/Serie/152/metadata.json
@@ -219,7 +219,7 @@
           "end" : 3374867
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/152/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/152/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/152/rip_log.txt
+++ b/web/data/Serie/152/rip_log.txt
@@ -46,7 +46,7 @@ AccurateRip Summary (DiscID: 001b370a-00f71295-a50d2e0c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/152／Skateboardfieber.m4a
+    Filename : 152／Skateboardfieber.m4a
     CRC32 hash               : D0FD2E0B
     CRC32 hash (skip zero)   : FE4B9C65
     Statistics

--- a/web/data/Serie/153/metadata.json
+++ b/web/data/Serie/153/metadata.json
@@ -205,7 +205,7 @@
           "end" : 3243960
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/153/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/153/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/153/rip_log.txt
+++ b/web/data/Serie/153/rip_log.txt
@@ -49,7 +49,7 @@ AccurateRip Summary (DiscID: 00160fd0-00bbff3e-9b0cab0b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/153／und das Fußballphantom.m4a
+    Filename : 153／und das Fußballphantom.m4a
     CRC32 hash               : 218D3E06
     CRC32 hash (skip zero)   : E44D1609
     Statistics

--- a/web/data/Serie/154/metadata.json
+++ b/web/data/Serie/154/metadata.json
@@ -242,7 +242,7 @@
           "end" : 4238587
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/154/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/154/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/154/rip_log.txt
+++ b/web/data/Serie/154/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 00209b2b-013ed80b-d8108e0d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/154／Botschaft aus der Unterwelt.m4a
+    Filename : 154／Botschaft aus der Unterwelt.m4a
     CRC32 hash               : 73E4DD58
     CRC32 hash (skip zero)   : 721888B3
     Statistics

--- a/web/data/Serie/155/metadata.json
+++ b/web/data/Serie/155/metadata.json
@@ -239,7 +239,7 @@
           "end" : 4055280
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/155/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/155/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/155/rip_log.txt
+++ b/web/data/Serie/155/rip_log.txt
@@ -59,7 +59,7 @@ AccurateRip Summary (DiscID: 0028d6fe-01d63df8-e20fd710)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/155／und der Meister des Todes.m4a
+    Filename : 155／und der Meister des Todes.m4a
     CRC32 hash               : 22D94962
     CRC32 hash (skip zero)   : A18BD28D
     Statistics

--- a/web/data/Serie/156/metadata.json
+++ b/web/data/Serie/156/metadata.json
@@ -229,7 +229,7 @@
           "end" : 4331240
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/156/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/156/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/156/rip_log.txt
+++ b/web/data/Serie/156/rip_log.txt
@@ -57,7 +57,7 @@ AccurateRip Summary (DiscID: 00287b71-01cf738c-e910eb0f)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/156／Im Netz des Drachen.m4a
+    Filename : 156／Im Netz des Drachen.m4a
     CRC32 hash               : 9C5C73E8
     CRC32 hash (skip zero)   : 0553CE2A
     Statistics

--- a/web/data/Serie/157/metadata.json
+++ b/web/data/Serie/157/metadata.json
@@ -200,7 +200,7 @@
           "end" : 4461093
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/157/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/157/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/157/rip_log.txt
+++ b/web/data/Serie/157/rip_log.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 0020e4b0-013141d2-a3116d0c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/157／Im Zeichen der Schlangen.m4a
+    Filename : 157／Im Zeichen der Schlangen.m4a
     CRC32 hash               : 9413A9DB
     CRC32 hash (skip zero)   : 5FDE10AE
     Statistics

--- a/web/data/Serie/158/metadata.json
+++ b/web/data/Serie/158/metadata.json
@@ -221,7 +221,7 @@
           "end" : 3396520
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/158/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/158/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/158/rip_log.txt
+++ b/web/data/Serie/158/rip_log.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 0019384d-00fe4952-b80d440d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/158 - Und der Feuergeist.m4a
+    Filename : 158 - Und der Feuergeist.m4a
     CRC32 hash               : B8B9CB02
     CRC32 hash (skip zero)   : 32931363
     Statistics

--- a/web/data/Serie/159/metadata.json
+++ b/web/data/Serie/159/metadata.json
@@ -182,7 +182,7 @@
           "end" : 3931427
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/159/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/159/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/159/rip_log.txt
+++ b/web/data/Serie/159/rip_log.txt
@@ -49,7 +49,7 @@ AccurateRip Summary (DiscID: 001c82ae-00f0cf9c-9c0f5b0b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 159 - Nacht der Tiger .m4a
+    Filename : Die Drei ??? - Folge 159 - Nacht der Tiger .m4a
     CRC32 hash               : F5B6D40A
     CRC32 hash (skip zero)   : 53843F53
     Statistics

--- a/web/data/Serie/160/metadata.json
+++ b/web/data/Serie/160/metadata.json
@@ -173,7 +173,7 @@
           "end" : 3820387
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/160/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/160/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/160/rip_log.txt
+++ b/web/data/Serie/160/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 0012a383-008d8bec-690eec09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/160／Geheimnisvolle Botschaften.m4a
+    Filename : 160／Geheimnisvolle Botschaften.m4a
     CRC32 hash               : AE960EF0
     CRC32 hash (skip zero)   : 3E1844E6
     Statistics

--- a/web/data/Serie/161/metadata.json
+++ b/web/data/Serie/161/metadata.json
@@ -219,7 +219,7 @@
           "end" : 4238493
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/161/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/161/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/161/rip_log.txt
+++ b/web/data/Serie/161/rip_log.txt
@@ -50,7 +50,7 @@ AccurateRip Summary (DiscID: 002427b2-017b13dc-e6108e0e)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 161 - Die blutenden Bilder.m4a
+    Filename : Die Drei ??? - Folge 161 - Die blutenden Bilder.m4a
     CRC32 hash               : 480521CB
     CRC32 hash (skip zero)   : 172D2C36
     Statistics

--- a/web/data/Serie/162/metadata.json
+++ b/web/data/Serie/162/metadata.json
@@ -185,7 +185,7 @@
           "end" : 4365707
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/162/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/162/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/162/rip_log.txt
+++ b/web/data/Serie/162/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 001b36f3-00ed320b-a2110d0b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 162 - ?und der schreiende Nebel.m4a
+    Filename : Die Drei ??? - Folge 162 - ?und der schreiende Nebel.m4a
     CRC32 hash               : ED105449
     CRC32 hash (skip zero)   : 77171DC3
     Statistics

--- a/web/data/Serie/163/metadata.json
+++ b/web/data/Serie/163/metadata.json
@@ -157,7 +157,7 @@
           "end" : 4468413
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/163/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/163/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/163/rip_log.txt
+++ b/web/data/Serie/163/rip_log.txt
@@ -49,7 +49,7 @@ AccurateRip Summary (DiscID: 001dcd21-010179a4-9011740b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 163 - und der verschollene Pilot.m4a
+    Filename : Die Drei ??? - Folge 163 - und der verschollene Pilot.m4a
     CRC32 hash               : 72E52361
     CRC32 hash (skip zero)   : 821AA601
     Statistics

--- a/web/data/Serie/164/metadata.json
+++ b/web/data/Serie/164/metadata.json
@@ -181,7 +181,7 @@
           "end" : 4125760
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/164/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/164/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/164/rip_log.txt
+++ b/web/data/Serie/164/rip_log.txt
@@ -47,7 +47,7 @@ AccurateRip Summary (DiscID: 001762ea-00bdac46-7c101d0a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 164 - Fußball-Teufel.m4a
+    Filename : Die Drei ??? - Folge 164 - Fußball-Teufel.m4a
     CRC32 hash               : 52D738B5
     CRC32 hash (skip zero)   : 36EC35CF
     Statistics

--- a/web/data/Serie/165/metadata.json
+++ b/web/data/Serie/165/metadata.json
@@ -193,7 +193,7 @@
           "end" : 4217360
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/165/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/165/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/165/rip_log.txt
+++ b/web/data/Serie/165/rip_log.txt
@@ -49,7 +49,7 @@ AccurateRip Summary (DiscID: 00192060-00e14143-a010790b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/165／Im Schatten des Giganten.m4a
+    Filename : 165／Im Schatten des Giganten.m4a
     CRC32 hash               : 4C829B92
     CRC32 hash (skip zero)   : 3C8903E7
     Statistics

--- a/web/data/Serie/166/metadata.json
+++ b/web/data/Serie/166/metadata.json
@@ -149,7 +149,7 @@
           "end" : 4063013
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/166/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/166/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/166/rip_log.txt
+++ b/web/data/Serie/166/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 0017fdd9-00addd31-790fdf09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 166 - und die brennende Stadt .m4a
+    Filename : Die Drei ??? - Folge 166 - und die brennende Stadt .m4a
     CRC32 hash               : 6E211875
     CRC32 hash (skip zero)   : 2EE9E5C2
     Statistics

--- a/web/data/Serie/167/metadata.json
+++ b/web/data/Serie/167/metadata.json
@@ -250,7 +250,7 @@
           "end" : 4324213
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/167/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/167/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/167/rip_log.txt
+++ b/web/data/Serie/167/rip_log.txt
@@ -52,7 +52,7 @@ AccurateRip Summary (DiscID: 002407bf-019f8fb5-d310e40f)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/167／und das blaue Biest.m4a
+    Filename : 167／und das blaue Biest.m4a
     CRC32 hash               : A7AAD82A
     CRC32 hash (skip zero)   : A19384BE
     Statistics

--- a/web/data/Serie/168/metadata.json
+++ b/web/data/Serie/168/metadata.json
@@ -199,7 +199,7 @@
           "end" : 4675973
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/168/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/168/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/168/rip_log.txt
+++ b/web/data/Serie/168/rip_log.txt
@@ -42,7 +42,7 @@ AccurateRip Summary (DiscID: 001fd63d-00fa38e1-9b12430a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 168 - GPS-Gangster.m4a
+    Filename : Die Drei ??? - Folge 168 - GPS-Gangster.m4a
     CRC32 hash               : 8EDDBA87
     CRC32 hash (skip zero)   : 50211B7B
     Statistics

--- a/web/data/Serie/169/metadata.json
+++ b/web/data/Serie/169/metadata.json
@@ -188,7 +188,7 @@
           "end" : 4910587
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/169/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/169/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/169/rip_log.txt
+++ b/web/data/Serie/169/rip_log.txt
@@ -42,7 +42,7 @@ AccurateRip Summary (DiscID: 001b528b-00dde395-a0132e0a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 169 - Die Spur des Spielers.m4a
+    Filename : Die Drei ??? - Folge 169 - Die Spur des Spielers.m4a
     CRC32 hash               : 9A6F54C5
     CRC32 hash (skip zero)   : 821A68E3
     Statistics

--- a/web/data/Serie/170/metadata.json
+++ b/web/data/Serie/170/metadata.json
@@ -213,7 +213,7 @@
           "end" : 4816533
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/170/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/170/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/170/rip_log.txt
+++ b/web/data/Serie/170/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 00217269-0121e809-be12d00b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 170 - Straße des Grauens.m4a
+    Filename : Die Drei ??? - Folge 170 - Straße des Grauens.m4a
     CRC32 hash               : D3728A8E
     CRC32 hash (skip zero)   : C05F20FC
     Statistics

--- a/web/data/Serie/171/metadata.json
+++ b/web/data/Serie/171/metadata.json
@@ -207,7 +207,7 @@
           "end" : 4040853
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/171/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/171/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/171/rip_log.txt
+++ b/web/data/Serie/171/rip_log.txt
@@ -42,7 +42,7 @@ AccurateRip Summary (DiscID: 001a009e-00ce231b-8a0fc80a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 171 - und das Phantom aus dem Meer.m4a
+    Filename : Die Drei ??? - Folge 171 - und das Phantom aus dem Meer.m4a
     CRC32 hash               : CC846D73
     CRC32 hash (skip zero)   : 225BB93E
     Statistics

--- a/web/data/Serie/172/metadata.json
+++ b/web/data/Serie/172/metadata.json
@@ -189,7 +189,7 @@
           "end" : 4375213
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/172/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/172/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/172/rip_log.txt
+++ b/web/data/Serie/172/rip_log.txt
@@ -44,7 +44,7 @@ AccurateRip Summary (DiscID: 001e5cd0-0103f0c1-b911170b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 172 - und der Eisenmann.m4a
+    Filename : Die Drei ??? - Folge 172 - und der Eisenmann.m4a
     CRC32 hash               : 88677C1E
     CRC32 hash (skip zero)   : 8BFCCED0
     Statistics

--- a/web/data/Serie/173/metadata.json
+++ b/web/data/Serie/173/metadata.json
@@ -175,7 +175,7 @@
           "end" : 4225213
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/173/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/173/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/173/rip_log.txt
+++ b/web/data/Serie/173/rip_log.txt
@@ -42,7 +42,7 @@ AccurateRip Summary (DiscID: 001a7627-00d4e687-8210810a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : /Shared/Audiobooks/_temp/Die Drei ??? - Folge 173 - Dämon der Rache.m4a
+    Filename : Die Drei ??? - Folge 173 - Dämon der Rache.m4a
     CRC32 hash               : A5F49A44
     CRC32 hash (skip zero)   : 8BE9ED8D
     Statistics

--- a/web/data/Serie/174/metadata.json
+++ b/web/data/Serie/174/metadata.json
@@ -161,7 +161,7 @@
           "end" : 3800827
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/174/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/174/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/174/rip_log.txt
+++ b/web/data/Serie/174/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 0016062a-00a0e989-8c0ed809)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/174／und das Tuch der Toten.m4a
+    Filename : 174／und das Tuch der Toten.m4a
     CRC32 hash               : CFAF2EB4
     CRC32 hash (skip zero)   : F772070E
     Statistics

--- a/web/data/Serie/175/metadata.json
+++ b/web/data/Serie/175/metadata.json
@@ -214,7 +214,7 @@
           "end" : 3648933
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -264,7 +264,7 @@
           "end" : 3434200
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -309,7 +309,7 @@
           "end" : 4166493
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/175/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/175/rip_log3.txt"
     }
   ],
   "teile" : [

--- a/web/data/Serie/175/rip_log1.txt
+++ b/web/data/Serie/175/rip_log1.txt
@@ -46,7 +46,7 @@ AccurateRip Summary (DiscID: 001beb18-0103a083-ab0e400c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/175／Schattenwelt.m4a
+    Filename : 175／Schattenwelt.m4a
     CRC32 hash               : D45C290E
     CRC32 hash (skip zero)   : FE66687E
     Statistics

--- a/web/data/Serie/175/rip_log2.txt
+++ b/web/data/Serie/175/rip_log2.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 0010ad3b-007d0912-6e0d6a09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/175／Schattenwelt.m4a
+    Filename : 175／Schattenwelt.m4a
     CRC32 hash               : 0CFF0D6F
     CRC32 hash (skip zero)   : 187BE1CE
     Statistics

--- a/web/data/Serie/175/rip_log3.txt
+++ b/web/data/Serie/175/rip_log3.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0013482a-00849dfe-83104608)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/175／Schattenwelt.m4a
+    Filename : 175／Schattenwelt.m4a
     CRC32 hash               : 5CFA0CE6
     CRC32 hash (skip zero)   : AEB2863E
     Statistics

--- a/web/data/Serie/176/metadata.json
+++ b/web/data/Serie/176/metadata.json
@@ -195,7 +195,7 @@
           "end" : 4064107
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/176/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/176/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/176/rip_log.txt
+++ b/web/data/Serie/176/rip_log.txt
@@ -46,7 +46,7 @@ AccurateRip Summary (DiscID: 001b9f33-010d9504-a50fe00c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/176／und der gestohlene Sieg.m4a
+    Filename : 176／und der gestohlene Sieg.m4a
     CRC32 hash               : 889EB654
     CRC32 hash (skip zero)   : 2E625153
     Statistics

--- a/web/data/Serie/177/metadata.json
+++ b/web/data/Serie/177/metadata.json
@@ -165,7 +165,7 @@
           "end" : 4121080
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/177/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/177/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/177/rip_log.txt
+++ b/web/data/Serie/177/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 0018eacd-00b60f05-62101909)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/177／Der Geist des Goldgräbers.m4a
+    Filename : 177／Der Geist des Goldgräbers.m4a
     CRC32 hash               : 96BC4334
     CRC32 hash (skip zero)   : C8AB1F7B
     Statistics

--- a/web/data/Serie/178/metadata.json
+++ b/web/data/Serie/178/metadata.json
@@ -157,7 +157,7 @@
           "end" : 3955933
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/178/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/178/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/178/rip_log.txt
+++ b/web/data/Serie/178/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 00149e93-009b33f8-900f7309)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/178／Der gefiederte Schrecken.m4a
+    Filename : 178／Der gefiederte Schrecken.m4a
     CRC32 hash               : 9FF2AC9A
     CRC32 hash (skip zero)   : 6F330748
     Statistics

--- a/web/data/Serie/179/metadata.json
+++ b/web/data/Serie/179/metadata.json
@@ -167,7 +167,7 @@
           "end" : 4297960
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/179/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/179/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/179/rip_log.txt
+++ b/web/data/Serie/179/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 001529c2-008d3ccb-7a10c908)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/179／Die Rache des Untoten.m4a
+    Filename : 179／Die Rache des Untoten.m4a
     CRC32 hash               : 8C831E32
     CRC32 hash (skip zero)   : 3E08AB90
     Statistics

--- a/web/data/Serie/180/metadata.json
+++ b/web/data/Serie/180/metadata.json
@@ -155,7 +155,7 @@
           "end" : 4667840
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/180/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/180/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/180/rip_log.txt
+++ b/web/data/Serie/180/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 001493a5-008c5c4b-7a123b08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Und Die Flüsternden Puppen, Folge 180.m4a
+    Filename : Und Die Flüsternden Puppen, Folge 180.m4a
     CRC32 hash               : 51B056AD
     CRC32 hash (skip zero)   : 60EB9E6D
     Statistics

--- a/web/data/Serie/181/metadata.json
+++ b/web/data/Serie/181/metadata.json
@@ -171,7 +171,7 @@
           "end" : 4413560
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/181/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/181/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/181/rip_log.txt
+++ b/web/data/Serie/181/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0013df90-008614fc-66113d08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Das Kabinett des Zauberers.m4a
+    Filename : Das Kabinett des Zauberers.m4a
     CRC32 hash               : 08611730
     CRC32 hash (skip zero)   : AFC52F8D
     Statistics

--- a/web/data/Serie/182/metadata.json
+++ b/web/data/Serie/182/metadata.json
@@ -185,7 +185,7 @@
           "end" : 4546493
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/182/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/182/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/182/rip_log.txt
+++ b/web/data/Serie/182/rip_log.txt
@@ -36,7 +36,7 @@ AccurateRip Summary (DiscID: 0013f57b-007b1b54-5a11c207)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 182 - Im Haus des Henkers.m4a
+    Filename : Die Drei ??? - Folge 182 - Im Haus des Henkers.m4a
     CRC32 hash               : 089FD958
     CRC32 hash (skip zero)   : CCA570DC
     Statistics

--- a/web/data/Serie/183/metadata.json
+++ b/web/data/Serie/183/metadata.json
@@ -179,7 +179,7 @@
           "end" : 4566333
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/183/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/183/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/183/rip_log.txt
+++ b/web/data/Serie/183/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 001580a4-00906f5d-6811d608)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/183 - und der letzte Song.m4a
+    Filename : 183 - und der letzte Song.m4a
     CRC32 hash               : 86DDAE2A
     CRC32 hash (skip zero)   : A5FE6584
     Statistics

--- a/web/data/Serie/184/metadata.json
+++ b/web/data/Serie/184/metadata.json
@@ -155,7 +155,7 @@
           "end" : 4139387
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/184/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/184/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/184/rip_log.txt
+++ b/web/data/Serie/184/rip_log.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 000ff0d8-0055ec47-59102b06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/184 und der Hexengarten.m4a
+    Filename : 184 und der Hexengarten.m4a
     CRC32 hash               : FF110980
     CRC32 hash (skip zero)   : 50878866
     Statistics

--- a/web/data/Serie/185/metadata.json
+++ b/web/data/Serie/185/metadata.json
@@ -177,7 +177,7 @@
           "end" : 3685613
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/185/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/185/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/185/rip_log.txt
+++ b/web/data/Serie/185/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 0013d801-0094973f-6a0e6509)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/185 und der Mann ohne Augen.m4a
+    Filename : 185 und der Mann ohne Augen.m4a
     CRC32 hash               : 951929CF
     CRC32 hash (skip zero)   : 1EFDADD2
     Statistics

--- a/web/data/Serie/186/metadata.json
+++ b/web/data/Serie/186/metadata.json
@@ -167,7 +167,7 @@
           "end" : 4356747
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/186/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/186/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/186/rip_log.txt
+++ b/web/data/Serie/186/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0015accb-00938fbb-73110408)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/186 - Insel Des Vergessens.m4a
+    Filename : 186 - Insel Des Vergessens.m4a
     CRC32 hash               : 88EF1287
     CRC32 hash (skip zero)   : 3288BF05
     Statistics

--- a/web/data/Serie/187/metadata.json
+++ b/web/data/Serie/187/metadata.json
@@ -180,7 +180,7 @@
           "end" : 4036133
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/187/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/187/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/187/rip_log.txt
+++ b/web/data/Serie/187/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 00153eeb-00a1063b-7e0fc409)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/187 und das silberne Amulett.m4a
+    Filename : 187 und das silberne Amulett.m4a
     CRC32 hash               : 8A7939F9
     CRC32 hash (skip zero)   : 45589128
     Statistics

--- a/web/data/Serie/188/metadata.json
+++ b/web/data/Serie/188/metadata.json
@@ -186,7 +186,7 @@
           "end" : 4807547
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/188/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/188/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/188/rip_log.txt
+++ b/web/data/Serie/188/rip_log.txt
@@ -42,7 +42,7 @@ AccurateRip Summary (DiscID: 001b5d11-00db0bc6-9d12c70a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/188 Signale aus dem Jenseits.m4a
+    Filename : 188 Signale aus dem Jenseits.m4a
     CRC32 hash               : 88F37C38
     CRC32 hash (skip zero)   : 5B74F521
     Statistics

--- a/web/data/Serie/189/metadata.json
+++ b/web/data/Serie/189/metadata.json
@@ -162,7 +162,7 @@
           "end" : 3917560
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/189/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/189/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/189/rip_log.txt
+++ b/web/data/Serie/189/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0016915d-00930596-660f4d08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/und der unsichtbare Passagier (189).m4a
+    Filename : und der unsichtbare Passagier (189).m4a
     CRC32 hash               : 2E3FD3AE
     CRC32 hash (skip zero)   : 3D63A574
     Statistics

--- a/web/data/Serie/190/metadata.json
+++ b/web/data/Serie/190/metadata.json
@@ -130,7 +130,7 @@
           "end" : 3834400
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/190/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/190/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/190/rip_log.txt
+++ b/web/data/Serie/190/rip_log.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 000dd095-004ae3d5-540efa06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/190 Die Kammer der Rätsel.m4a
+    Filename : 190 Die Kammer der Rätsel.m4a
     CRC32 hash               : 4124AE6D
     CRC32 hash (skip zero)   : 8133B645
     Statistics

--- a/web/data/Serie/191/metadata.json
+++ b/web/data/Serie/191/metadata.json
@@ -146,7 +146,7 @@
           "end" : 4266120
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/191/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/191/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/191/rip_log.txt
+++ b/web/data/Serie/191/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0016798a-0094ea7f-7010aa08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/191 - Verbrechen Im Nichts.m4a
+    Filename : 191 - Verbrechen Im Nichts.m4a
     CRC32 hash               : 703F602C
     CRC32 hash (skip zero)   : B5219212
     Statistics

--- a/web/data/Serie/192/metadata.json
+++ b/web/data/Serie/192/metadata.json
@@ -158,7 +158,7 @@
           "end" : 4081427
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/192/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/192/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/192/rip_log.txt
+++ b/web/data/Serie/192/rip_log.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 001575d5-008f90de-550ff108)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/192 - Im Bann des Drachen.m4a
+    Filename : 192 - Im Bann des Drachen.m4a
     CRC32 hash               : 80654DB3
     CRC32 hash (skip zero)   : 15ECF178
     Statistics

--- a/web/data/Serie/193/metadata.json
+++ b/web/data/Serie/193/metadata.json
@@ -178,7 +178,7 @@
           "end" : 4183227
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/193/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/193/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/193/rip_log.txt
+++ b/web/data/Serie/193/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 0013b31f-00848c91-77105708)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Folge 193： Schrecken aus der Tiefe.m4a
+    Filename : Folge 193： Schrecken aus der Tiefe.m4a
     CRC32 hash               : 027A063B
     CRC32 hash (skip zero)   : 679836D8
     Statistics

--- a/web/data/Serie/194/metadata.json
+++ b/web/data/Serie/194/metadata.json
@@ -174,7 +174,7 @@
           "end" : 4616840
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/194/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/194/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/194/rip_log.txt
+++ b/web/data/Serie/194/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 001785ee-009dcaa6-77120808)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/194 - Die Zeitreisende.m4a
+    Filename : 194 - Die Zeitreisende.m4a
     CRC32 hash               : 6E47DF32
     CRC32 hash (skip zero)   : 7E531A67
     Statistics

--- a/web/data/Serie/195/metadata.json
+++ b/web/data/Serie/195/metadata.json
@@ -140,7 +140,7 @@
           "end" : 4503053
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/195/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/195/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/195/rip_log.txt
+++ b/web/data/Serie/195/rip_log.txt
@@ -36,7 +36,7 @@ AccurateRip Summary (DiscID: 00134ea8-00771011-71119707)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/195 - Im Reich Der Ungeheuer.m4a
+    Filename : 195 - Im Reich Der Ungeheuer.m4a
     CRC32 hash               : B6258B74
     CRC32 hash (skip zero)   : 1C760873
     Statistics

--- a/web/data/Serie/196/metadata.json
+++ b/web/data/Serie/196/metadata.json
@@ -154,7 +154,7 @@
           "end" : 4728400
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/196/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/196/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/196/rip_log.txt
+++ b/web/data/Serie/196/rip_log.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 001927ad-00a728ad-65127808)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Folge 196： Geheimnis des Bauchredners.m4a
+    Filename : Folge 196： Geheimnis des Bauchredners.m4a
     CRC32 hash               : 7B6E23C4
     CRC32 hash (skip zero)   : E61A0AE3
     Statistics

--- a/web/data/Serie/197/metadata.json
+++ b/web/data/Serie/197/metadata.json
@@ -189,7 +189,7 @@
           "end" : 4190827
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/197/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/197/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/197/rip_log.txt
+++ b/web/data/Serie/197/rip_log.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 00190ed9-00b8a512-6b105e09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/197 - Im Auge des Sturms.m4a
+    Filename : 197 - Im Auge des Sturms.m4a
     CRC32 hash               : EDCEF54E
     CRC32 hash (skip zero)   : 5B733A88
     Statistics

--- a/web/data/Serie/198/metadata.json
+++ b/web/data/Serie/198/metadata.json
@@ -178,7 +178,7 @@
           "end" : 4166400
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/198/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/198/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/198/rip_log.txt
+++ b/web/data/Serie/198/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 198 - Die Legende der Gaukler.m4a
+    Filename : Die Drei ??? - Folge 198 - Die Legende der Gaukler.m4a
     CRC32 hash               : F7A4F476
     CRC32 hash (skip zero)   : 507501BB
     Statistics

--- a/web/data/Serie/199/metadata.json
+++ b/web/data/Serie/199/metadata.json
@@ -154,7 +154,7 @@
           "end" : 4506587
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/199/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/199/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/199/rip_log.txt
+++ b/web/data/Serie/199/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 199 - und der grüne Kobold.m4a
+    Filename : Die Drei ??? - Folge 199 - und der grüne Kobold.m4a
     CRC32 hash               : F179EE18
     CRC32 hash (skip zero)   : 8A12C5C6
     Statistics

--- a/web/data/Serie/200/metadata.json
+++ b/web/data/Serie/200/metadata.json
@@ -292,7 +292,7 @@
           "end" : 4340627
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -327,7 +327,7 @@
           "end" : 4273520
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -362,7 +362,7 @@
           "end" : 4442693
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log3.txt"
     },
     {
       "tracks" : [
@@ -397,7 +397,7 @@
           "end" : 4655267
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/200/rip_log4.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/200/rip_log4.txt"
     }
   ]
 }

--- a/web/data/Serie/200/rip_log1.txt
+++ b/web/data/Serie/200/rip_log1.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 200 - Feuriges Auge - CD1.m4a
+    Filename : Die Drei ??? - Folge 200 - Feuriges Auge - CD1.m4a
     CRC32 hash               : C06CAF24
     CRC32 hash (skip zero)   : 20627251
     Statistics

--- a/web/data/Serie/200/rip_log2.txt
+++ b/web/data/Serie/200/rip_log2.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 200 - Feuriges Auge - CD2.m4a
+    Filename : Die Drei ??? - Folge 200 - Feuriges Auge - CD2.m4a
     CRC32 hash               : 6ACC1F40
     CRC32 hash (skip zero)   : 31C511BC
     Statistics

--- a/web/data/Serie/200/rip_log3.txt
+++ b/web/data/Serie/200/rip_log3.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 200 - Feuriges Auge - CD3.m4a
+    Filename : Die Drei ??? - Folge 200 - Feuriges Auge - CD3.m4a
     CRC32 hash               : 71C94A7F
     CRC32 hash (skip zero)   : A8FFE6E6
     Statistics

--- a/web/data/Serie/200/rip_log4.txt
+++ b/web/data/Serie/200/rip_log4.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 200 - Feuriges Auge - CD4.m4a
+    Filename : Die Drei ??? - Folge 200 - Feuriges Auge - CD4.m4a
     CRC32 hash               : 6CE3BE20
     CRC32 hash (skip zero)   : 0817719F
     Statistics

--- a/web/data/Serie/201/metadata.json
+++ b/web/data/Serie/201/metadata.json
@@ -164,7 +164,7 @@
           "end" : 4703027
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/201/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/201/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/201/rip_log.txt
+++ b/web/data/Serie/201/rip_log.txt
@@ -31,7 +31,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Folge 201 - Höhenangst.m4a
+    Filename : Die Drei ??? - Folge 201 - Höhenangst.m4a
     CRC32 hash               : 2C15C6AC
     CRC32 hash (skip zero)   : 3978CE21
     Statistics

--- a/web/data/Serie/202/metadata.json
+++ b/web/data/Serie/202/metadata.json
@@ -132,7 +132,7 @@
           "end" : 4568253
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/202/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/202/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/202/rip_log.txt
+++ b/web/data/Serie/202/rip_log.txt
@@ -29,7 +29,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 202 - Das weiße Grab.m4a
+    Filename : Die drei ??? - Folge 202 - Das weiße Grab.m4a
     CRC32 hash               : 71F67201
     CRC32 hash (skip zero)   : CCD95C81
     Statistics

--- a/web/data/Serie/203/metadata.json
+++ b/web/data/Serie/203/metadata.json
@@ -142,7 +142,7 @@
           "end" : 4610333
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/203/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/203/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/203/rip_log.txt
+++ b/web/data/Serie/203/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 203 - Tauchgang ins Ungewisse.m4a
+    Filename : Die drei ??? - Folge 203 - Tauchgang ins Ungewisse.m4a
     CRC32 hash               : F8EA5AF5
     CRC32 hash (skip zero)   : 2308F0BA
     Statistics

--- a/web/data/Serie/204/metadata.json
+++ b/web/data/Serie/204/metadata.json
@@ -126,7 +126,7 @@
           "end" : 4144067
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/204/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/204/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/204/rip_log.txt
+++ b/web/data/Serie/204/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 204 - Der dunkle Wächter.m4a
+    Filename : Die drei ??? - Folge 204 - Der dunkle Wächter.m4a
     CRC32 hash               : BC139223
     CRC32 hash (skip zero)   : 3062852C
     Statistics

--- a/web/data/Serie/205/metadata.json
+++ b/web/data/Serie/205/metadata.json
@@ -150,7 +150,7 @@
           "end" : 4255120
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/205/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/205/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/205/rip_log.txt
+++ b/web/data/Serie/205/rip_log.txt
@@ -34,7 +34,7 @@ AccurateRip Summary (DiscID: 000e54a1-00506d59-4e109f06)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 205 - Das rätselhafte Erbe.m4a
+    Filename : Die drei ??? - Folge 205 - Das rätselhafte Erbe.m4a
     CRC32 hash               : ECE1F02B
     CRC32 hash (skip zero)   : E797C221
     Statistics

--- a/web/data/Serie/206/metadata.json
+++ b/web/data/Serie/206/metadata.json
@@ -126,7 +126,7 @@
           "end" : 3762867
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/206/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/206/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/206/rip_log.txt
+++ b/web/data/Serie/206/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 206 - und der Mottenmann.m4a
+    Filename : Die drei ??? - Folge 206 - und der Mottenmann.m4a
     CRC32 hash               : 63FE8CC9
     CRC32 hash (skip zero)   : C38AB24F
     Statistics

--- a/web/data/Serie/207/metadata.json
+++ b/web/data/Serie/207/metadata.json
@@ -138,7 +138,7 @@
           "end" : 3725680
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/207/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/207/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/207/rip_log.txt
+++ b/web/data/Serie/207/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 207 - Die falschen Detektive.m4a
+    Filename : Die drei ??? - Folge 207 - Die falschen Detektive.m4a
     CRC32 hash               : EE8D7542
     CRC32 hash (skip zero)   : B4220E3B
     Statistics

--- a/web/data/Serie/208/metadata.json
+++ b/web/data/Serie/208/metadata.json
@@ -154,7 +154,7 @@
           "end" : 4250387
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/208/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/208/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/208/rip_log.txt
+++ b/web/data/Serie/208/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 208 - Kelch des Schicksals.m4a
+    Filename : Die drei ??? - Folge 208 - Kelch des Schicksals.m4a
     CRC32 hash               : 9EC5F971
     CRC32 hash (skip zero)   : 173EA21B
     Statistics

--- a/web/data/Serie/209/metadata.json
+++ b/web/data/Serie/209/metadata.json
@@ -144,7 +144,7 @@
           "end" : 3596773
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/209/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/209/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/209/rip_log.txt
+++ b/web/data/Serie/209/rip_log.txt
@@ -29,7 +29,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 209 - Kreaturen der Nacht.m4a
+    Filename : Die drei ??? - Folge 209 - Kreaturen der Nacht.m4a
     CRC32 hash               : 5764FF0A
     CRC32 hash (skip zero)   : 3289C5B0
     Statistics

--- a/web/data/Serie/210/metadata.json
+++ b/web/data/Serie/210/metadata.json
@@ -126,7 +126,7 @@
           "end" : 3627267
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/210/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/210/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/210/rip_log.txt
+++ b/web/data/Serie/210/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 210 - und die schweigende Grotte.m4a
+    Filename : Die drei ??? - Folge 210 - und die schweigende Grotte.m4a
     CRC32 hash               : 158A9202
     CRC32 hash (skip zero)   : 31EC72A6
     Statistics

--- a/web/data/Serie/211/metadata.json
+++ b/web/data/Serie/211/metadata.json
@@ -134,7 +134,7 @@
           "end" : 4321973
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/211/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/211/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/211/rip_log.txt
+++ b/web/data/Serie/211/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 211 - und der Jadekönig.m4a
+    Filename : Die drei ??? - Folge 211 - und der Jadekönig.m4a
     CRC32 hash               : 8DAB05B9
     CRC32 hash (skip zero)   : A4BCC2ED
     Statistics

--- a/web/data/Serie/212/metadata.json
+++ b/web/data/Serie/212/metadata.json
@@ -144,7 +144,7 @@
           "end" : 4395213
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/212/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/212/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/212/rip_log.txt
+++ b/web/data/Serie/212/rip_log.txt
@@ -29,7 +29,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 212： Der weiße Leopard.m4a
+    Filename : Die drei ??? - Folge 212： Der weiße Leopard.m4a
     CRC32 hash               : 264C6E03
     CRC32 hash (skip zero)   : D9359544
     Statistics

--- a/web/data/Serie/213/metadata.json
+++ b/web/data/Serie/213/metadata.json
@@ -160,7 +160,7 @@
           "end" : 4378267
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/213/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/213/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/213/rip_log.txt
+++ b/web/data/Serie/213/rip_log.txt
@@ -29,7 +29,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 213： Der Fluch der Medusa.m4a
+    Filename : Die drei ??? - Folge 213： Der Fluch der Medusa.m4a
     CRC32 hash               : FA0421C0
     CRC32 hash (skip zero)   : DFCD0497
     Statistics

--- a/web/data/Serie/214/metadata.json
+++ b/web/data/Serie/214/metadata.json
@@ -142,7 +142,7 @@
           "end" : 3938600
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/214/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/214/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/214/rip_log.txt
+++ b/web/data/Serie/214/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 214： und der Geisterbunker.m4a
+    Filename : Die drei ??? - Folge 214： und der Geisterbunker.m4a
     CRC32 hash               : 5ED595AB
     CRC32 hash (skip zero)   : 6812B9ED
     Statistics

--- a/web/data/Serie/215/metadata.json
+++ b/web/data/Serie/215/metadata.json
@@ -158,7 +158,7 @@
           "end" : 3954893
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/215/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/215/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/215/rip_log.txt
+++ b/web/data/Serie/215/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 215： und die verlorene Zeit.m4a
+    Filename : Die drei ??? - Folge 215： und die verlorene Zeit.m4a
     CRC32 hash               : E456C48C
     CRC32 hash (skip zero)   : 43657778
     Statistics

--- a/web/data/Serie/216/metadata.json
+++ b/web/data/Serie/216/metadata.json
@@ -160,7 +160,7 @@
           "end" : 3884267
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/216/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/216/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/216/rip_log.txt
+++ b/web/data/Serie/216/rip_log.txt
@@ -31,7 +31,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 216： Die Schwingen des Unheils.m4a
+    Filename : Die drei ??? - Folge 216： Die Schwingen des Unheils.m4a
     CRC32 hash               : 1D591411
     CRC32 hash (skip zero)   : A071FE12
     Statistics

--- a/web/data/Serie/217/metadata.json
+++ b/web/data/Serie/217/metadata.json
@@ -163,7 +163,7 @@
           "end" : 4520653
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/217/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/217/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/217/rip_log.txt
+++ b/web/data/Serie/217/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 217： und der Kristallschädel.m4a
+    Filename : Die drei ??? - Folge 217： und der Kristallschädel.m4a
     CRC32 hash               : C4ED4847
     CRC32 hash (skip zero)   : 93006D41
     Statistics

--- a/web/data/Serie/218/metadata.json
+++ b/web/data/Serie/218/metadata.json
@@ -163,7 +163,7 @@
           "end" : 4372133
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/218/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/218/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/218/rip_log.txt
+++ b/web/data/Serie/218/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 218： Im Netz der Lügen.m4a
+    Filename : Die drei ??? - Folge 218： Im Netz der Lügen.m4a
     CRC32 hash               : CF1770B9
     CRC32 hash (skip zero)   : DAA13016
     Statistics

--- a/web/data/Serie/219/metadata.json
+++ b/web/data/Serie/219/metadata.json
@@ -163,7 +163,7 @@
           "end" : 4189547
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/219/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/219/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/219/rip_log.txt
+++ b/web/data/Serie/219/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 219： und die Teufelsklippe.m4a
+    Filename : Die drei ??? - Folge 219： und die Teufelsklippe.m4a
     CRC32 hash               : B1D9DE5F
     CRC32 hash (skip zero)   : 10655E45
     Statistics

--- a/web/data/Serie/220/metadata.json
+++ b/web/data/Serie/220/metadata.json
@@ -175,7 +175,7 @@
           "end" : 4446747
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/220/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/220/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/220/rip_log.txt
+++ b/web/data/Serie/220/rip_log.txt
@@ -32,7 +32,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 220： Im Wald der Gefahren.m4a
+    Filename : Die drei ??? - Folge 220： Im Wald der Gefahren.m4a
     CRC32 hash               : 21B2F17A
     CRC32 hash (skip zero)   : 691F14A7
     Statistics

--- a/web/data/Serie/221/metadata.json
+++ b/web/data/Serie/221/metadata.json
@@ -153,7 +153,7 @@
           "end" : 3932520
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/221/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/221/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/221/rip_log.txt
+++ b/web/data/Serie/221/rip_log.txt
@@ -31,7 +31,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 221： Manuskript des Satans.m4a
+    Filename : Die drei ??? - Folge 221： Manuskript des Satans.m4a
     CRC32 hash               : 3A76E01F
     CRC32 hash (skip zero)   : 695FC9D9
     Statistics

--- a/web/data/Serie/222/metadata.json
+++ b/web/data/Serie/222/metadata.json
@@ -163,7 +163,7 @@
           "end" : 4615480
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/222/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/222/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/222/rip_log.txt
+++ b/web/data/Serie/222/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 222： und die Gesetzlosen.m4a
+    Filename : Die drei ??? - Folge 222： und die Gesetzlosen.m4a
     CRC32 hash               : FC309FB3
     CRC32 hash (skip zero)   : 40CC476E
     Statistics

--- a/web/data/Serie/223/metadata.json
+++ b/web/data/Serie/223/metadata.json
@@ -168,7 +168,7 @@
           "end" : 4799880
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/223/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/223/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/223/rip_log.txt
+++ b/web/data/Serie/223/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 223： und der Knochenmann.m4a
+    Filename : Die drei ??? - Folge 223： und der Knochenmann.m4a
     CRC32 hash               : 49ED879E
     CRC32 hash (skip zero)   : B1C55F42
     Statistics

--- a/web/data/Serie/224/metadata.json
+++ b/web/data/Serie/224/metadata.json
@@ -151,7 +151,7 @@
           "end" : 4363613
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/224/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/224/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/224/rip_log.txt
+++ b/web/data/Serie/224/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 224： Die Yacht des Verrats.m4a
+    Filename : Die drei ??? - Folge 224： Die Yacht des Verrats.m4a
     CRC32 hash               : 3C12D708
     CRC32 hash (skip zero)   : A2DFCC25
     Statistics

--- a/web/data/Serie/225/metadata.json
+++ b/web/data/Serie/225/metadata.json
@@ -219,7 +219,7 @@
           "end" : 3077933
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -254,7 +254,7 @@
           "end" : 3689613
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -289,7 +289,7 @@
           "end" : 3928907
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/225/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/225/rip_log3.txt"
     }
   ]
 }

--- a/web/data/Serie/225/rip_log1.txt
+++ b/web/data/Serie/225/rip_log1.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 225： und der Puppenmacher - CD1.m4a
+    Filename : Die drei ??? - Folge 225： und der Puppenmacher - CD1.m4a
     CRC32 hash               : 008CC34C
     CRC32 hash (skip zero)   : A1FB9B2A
     Statistics

--- a/web/data/Serie/225/rip_log2.txt
+++ b/web/data/Serie/225/rip_log2.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 225： und der Puppenmacher - CD2.m4a
+    Filename : Die drei ??? - Folge 225： und der Puppenmacher - CD2.m4a
     CRC32 hash               : 64F2C3D8
     CRC32 hash (skip zero)   : 1531FAB5
     Statistics

--- a/web/data/Serie/225/rip_log3.txt
+++ b/web/data/Serie/225/rip_log3.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 225： und der Puppenmacher - CD3.m4a
+    Filename : Die drei ??? - Folge 225： und der Puppenmacher - CD3.m4a
     CRC32 hash               : A8C0C75D
     CRC32 hash (skip zero)   : 6DF10108
     Statistics

--- a/web/data/Serie/226/metadata.json
+++ b/web/data/Serie/226/metadata.json
@@ -135,7 +135,7 @@
           "end" : 4953600
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/226/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/226/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/226/rip_log.txt
+++ b/web/data/Serie/226/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 226： Die Spur der Toten.m4a
+    Filename : Die drei ??? - Folge 226： Die Spur der Toten.m4a
     CRC32 hash               : A8A12DE0
     CRC32 hash (skip zero)   : D702AFAE
     Statistics

--- a/web/data/Serie/227/metadata.json
+++ b/web/data/Serie/227/metadata.json
@@ -135,7 +135,7 @@
           "end" : 3870227
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/227/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/227/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/227/rip_log.txt
+++ b/web/data/Serie/227/rip_log.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 227： Melodie der Rache.m4a
+    Filename : Die drei ??? - Folge 227： Melodie der Rache.m4a
     CRC32 hash               : 47CC5DA4
     CRC32 hash (skip zero)   : 06DBD263
     Statistics

--- a/web/data/Serie/228/metadata.json
+++ b/web/data/Serie/228/metadata.json
@@ -139,7 +139,7 @@
           "end" : 4761320
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Serie/228/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Serie/228/rip_log.txt"
     }
   ]
 }

--- a/web/data/Serie/228/rip_log.txt
+++ b/web/data/Serie/228/rip_log.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Folge 228： Der Ruf der Krähen.m4a
+    Filename : Die drei ??? - Folge 228： Der Ruf der Krähen.m4a
     CRC32 hash               : 7DAA813C
     CRC32 hash (skip zero)   : C22F8D56
     Statistics

--- a/web/data/Spezial.json
+++ b/web/data/Spezial.json
@@ -199,7 +199,7 @@
               "end" : 3418440
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -229,7 +229,7 @@
               "end" : 1981684
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt"
         }
       ]
     },
@@ -498,7 +498,7 @@
               "end" : 4757160
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -563,7 +563,7 @@
               "end" : 3904933
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -643,7 +643,7 @@
               "end" : 4416000
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log3.txt"
         }
       ],
       "teile" : [
@@ -1443,7 +1443,7 @@
               "end" : 3675453
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt"
         }
       ]
     },
@@ -2020,7 +2020,7 @@
               "end" : 3498480
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -2315,7 +2315,7 @@
               "end" : 4497427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt"
         }
       ]
     },
@@ -2485,7 +2485,7 @@
               "end" : 3170453
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt"
         }
       ]
     },
@@ -2732,7 +2732,7 @@
               "end" : 3369320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -2777,7 +2777,7 @@
               "end" : 2843747
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -2822,7 +2822,7 @@
               "end" : 4068240
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log3.txt"
         }
       ]
     },
@@ -3081,7 +3081,7 @@
               "end" : 3650720
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -3126,7 +3126,7 @@
               "end" : 2881880
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -3171,7 +3171,7 @@
               "end" : 3360800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt"
         }
       ]
     },
@@ -3419,7 +3419,7 @@
               "end" : 3271667
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -3464,7 +3464,7 @@
               "end" : 3143893
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -3509,7 +3509,7 @@
               "end" : 3533293
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log3.txt"
         }
       ]
     },
@@ -3847,7 +3847,7 @@
               "end" : 4545373
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -3907,7 +3907,7 @@
               "end" : 4609387
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt"
         }
       ]
     },
@@ -4168,7 +4168,7 @@
               "end" : 4319693
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -4213,7 +4213,7 @@
               "end" : 2885320
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt"
         },
         {
           "tracks" : [
@@ -4258,7 +4258,7 @@
               "end" : 5005253
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt"
         }
       ]
     },
@@ -4469,7 +4469,7 @@
               "end" : 2322920
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -4504,7 +4504,7 @@
               "end" : 3059627
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt"
         }
       ]
     },
@@ -4716,7 +4716,7 @@
               "end" : 4300133
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/rip_log.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/rip_log.txt"
         }
       ]
     },
@@ -4928,7 +4928,7 @@
               "end" : 1989427
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -4968,7 +4968,7 @@
               "end" : 3077053
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log2.txt"
         }
       ]
     },
@@ -5195,7 +5195,7 @@
               "end" : 2641800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -5230,7 +5230,7 @@
               "end" : 2675787
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log2.txt"
         }
       ]
     },
@@ -5442,7 +5442,7 @@
               "end" : 2852240
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -5487,7 +5487,7 @@
               "end" : 3273800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt"
         }
       ]
     },
@@ -5675,7 +5675,7 @@
               "end" : 3019707
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -5700,7 +5700,7 @@
               "end" : 2733640
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt"
         }
       ]
     },
@@ -5937,7 +5937,7 @@
               "end" : 3351587
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt"
         },
         {
           "tracks" : [
@@ -5992,7 +5992,7 @@
               "end" : 3418800
             }
           ],
-          "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt"
+          "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt"
         }
       ]
     }

--- a/web/data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json
+++ b/web/data/Spezial/Boeser-die-Glocken-nie-klingen/metadata.json
@@ -255,7 +255,7 @@
           "end" : 4319693
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -300,7 +300,7 @@
           "end" : 2885320
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -345,7 +345,7 @@
           "end" : 5005253
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt"
     }
   ]
 }

--- a/web/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt
+++ b/web/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log1.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei Fragezeichen -  Adventskalender： Böser die Glocken nie klingen - CD1.m4a
+    Filename : Die drei Fragezeichen -  Adventskalender： Böser die Glocken nie klingen - CD1.m4a
     CRC32 hash               : E5A6C9AA
     CRC32 hash (skip zero)   : 7A187A30
     Statistics

--- a/web/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt
+++ b/web/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log2.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei Fragezeichen -  Adventskalender： Böser die Glocken nie klingen - CD2.m4a
+    Filename : Die drei Fragezeichen -  Adventskalender： Böser die Glocken nie klingen - CD2.m4a
     CRC32 hash               : 37DA64B6
     CRC32 hash (skip zero)   : A1155D8E
     Statistics

--- a/web/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt
+++ b/web/data/Spezial/Boeser-die-Glocken-nie-klingen/rip_log3.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei Fragezeichen -  Adventskalender： Böser die Glocken nie klingen - CD3.m4a
+    Filename : Die drei Fragezeichen -  Adventskalender： Böser die Glocken nie klingen - CD3.m4a
     CRC32 hash               : 9EDFB16E
     CRC32 hash (skip zero)   : CF1E8CBA
     Statistics

--- a/web/data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json
+++ b/web/data/Spezial/Brainwash-Gefangene-Gedanken/metadata.json
@@ -236,7 +236,7 @@
           "end" : 3675453
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt"
     }
   ]
 }

--- a/web/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt
+++ b/web/data/Spezial/Brainwash-Gefangene-Gedanken/rip_log.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 001bf703-0105ed7c-a10e5b0c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Brainwash - Gefangene Gedanken.m4a
+    Filename : Die Drei ??? - Brainwash - Gefangene Gedanken.m4a
     CRC32 hash               : 5DC1BC34
     CRC32 hash (skip zero)   : 4E522556
     Statistics

--- a/web/data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json
+++ b/web/data/Spezial/Das-Grab-der-Inka-Mumie/metadata.json
@@ -205,7 +205,7 @@
           "end" : 2322920
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -240,7 +240,7 @@
           "end" : 3059627
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt
+++ b/web/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log1.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 00088d57-002d187a-4b091206)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? Das Grab der Inka-Mumie - CD1.m4a
+    Filename : Die Drei ??? Das Grab der Inka-Mumie - CD1.m4a
     CRC32 hash               : 085D9B69
     CRC32 hash (skip zero)   : 53A93F18
     Statistics

--- a/web/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt
+++ b/web/data/Spezial/Das-Grab-der-Inka-Mumie/rip_log2.txt
@@ -39,7 +39,7 @@ AccurateRip Summary (DiscID: 000ba466-003dc408-440bf306)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Das Grab der Inka-Mumie - CD2.m4a
+    Filename : Die Drei ??? - Das Grab der Inka-Mumie - CD2.m4a
     CRC32 hash               : 39923A7A
     CRC32 hash (skip zero)   : 8D85E90C
     Statistics

--- a/web/data/Spezial/Eine-schreckliche-Bescherung/metadata.json
+++ b/web/data/Spezial/Eine-schreckliche-Bescherung/metadata.json
@@ -332,7 +332,7 @@
           "end" : 4545373
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -392,7 +392,7 @@
           "end" : 4609387
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt
+++ b/web/data/Spezial/Eine-schreckliche-Bescherung/rip_log1.txt
@@ -35,7 +35,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei Fragezeichen - Adventskalender - Eine schreckliche Bescherung - CD1.m4a
+    Filename : Die drei Fragezeichen - Adventskalender - Eine schreckliche Bescherung - CD1.m4a
     CRC32 hash               : C1C5F8EA
     CRC32 hash (skip zero)   : 1EF18C1A
     Statistics

--- a/web/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt
+++ b/web/data/Spezial/Eine-schreckliche-Bescherung/rip_log2.txt
@@ -33,7 +33,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei Fragezeichen - Adventskalender - Eine schreckliche Bescherung - CD2.m4a
+    Filename : Die drei Fragezeichen - Adventskalender - Eine schreckliche Bescherung - CD2.m4a
     CRC32 hash               : 18636A49
     CRC32 hash (skip zero)   : 65BFAD08
     Statistics

--- a/web/data/Spezial/High-Strung-Unter-Hochspannung/metadata.json
+++ b/web/data/Spezial/High-Strung-Unter-Hochspannung/metadata.json
@@ -164,7 +164,7 @@
           "end" : 3170453
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt"
     }
   ]
 }

--- a/web/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt
+++ b/web/data/Spezial/High-Strung-Unter-Hochspannung/rip_log.txt
@@ -45,7 +45,7 @@ AccurateRip Summary (DiscID: 0012fab7-0089bc62-6c0c6209)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/(Special) High Strung.m4a
+    Filename : (Special) High Strung.m4a
     CRC32 hash               : 9A52B6BD
     CRC32 hash (skip zero)   : EF757321
     Statistics

--- a/web/data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json
+++ b/web/data/Spezial/House-of-Horrors-Haus-der-Angst/metadata.json
@@ -571,7 +571,7 @@
           "end" : 3498480
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -866,7 +866,7 @@
           "end" : 4497427
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt
+++ b/web/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log1.txt
@@ -81,7 +81,7 @@ AccurateRip Summary (DiscID: 0038ca48-0439071f-810daa1b)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - House of Horrors - Haus der Angst - CD1.m4a
+    Filename : Die Drei ??? - House of Horrors - Haus der Angst - CD1.m4a
     CRC32 hash               : 8591A625
     CRC32 hash (skip zero)   : DD0120E2
     Statistics

--- a/web/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt
+++ b/web/data/Spezial/House-of-Horrors-Haus-der-Angst/rip_log2.txt
@@ -143,7 +143,7 @@ AccurateRip Summary (DiscID: 00683e80-12bd3e58-0811913a)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - House of Horrors - Haus der Angst - CD2.m4a
+    Filename : Die Drei ??? - House of Horrors - Haus der Angst - CD2.m4a
     CRC32 hash               : 6B5A6A83
     CRC32 hash (skip zero)   : A4BEF778
     Statistics

--- a/web/data/Spezial/O-du-finstere/metadata.json
+++ b/web/data/Spezial/O-du-finstere/metadata.json
@@ -242,7 +242,7 @@
           "end" : 3271667
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -287,7 +287,7 @@
           "end" : 3143893
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -332,7 +332,7 @@
           "end" : 3533293
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/O-du-finstere/rip_log3.txt"
     }
   ]
 }

--- a/web/data/Spezial/O-du-finstere/rip_log1.txt
+++ b/web/data/Spezial/O-du-finstere/rip_log1.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Adventskalender - O du finstere - CD1.m4a
+    Filename : Die drei ??? - Adventskalender - O du finstere - CD1.m4a
     CRC32 hash               : 0F8DED51
     CRC32 hash (skip zero)   : A1AA6791
     Statistics

--- a/web/data/Spezial/O-du-finstere/rip_log2.txt
+++ b/web/data/Spezial/O-du-finstere/rip_log2.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Adventskalender - O du finstere - CD2.m4a
+    Filename : Die drei ??? - Adventskalender - O du finstere - CD2.m4a
     CRC32 hash               : 9573E77B
     CRC32 hash (skip zero)   : 976B9D34
     Statistics

--- a/web/data/Spezial/O-du-finstere/rip_log3.txt
+++ b/web/data/Spezial/O-du-finstere/rip_log3.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - Adventskalender - O du finstere - CD3.m4a
+    Filename : Die drei ??? - Adventskalender - O du finstere - CD3.m4a
     CRC32 hash               : C43561AC
     CRC32 hash (skip zero)   : 04D7F2C9
     Statistics

--- a/web/data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json
+++ b/web/data/Spezial/Stille-Nacht-duestere-Nacht/metadata.json
@@ -253,7 +253,7 @@
           "end" : 3650720
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -298,7 +298,7 @@
           "end" : 2881880
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -343,7 +343,7 @@
           "end" : 3360800
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt"
     }
   ]
 }

--- a/web/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt
+++ b/web/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log1.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 00125986-007ab6de-650e4208)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/A - Stille Nacht, Düstere Nacht.m4a
+    Filename : A - Stille Nacht, Düstere Nacht.m4a
     CRC32 hash               : 01E894AA
     CRC32 hash (skip zero)   : 939590CE
     Statistics

--- a/web/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt
+++ b/web/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log2.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 00108ddc-006bb57f-660b4108)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Stille Nacht, Düstere Nacht.m4a
+    Filename : Stille Nacht, Düstere Nacht.m4a
     CRC32 hash               : 276DC0BF
     CRC32 hash (skip zero)   : 79899865
     Statistics

--- a/web/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt
+++ b/web/data/Spezial/Stille-Nacht-duestere-Nacht/rip_log3.txt
@@ -38,7 +38,7 @@ AccurateRip Summary (DiscID: 000d5a49-005ecabd-680d2008)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Stille Nacht, Düstere Nacht(1).m4a
+    Filename : Stille Nacht, Düstere Nacht(1).m4a
     CRC32 hash               : 8E0CF6C4
     CRC32 hash (skip zero)   : 36585C7B
     Statistics

--- a/web/data/Spezial/und-das-Grab-der-Maya/metadata.json
+++ b/web/data/Spezial/und-das-Grab-der-Maya/metadata.json
@@ -231,7 +231,7 @@
           "end" : 3351587
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -286,7 +286,7 @@
           "end" : 3418800
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt
+++ b/web/data/Spezial/und-das-Grab-der-Maya/rip_log1.txt
@@ -32,7 +32,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - und das Grab der Maya (Planetarium Special - CD1).m4a
+    Filename : Die drei ??? - und das Grab der Maya (Planetarium Special - CD1).m4a
     CRC32 hash               : 3B0381CE
     CRC32 hash (skip zero)   : 935FAF2C
     Statistics

--- a/web/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt
+++ b/web/data/Spezial/und-das-Grab-der-Maya/rip_log2.txt
@@ -32,7 +32,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - und das Grab der Maya (Planetarium Special - CD2).m4a
+    Filename : Die drei ??? - und das Grab der Maya (Planetarium Special - CD2).m4a
     CRC32 hash               : 37682BB1
     CRC32 hash (skip zero)   : D31B328F
     Statistics

--- a/web/data/Spezial/und-das-kalte-Auge/metadata.json
+++ b/web/data/Spezial/und-das-kalte-Auge/metadata.json
@@ -206,7 +206,7 @@
           "end" : 1989427
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -246,7 +246,7 @@
           "end" : 3077053
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-kalte-Auge/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/und-das-kalte-Auge/rip_log1.txt
+++ b/web/data/Spezial/und-das-kalte-Auge/rip_log1.txt
@@ -30,7 +30,7 @@ AccurateRip Summary (DiscID: 0005907e-00169711-2307c504)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - und das kalte Auge - CD1.m4a
+    Filename : Die Drei ??? - und das kalte Auge - CD1.m4a
     CRC32 hash               : 1457E8F8
     CRC32 hash (skip zero)   : B1DCC919
     Statistics

--- a/web/data/Spezial/und-das-kalte-Auge/rip_log2.txt
+++ b/web/data/Spezial/und-das-kalte-Auge/rip_log2.txt
@@ -36,7 +36,7 @@ AccurateRip Summary (DiscID: 000e75d5-00568152-5b0c0507)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - und das kalte Auge - CD2.m4a
+    Filename : Die Drei ??? - und das kalte Auge - CD2.m4a
     CRC32 hash               : 239DA8DB
     CRC32 hash (skip zero)   : 159A1BB9
     Statistics

--- a/web/data/Spezial/und-das-versunkene-Schiff/metadata.json
+++ b/web/data/Spezial/und-das-versunkene-Schiff/metadata.json
@@ -206,7 +206,7 @@
           "end" : 2852240
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -251,7 +251,7 @@
           "end" : 3273800
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt
+++ b/web/data/Spezial/und-das-versunkene-Schiff/rip_log1.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - und das versunkene Schiff - CD1.m4a
+    Filename : Die drei ??? - und das versunkene Schiff - CD1.m4a
     CRC32 hash               : 1C4C90EC
     CRC32 hash (skip zero)   : 4A282649
     Statistics

--- a/web/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt
+++ b/web/data/Spezial/und-das-versunkene-Schiff/rip_log2.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - und das versunkene Schiff - CD2.m4a
+    Filename : Die drei ??? - und das versunkene Schiff - CD2.m4a
     CRC32 hash               : 31D49DF7
     CRC32 hash (skip zero)   : 62E66919
     Statistics

--- a/web/data/Spezial/und-der-5-Advent/metadata.json
+++ b/web/data/Spezial/und-der-5-Advent/metadata.json
@@ -241,7 +241,7 @@
           "end" : 3369320
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -286,7 +286,7 @@
           "end" : 2843747
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -331,7 +331,7 @@
           "end" : 4068240
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-5-Advent/rip_log3.txt"
     }
   ]
 }

--- a/web/data/Spezial/und-der-5-Advent/rip_log1.txt
+++ b/web/data/Spezial/und-der-5-Advent/rip_log1.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 00123997-00779954-670d2908)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Der 5. Advent - CD1.m4a
+    Filename : Die Drei ??? - Der 5. Advent - CD1.m4a
     CRC32 hash               : 9D1E8E8E
     CRC32 hash (skip zero)   : 735740FB
     Statistics

--- a/web/data/Spezial/und-der-5-Advent/rip_log2.txt
+++ b/web/data/Spezial/und-der-5-Advent/rip_log2.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 001010e3-00696741-5c0b1b08)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Der 5. Advent - CD2.m4a
+    Filename : Die Drei ??? - Der 5. Advent - CD2.m4a
     CRC32 hash               : 7C971C6B
     CRC32 hash (skip zero)   : 1062E3B9
     Statistics

--- a/web/data/Spezial/und-der-5-Advent/rip_log3.txt
+++ b/web/data/Spezial/und-der-5-Advent/rip_log3.txt
@@ -43,7 +43,7 @@ AccurateRip Summary (DiscID: 0011cdfa-00794ae2-7e0fe408)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Der 5. Advent - CD3.m4a
+    Filename : Die Drei ??? - Der 5. Advent - CD3.m4a
     CRC32 hash               : 3B0B8284
     CRC32 hash (skip zero)   : C7C5EABA
     Statistics

--- a/web/data/Spezial/und-der-Super-Papagei-2004/metadata.json
+++ b/web/data/Spezial/und-der-Super-Papagei-2004/metadata.json
@@ -197,7 +197,7 @@
           "end" : 3418440
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -227,7 +227,7 @@
           "end" : 1981684
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt
+++ b/web/data/Spezial/und-der-Super-Papagei-2004/rip_log1.txt
@@ -40,7 +40,7 @@ AccurateRip Summary (DiscID: 0016999a-009ffd53-7d0d5a09)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/001 Der Super-Papagei 2004 [Disc 1].m4a
+    Filename : 001 Der Super-Papagei 2004 [Disc 1].m4a
     CRC32 hash               : 35E527AA
     CRC32 hash (skip zero)   : 8F212594
     Statistics

--- a/web/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt
+++ b/web/data/Spezial/und-der-Super-Papagei-2004/rip_log2.txt
@@ -98,7 +98,7 @@ AccurateRip Summary (DiscID: 00685f37-0957ad83-2e0dec26)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/001 Der Super-Papagei 2004 [Disc 2].m4a
+    Filename : 001 Der Super-Papagei 2004 [Disc 2].m4a
     CRC32 hash               : 2A72A7C9
     CRC32 hash (skip zero)   : 8E043133
     Statistics

--- a/web/data/Spezial/und-der-Tornadojaeger/metadata.json
+++ b/web/data/Spezial/und-der-Tornadojaeger/metadata.json
@@ -206,7 +206,7 @@
           "end" : 4300133
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/rip_log.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-Tornadojaeger/rip_log.txt"
     }
   ]
 }

--- a/web/data/Spezial/und-der-Tornadojaeger/rip_log.txt
+++ b/web/data/Spezial/und-der-Tornadojaeger/rip_log.txt
@@ -46,7 +46,7 @@ AccurateRip Summary (DiscID: 0020a21b-01316707-9e10cc0c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - Und Der Tornadojäger.m4a
+    Filename : Die Drei ??? - Und Der Tornadojäger.m4a
     CRC32 hash               : 929DC3C6
     CRC32 hash (skip zero)   : F1D90173
     Statistics

--- a/web/data/Spezial/und-der-dreiTag/metadata.json
+++ b/web/data/Spezial/und-der-dreiTag/metadata.json
@@ -263,7 +263,7 @@
           "end" : 4757160
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -328,7 +328,7 @@
           "end" : 3904933
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log2.txt"
     },
     {
       "tracks" : [
@@ -408,7 +408,7 @@
           "end" : 4416000
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log3.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiTag/rip_log3.txt"
     }
   ],
   "teile" : [

--- a/web/data/Spezial/und-der-dreiTag/rip_log1.txt
+++ b/web/data/Spezial/und-der-dreiTag/rip_log1.txt
@@ -53,7 +53,7 @@ AccurateRip Summary (DiscID: 00265c82-0186d7f6-b612950d)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Der Fluch Der Sheldon Street (J).m4a
+    Filename : Der Fluch Der Sheldon Street (J).m4a
     CRC32 hash               : 494A8F66
     CRC32 hash (skip zero)   : 8F6F57A2
     Statistics

--- a/web/data/Spezial/und-der-dreiTag/rip_log2.txt
+++ b/web/data/Spezial/und-der-dreiTag/rip_log2.txt
@@ -51,7 +51,7 @@ AccurateRip Summary (DiscID: 001aa4c2-00fd8fd3-990f400c)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Im Zeichen Der Ritter (B).m4a
+    Filename : Im Zeichen Der Ritter (B).m4a
     CRC32 hash               : 1DE1681A
     CRC32 hash (skip zero)   : 986C65C3
     Statistics

--- a/web/data/Spezial/und-der-dreiTag/rip_log3.txt
+++ b/web/data/Spezial/und-der-dreiTag/rip_log3.txt
@@ -57,7 +57,7 @@ AccurateRip Summary (DiscID: 00263403-01b59b2e-c711400f)
         ->All tracks accurately ripped.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Fremder Freund P.m4a
+    Filename : Fremder Freund P.m4a
     CRC32 hash               : 9A800DF5
     CRC32 hash (skip zero)   : 3A884CCF
     Statistics

--- a/web/data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json
+++ b/web/data/Spezial/und-der-dreiaeugige-Totenkopf/metadata.json
@@ -182,7 +182,7 @@
           "end" : 3019707
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -207,7 +207,7 @@
           "end" : 2733640
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt
+++ b/web/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log1.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - und der dreiäugige Totenkopf (Planetarium Special) - CD1.m4a
+    Filename : Die drei ??? - und der dreiäugige Totenkopf (Planetarium Special) - CD1.m4a
     CRC32 hash               : 292DCB2A
     CRC32 hash (skip zero)   : C7240A00
     Statistics

--- a/web/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt
+++ b/web/data/Spezial/und-der-dreiaeugige-Totenkopf/rip_log2.txt
@@ -26,7 +26,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die drei ??? - und der dreiäugige Totenkopf (Planetarium Special) - CD2.m4a
+    Filename : Die drei ??? - und der dreiäugige Totenkopf (Planetarium Special) - CD2.m4a
     CRC32 hash               : EB8D9EE3
     CRC32 hash (skip zero)   : DAECEC23
     Statistics

--- a/web/data/Spezial/und-die-schwarze-Katze/metadata.json
+++ b/web/data/Spezial/und-die-schwarze-Katze/metadata.json
@@ -221,7 +221,7 @@
           "end" : 2641800
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log1.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log1.txt"
     },
     {
       "tracks" : [
@@ -256,7 +256,7 @@
           "end" : 2675787
         }
       ],
-      "xld_log" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log2.txt"
+      "ripLog" : "http://dreimetadaten.de/data/Spezial/und-die-schwarze-Katze/rip_log2.txt"
     }
   ]
 }

--- a/web/data/Spezial/und-die-schwarze-Katze/rip_log1.txt
+++ b/web/data/Spezial/und-die-schwarze-Katze/rip_log1.txt
@@ -30,7 +30,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - und die schwarze Katze - CD1.m4a
+    Filename : Die Drei ??? - und die schwarze Katze - CD1.m4a
     CRC32 hash               : F11777E9
     CRC32 hash (skip zero)   : 940308DC
     Statistics

--- a/web/data/Spezial/und-die-schwarze-Katze/rip_log2.txt
+++ b/web/data/Spezial/und-die-schwarze-Katze/rip_log2.txt
@@ -28,7 +28,7 @@ AccurateRip Summary
     Disc not found in AccurateRip DB.
 
 All Tracks
-    Filename : ~/Projects/Audiobooks/_temp/Die Drei ??? - und die schwarze Katze - CD2.m4a
+    Filename : Die Drei ??? - und die schwarze Katze - CD2.m4a
     CRC32 hash               : F38A0B0B
     CRC32 hash (skip zero)   : DD583C5B
     Statistics


### PR DESCRIPTION
* **Removed file paths in rip log files**  
Leaving only the actual file name in the "Filename : " line of the log file.

* **Renamed property "xld_log" to "ripLog"**  
Both object model property "xld_log" and relational model property "xldLog" are now called "ripLog".