### PR TITLE
Refactor CLI tools with more convenient usage

### DIFF
--- a/code/dreimetadaten/CollectionType.swift
+++ b/code/dreimetadaten/CollectionType.swift
@@ -60,20 +60,16 @@ enum CollectionType: String, ArgumentEnum {
 		}
 	}
 	
-	var jsonFilePath: String {
-		"metadata/json/\(fileName).json"
+	var jsonFile: String {
+		"\(fileName).json"
 	}
-	
+	var htmlFile: String {
+		"\(htmlFileName).html"
+	}
 	private var htmlFileName: String {
 		switch self {
 			case .serie: return "index"
 			default: return rawValue
 		}
-	}
-	var htmlFilePath: String {
-		"web/\(htmlFileName).html"
-	}
-	var htmlTemplateFilePath: String {
-		"web_templates/\(htmlFileName).html"
 	}
 }

--- a/code/dreimetadaten/Command/Command.Export.All.swift
+++ b/code/dreimetadaten/Command/Command.Export.All.swift
@@ -1,0 +1,29 @@
+//
+//  Command.Export.All.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 30.07.24.
+//
+
+import Foundation
+import CommandLineTool
+import ArgumentParser
+
+
+extension Command.Export {
+	struct All: ParsableCommand {
+		static let configuration = CommandConfiguration(
+			abstract: "Perform all export commands with default arguments.",
+			alwaysCompactUsageOptions: true
+		)
+		
+		func run() throws {
+			let commandTypes = Command.Export.configuration.subcommands.filter { $0 != Self.self }
+			for commandType in commandTypes {
+				stderr("Export \(commandType._commandName)")
+				var command = try commandType.parse([])
+				try command.run()
+			}
+		}
+	}
+}

--- a/code/dreimetadaten/Command/Command.Export.JSON.swift
+++ b/code/dreimetadaten/Command/Command.Export.JSON.swift
@@ -18,11 +18,11 @@ extension Command.Export {
 			alwaysCompactUsageOptions: true
 		)
 		
-		@Argument(help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
-		var databaseFilePath: String = Command.databaseFile.relativePath
-		
 		@Argument(help: ArgumentHelp("The path to the JSON output directory.", valueName: "output directory"))
 		var jsonDirectoryPath: String = Command.jsonDir.relativePath
+		
+		@Option(name: .customLong("db"), help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
+		var databaseFilePath: String = Command.databaseFile.relativePath
 		
 		@Option(name: .customLong("webDataURL"), help: ArgumentHelp("The URL pointing to the web data directory. Used as the base URL for generated metadata links.", valueName: "URL"))
 		var webDataURLString: String = Command.webDataURL.absoluteString

--- a/code/dreimetadaten/Command/Command.Export.SQL.swift
+++ b/code/dreimetadaten/Command/Command.Export.SQL.swift
@@ -18,11 +18,11 @@ extension Command.Export {
 			alwaysCompactUsageOptions: true
 		)
 		
-		@Argument(help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
-		var databaseFilePath: String = Command.databaseFile.relativePath
-		
 		@Argument(help: ArgumentHelp("The path to the SQL dump output file.", valueName: "sql dump file"))
 		var sqlFilePath: String = Command.sqlFile.relativePath
+		
+		@Option(name: .customLong("db"), help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
+		var databaseFilePath: String = Command.databaseFile.relativePath
 		
 		@Option(name: .customLong("sqlite"), help: ArgumentHelp("The path to the SQLite CLI binary.", valueName: "sqlite binary"))
 		var sqliteBinaryPath: String = SQLPorter.defaultSqliteBinaryPath

--- a/code/dreimetadaten/Command/Command.Export.TSV.swift
+++ b/code/dreimetadaten/Command/Command.Export.TSV.swift
@@ -18,7 +18,7 @@ extension Command.Export {
 			alwaysCompactUsageOptions: true
 		)
 		
-		@Argument(help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
+		@Option(name: .customLong("db"), help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
 		var databaseFilePath: String = Command.databaseFile.relativePath
 		
 		@Argument(help: ArgumentHelp("The path to the TSV output directory.", valueName: "output directory"))

--- a/code/dreimetadaten/Command/Command.Export.swift
+++ b/code/dreimetadaten/Command/Command.Export.swift
@@ -14,7 +14,7 @@ extension Command {
 	struct Export: ParsableCommand {
 		static let configuration = CommandConfiguration(
 			abstract: "Export dataset into various (more convenient) formats.",
-			subcommands: [SQL.self, TSV.self, JSON.self, Web.self],
+			subcommands: [SQL.self, TSV.self, JSON.self, Web.self, All.self],
 			helpMessageLabelColumnWidth: 20,
 			alwaysCompactUsageOptions: true
 		)

--- a/code/dreimetadaten/Command/Command.Load.swift
+++ b/code/dreimetadaten/Command/Command.Load.swift
@@ -18,11 +18,11 @@ extension Command {
 			alwaysCompactUsageOptions: true
 		)
 		
-		@Argument(help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
-		var databaseFilePath: String = Command.databaseFile.relativePath
-		
 		@Argument(help: ArgumentHelp("The path to the SQL dump input file.", valueName: "sql dump file"))
 		var sqlFilePath: String = Command.sqlFile.relativePath
+		
+		@Option(name: .customLong("db"), help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
+		var databaseFilePath: String = Command.databaseFile.relativePath
 		
 		@Option(name: .customLong("sqlite"), help: ArgumentHelp("The path to the SQLite CLI binary.", valueName: "sqlite binary"))
 		var sqliteBinaryPath: String = SQLPorter.defaultSqliteBinaryPath

--- a/code/dreimetadaten/Command/Command.Migrate.swift
+++ b/code/dreimetadaten/Command/Command.Migrate.swift
@@ -21,7 +21,7 @@ extension Command {
 		@Argument(help: ArgumentHelp("The path to the JSON dataset input file.", valueName: "json file"))
 		var jsonFilePath: String
 		
-		@Argument(help: ArgumentHelp("The path to the SQLite database output file.", valueName: "sqlite file"))
+		@Option(name: .customLong("db"), help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
 		var databaseFilePath: String = Command.databaseFile.relativePath
 		
 		@Flag(help: ArgumentHelp("Only create schema."))

--- a/code/dreimetadaten/Command/Command.WebBuild.swift
+++ b/code/dreimetadaten/Command/Command.WebBuild.swift
@@ -38,10 +38,10 @@ extension Command {
 		var ioOptions: IOOptions
 		
 		func run() throws {
-			func automaticDefault(_ optionKeyPath: KeyPath<IOOptions, String?>, defaultKeyPath: KeyPath<CollectionType, String>) throws -> URL {
+			func automaticDefault(_ optionKeyPath: KeyPath<IOOptions, String?>, defaultFile defaultFileKeyPath: KeyPath<CollectionType, String>, in defaultDir: URL) throws -> URL {
 				let url = ioOptions[keyPath: optionKeyPath]
 					.map { URL(fileURLWithPath: $0, isDirectory: false) }
-					?? Command.url(projectRelativePath: collectionType[keyPath: defaultKeyPath])
+					?? defaultDir.appendingPathComponent(collectionType[keyPath: defaultFileKeyPath], isDirectory: false)
 				
 				var directory: ObjCBool = false
 				guard FileManager.default.fileExists(atPath: url.path, isDirectory: &directory), !directory.boolValue else {
@@ -50,9 +50,9 @@ extension Command {
 				return url
 			}
 			
-			let jsonFileURL = try automaticDefault(\.jsonFilePath, defaultKeyPath: \.jsonFilePath)
-			let templateFileURL = try automaticDefault(\.templateFilePath, defaultKeyPath: \.htmlTemplateFilePath)
-			let outputFileURL = try automaticDefault(\.outputFilePath, defaultKeyPath: \.htmlFilePath)
+			let jsonFileURL = try automaticDefault(\.jsonFilePath, defaultFile: \.jsonFile, in: Command.jsonDir)
+			let templateFileURL = try automaticDefault(\.templateFilePath, defaultFile: \.htmlFile, in: Command.webTemplatesDir)
+			let outputFileURL = try automaticDefault(\.outputFilePath, defaultFile: \.htmlFile, in: Command.webDir)
 			
 			let templateContent: String
 			do {

--- a/code/dreimetadaten/Command/Command.WebBuild.swift
+++ b/code/dreimetadaten/Command/Command.WebBuild.swift
@@ -8,6 +8,7 @@
 import Foundation
 import CommandLineTool
 import ArgumentParser
+import GRDB
 
 
 extension Command {
@@ -21,9 +22,6 @@ extension Command {
 		struct IOOptions: ParsableArguments {
 			private static let argumentHelpAutomaticDefault = "(default: automatic based on <collection type>)"
 			
-			@Option(name: .customLong("json"), help: ArgumentHelp("The path to the JSON dataset input file. \(argumentHelpAutomaticDefault)", valueName: "json file"))
-			var jsonFilePath: String?
-			
 			@Option(name: .customLong("template"), help: ArgumentHelp("The path to the template HTML input file to use for filling in the placeholders. \(argumentHelpAutomaticDefault)", valueName: "html file"))
 			var templateFilePath: String?
 			
@@ -32,50 +30,64 @@ extension Command {
 		}
 		
 		@Argument(help: ArgumentHelp("The collection type to generate the HTML code for.", valueName: "collection type"))
-		var collectionType: CollectionType
+		var collectionTypeArgument: CollectionTypeArgument
+		
+		@Option(name: .customLong("db"), help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
+		var databaseFilePath: String = Command.databaseFile.relativePath
+		
+		@Option(name: .customLong("webDataURL"), help: ArgumentHelp("The URL pointing to the web data directory. Used as the base URL for generated metadata links.", valueName: "URL"))
+		var webDataURLString: String = Command.webDataURL.absoluteString
 		
 		@OptionGroup(title: "IO Options")
 		var ioOptions: IOOptions
 		
 		func run() throws {
-			func automaticDefault(_ optionKeyPath: KeyPath<IOOptions, String?>, defaultFile defaultFileKeyPath: KeyPath<CollectionType, String>, in defaultDir: URL) throws -> URL {
-				let url = ioOptions[keyPath: optionKeyPath]
-					.map { URL(fileURLWithPath: $0, isDirectory: false) }
-					?? defaultDir.appendingPathComponent(collectionType[keyPath: defaultFileKeyPath], isDirectory: false)
+			guard let webDataURL = URL(string: webDataURLString) else {
+				throw IOError.invalidURL(string: webDataURLString)
+			}
+			
+			let dbQueue = try DatabaseQueue(path: databaseFilePath)
+			try dbQueue.read { db in
+				let objectModel = try MetadataObjectModel(fromDatabase: db, withBaseURL: webDataURL)
 				
-				var directory: ObjCBool = false
-				guard FileManager.default.fileExists(atPath: url.path, isDirectory: &directory), !directory.boolValue else {
-					throw IOError.noSuchFile(url: url)
+				for collectionType in collectionTypeArgument.collectionType {
+					func automaticDefault(_ optionKeyPath: KeyPath<IOOptions, String?>, defaultIn defaultDir: URL) throws -> URL {
+						let path = ioOptions[keyPath: optionKeyPath]
+						let defaultFile = collectionType.htmlFile
+						let url = path.map { URL(fileURLWithPath: $0, isDirectory: false) } ?? defaultDir.appendingPathComponent(defaultFile, isDirectory: false)
+						
+						var directory: ObjCBool = false
+						guard FileManager.default.fileExists(atPath: url.path, isDirectory: &directory), !directory.boolValue else {
+							throw IOError.noSuchFile(url: url)
+						}
+						return url
+					}
+					let templateFileURL = try automaticDefault(\.templateFilePath, defaultIn: Command.webTemplatesDir)
+					let outputFileURL = try automaticDefault(\.outputFilePath, defaultIn: Command.webDir)
+					
+					let templateContent: String
+					do {
+						templateContent = try String(contentsOf: templateFileURL, encoding: .utf8)
+					}
+					catch {
+						throw IOError.fileReadingFailed(url: templateFileURL, error: error)
+					}
+					
+					let webBuilder = WebBuilder(
+						objectModel: objectModel,
+						collectionType: collectionType,
+						templateContent: templateContent,
+						host: webDataURL.host!
+					)
+					try webBuilder.build()
+					
+					do {
+						try webBuilder.content.write(to: outputFileURL, atomically: false, encoding: .utf8)
+					}
+					catch {
+						throw IOError.fileWritingFailed(url: outputFileURL, error: error)
+					}
 				}
-				return url
-			}
-			
-			let jsonFileURL = try automaticDefault(\.jsonFilePath, defaultFile: \.jsonFile, in: Command.jsonDir)
-			let templateFileURL = try automaticDefault(\.templateFilePath, defaultFile: \.htmlFile, in: Command.webTemplatesDir)
-			let outputFileURL = try automaticDefault(\.outputFilePath, defaultFile: \.htmlFile, in: Command.webDir)
-			
-			let templateContent: String
-			do {
-				templateContent = try String(contentsOf: templateFileURL, encoding: .utf8)
-			}
-			catch {
-				throw IOError.fileReadingFailed(url: templateFileURL, error: error)
-			}
-			
-			let objectModel = try MetadataObjectModel(fromJSON: jsonFileURL)
-			let webBuilder = WebBuilder(
-				objectModel: objectModel,
-				collectionType: collectionType,
-				templateContent: templateContent,
-				host: Command.webURL.host!
-			)
-			try webBuilder.build()
-			
-			do {
-				try webBuilder.content.write(to: outputFileURL, atomically: false, encoding: .utf8)
-			}
-			catch {
-				throw IOError.fileWritingFailed(url: outputFileURL, error: error)
 			}
 		}
 	}
@@ -83,10 +95,29 @@ extension Command {
 
 
 extension Command.WebBuild {
+	enum CollectionTypeArgument: String, ArgumentEnum {
+		case serie
+		case spezial
+		case kurzgeschichten
+		case die_dr3i
+		case all
+		
+		var collectionType: [CollectionType] {
+			switch self {
+				case .serie: return [.serie]
+				case .spezial: return [.spezial]
+				case .kurzgeschichten: return [.kurzgeschichten]
+				case .die_dr3i: return [.die_dr3i]
+				case .all: return CollectionType.allCases
+			}
+		}
+	}
+	
 	enum IOError: LocalizedError {
 		case noSuchFile(url: URL)
 		case fileReadingFailed(url: URL, error: Error)
 		case fileWritingFailed(url: URL, error: Error)
+		case invalidURL(string: String)
 		
 		var errorDescription: String? {
 			switch self {
@@ -96,6 +127,8 @@ extension Command.WebBuild {
 					return "Couldn't read file \"\(url.relativePath)\": \(error.localizedDescription)"
 				case .fileWritingFailed(let url, let error):
 					return "Couldn't write to file \"\(url.relativePath)\": \(error.localizedDescription)"
+				case .invalidURL(let string):
+					return "Invalid URL \"\(string)\""
 			}
 		}
 	}

--- a/code/dreimetadaten/Command/Command.swift
+++ b/code/dreimetadaten/Command/Command.swift
@@ -14,7 +14,7 @@ struct Command: ParsableCommand {
 	static let configuration = CommandConfiguration(
 		commandName: executableName,
 		version: "1.2.1",
-		subcommands: [Migrate.self, Export.self, WebBuild.self, Load.self],
+		subcommands: [Load.self, Export.self, WebBuild.self, Migrate.self],
 		helpMessageLabelColumnWidth: 20
 	)
 	

--- a/code/dreimetadaten/Command/Command.swift
+++ b/code/dreimetadaten/Command/Command.swift
@@ -13,7 +13,7 @@ import ArgumentParser
 struct Command: ParsableCommand {
 	static let configuration = CommandConfiguration(
 		commandName: executableName,
-		version: "1.2.1",
+		version: "2.0.0",
 		subcommands: [Load.self, Export.self, WebBuild.self, Migrate.self],
 		helpMessageLabelColumnWidth: 20
 	)

--- a/code/dreimetadaten/Command/Command.swift
+++ b/code/dreimetadaten/Command/Command.swift
@@ -35,6 +35,7 @@ struct Command: ParsableCommand {
 	static var webDataURL = webURL.appendingPathComponent(webDataDirRelativePath)
 	static var webDataDir = webDir.appendingPathComponent(webDataDirRelativePath)
 	static var webIndexDir = webDir.appendingPathComponent("index")
+	static let webTemplatesDir = url(projectRelativePath: "web_templates")
 	
 	static func url(projectRelativePath projectDirRelativePath: String) -> URL {
 		let dest = URL(fileURLWithPath: projectDirRelativePath, relativeTo: projectDir)

--- a/code/dreimetadaten/Export/JSONExporter.swift
+++ b/code/dreimetadaten/Export/JSONExporter.swift
@@ -17,7 +17,7 @@ struct JSONExporter {
 		let objectModels = try MetadataObjectModel(fromDatabase: db, withBaseURL: webDataURL).separateByCollectionType()
 		
 		for (objectModel, collectionType) in objectModels {
-			let jsonURL = outputDir.appendingPathComponent("\(collectionType.fileName).json")
+			let jsonURL = outputDir.appendingPathComponent(collectionType.jsonFile)
 			let jsonString = try objectModel.jsonString()
 			try jsonString.write(to: jsonURL, atomically: true, encoding: .utf8)
 		}


### PR DESCRIPTION
* Changed argument/option for database file to be consistent with all subcommands
* New subcommand shortcuts:
  * **`export all`**: `export sql`, `export tsv`, `export json`, `export web`
  * **`webbuild all`**: `webbuild serie`, `webbuild spezial`, `webbuild kurzgeschichten`, `webbuild die_dr3i`
