### PR TITLE
Add subcommand for testing external URLs in dataset

### DIFF
--- a/code/Package.swift
+++ b/code/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
 	name: "dreimetadaten",
-	platforms: [.macOS(.v10_15)],
+	platforms: [.macOS(.v13)],
 	products: [
 		.executable(name: "dreimetadaten", targets: ["dreimetadaten"]),
 	],

--- a/code/Package.swift
+++ b/code/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
 		.package(url: "https://github.com/dehesa/CodableCSV", from: "0.6.0"),
 		.package(url: "https://github.com/groue/GRDB.swift", from: "6.27.0"),
 		.package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
+		.package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.6.0"),
 	],
 	targets: [
 		.executableTarget(
@@ -21,7 +22,8 @@ let package = Package(
 				"CommandLineTool",
 				"CodableCSV",
 				.product(name: "GRDB", package: "GRDB.swift"),
-				.product(name: "Collections", package: "swift-collections")
+				.product(name: "Collections", package: "swift-collections"),
+				"SwiftSoup",
 			],
 			path: "dreimetadaten"
 		)

--- a/code/dreimetadaten/Command/Command.Test.Links.swift
+++ b/code/dreimetadaten/Command/Command.Test.Links.swift
@@ -71,9 +71,9 @@ extension Command.Test.Links {
 		case appleMusic
 		case spotify
 		case bookbeat
-		//case amazonMusic
+		case amazonMusic
 		case amazon
-		//case youTubeMusic
+		case youTubeMusic
 		case deezer
 		
 		case all
@@ -88,9 +88,9 @@ extension Command.Test.Links {
 				case .appleMusic: [.appleMusic]
 				case .spotify: [.spotify]
 				case .bookbeat: [.bookbeat]
-				//case .amazonMusic: [.amazonMusic]
+				case .amazonMusic: [.amazonMusic]
 				case .amazon: [.amazon]
-				//case .youTubeMusic: [.youTubeMusic]
+				case .youTubeMusic: [.youTubeMusic]
 				case .deezer: [.deezer]
 					
 				case .all: LinkTester.LinkType.allCases
@@ -103,9 +103,9 @@ extension Command.Test.Links {
 					.appleMusic,
 					.spotify,
 					.bookbeat,
-					//.amazonMusic,
+					.amazonMusic,
 					.amazon,
-					//.youTubeMusic,
+					.youTubeMusic,
 					.deezer,
 				]
 			}

--- a/code/dreimetadaten/Command/Command.Test.Links.swift
+++ b/code/dreimetadaten/Command/Command.Test.Links.swift
@@ -1,0 +1,125 @@
+//
+//  Command.Test.Links.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 03.09.25.
+//
+
+import Foundation
+import CommandLineTool
+import ArgumentParser
+import GRDB
+import OrderedCollections
+
+
+extension Command.Test {
+	struct Links: AsyncParsableCommand {
+		static let configuration = CommandConfiguration(
+			abstract: "Test URLs to detect invalid or dead links/IDs.",
+			alwaysCompactUsageOptions: true
+		)
+		
+		@Argument(help: ArgumentHelp("The links to test.", valueName: "link type"))
+		var linkTypeArgument: [LinkTypeArgument]
+		
+		@Option(name: .customLong("db"), help: ArgumentHelp("The path to the SQLite database file.", valueName: "sqlite file"))
+		var databaseFilePath: String = Command.databaseFile.relativePath
+		
+		@Option(name: .customLong("webDataURL"), help: ArgumentHelp("The URL pointing to the web data directory. Used as the base URL for generated metadata links.", valueName: "URL"))
+		var webDataURLString: String = Command.webDataURL.absoluteString
+		
+		@Option(name: .customLong("skip"), help: ArgumentHelp("The number of items to skip at the start.", valueName: "count"))
+		var skipCount: UInt = 0
+		
+		@Flag(name: .long, help: ArgumentHelp("Only check whether the strings are valid URLs."))
+		var syntaxOnly: Bool = false
+		
+		mutating func run() async throws {
+			guard let webDataURL = URL(string: webDataURLString) else {
+				throw ArgumentsError.invalidURL(string: webDataURLString)
+			}
+			let linkTypes = OrderedSet(linkTypeArgument.map(\.linkTypes).joined())
+			
+			let dbQueue = try DatabaseQueue(path: databaseFilePath)
+			let objectModel = try await dbQueue.read { db in
+				try MetadataObjectModel(fromDatabase: db, withBaseURL: webDataURL)
+			}
+			let linkTester = LinkTester(objectModel: objectModel)
+			
+			for linkType in linkTypes {
+				try await linkTester.test(linkType: linkType, startIndex: skipCount, syntaxOnly: syntaxOnly) { progress in
+					let clearLine = "\u{1B}[2K\r"
+					let id = progress.current.map { " (ID=\($0.hörspielID), URL=\($0.url))" } ?? ""
+					stderr("\(clearLine)\(linkType):  \(progress.checked)/\(progress.total)\(id)", terminator: "")
+				} failedLink: { result in
+					let statusCode = result.statusCode.map { "\($0.value)" } ?? ""
+					stderr("")
+					stdout("> FAILED: \(result.hörspielID)\t\(result.url)\t\(statusCode)")
+				}
+				stderr("")
+			}
+		}
+	}
+}
+
+
+extension Command.Test.Links {
+	enum LinkTypeArgument: String, ArgumentEnum {
+		case cover_itunes
+		case cover_kosmos
+		case dreifragezeichen
+		case appleMusic
+		case spotify
+		case bookbeat
+		//case amazonMusic
+		case amazon
+		//case youTubeMusic
+		case deezer
+		
+		case all
+		case covers
+		case platforms
+		
+		var linkTypes: [LinkTester.LinkType] {
+			switch self {
+				case .cover_itunes: [.cover_itunes]
+				case .cover_kosmos: [.cover_kosmos]
+				case .dreifragezeichen: [.dreifragezeichen]
+				case .appleMusic: [.appleMusic]
+				case .spotify: [.spotify]
+				case .bookbeat: [.bookbeat]
+				//case .amazonMusic: [.amazonMusic]
+				case .amazon: [.amazon]
+				//case .youTubeMusic: [.youTubeMusic]
+				case .deezer: [.deezer]
+					
+				case .all: LinkTester.LinkType.allCases
+				case .covers: [
+					.cover_itunes,
+					.cover_kosmos,
+				]
+				case .platforms: [
+					.dreifragezeichen,
+					.appleMusic,
+					.spotify,
+					.bookbeat,
+					//.amazonMusic,
+					.amazon,
+					//.youTubeMusic,
+					.deezer,
+				]
+			}
+		}
+	}
+	
+	enum ArgumentsError: LocalizedError {
+		case invalidURL(string: String)
+		
+		var errorDescription: String? {
+			switch self {
+				case .invalidURL(let string):
+					return "Invalid URL \"\(string)\""
+			}
+		}
+	}
+}

--- a/code/dreimetadaten/Command/Command.Test.swift
+++ b/code/dreimetadaten/Command/Command.Test.swift
@@ -1,0 +1,22 @@
+//
+//  Command.Test.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 03.09.25.
+//
+
+import Foundation
+import CommandLineTool
+import ArgumentParser
+
+
+extension Command {
+	struct Test: AsyncParsableCommand {
+		static let configuration = CommandConfiguration(
+			abstract: "Test dataset completeness, validity and up-to-dateness.",
+			subcommands: [Links.self],
+			helpMessageLabelColumnWidth: 20,
+			alwaysCompactUsageOptions: true
+		)
+	}
+}

--- a/code/dreimetadaten/Command/Command.swift
+++ b/code/dreimetadaten/Command/Command.swift
@@ -10,11 +10,11 @@ import CommandLineTool
 import ArgumentParser
 
 @main
-struct Command: ParsableCommand {
+struct Command: AsyncParsableCommand {
 	static let configuration = CommandConfiguration(
 		commandName: executableName,
 		version: "2.5.0",
-		subcommands: [Load.self, Export.self, WebBuild.self, Import.self],
+		subcommands: [Load.self, Export.self, WebBuild.self, Import.self, Test.self],
 		helpMessageLabelColumnWidth: 20
 	)
 	

--- a/code/dreimetadaten/Test/LinkTester.CheckMethod.swift
+++ b/code/dreimetadaten/Test/LinkTester.CheckMethod.swift
@@ -1,0 +1,20 @@
+//
+//  LinkTester.CheckMethod.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 03.09.25.
+//
+
+
+extension LinkTester {
+	enum CheckMethod {
+		case is2XX
+		
+		func isValid(statusCode: StatusCode) -> Bool {
+			switch self {
+				case .is2XX:
+					return statusCode.class == .successful
+			}
+		}
+	}
+}

--- a/code/dreimetadaten/Test/LinkTester.CheckMethod.swift
+++ b/code/dreimetadaten/Test/LinkTester.CheckMethod.swift
@@ -5,16 +5,64 @@
 //  Created by YourMJK on 03.09.25.
 //
 
+import Foundation
+
 
 extension LinkTester {
-	enum CheckMethod {
-		case is2XX
+	protocol CheckMethod {
+		func check(url: URL) async throws -> (Bool, StatusCode?)
+	}
+}
+
+
+extension LinkTester {
+	enum MetadataCheckMethod: CheckMethod {
+		case headWith2XX
+		case getWith2XX
+		case custom(httpMethod: String, statusCodeCheck: (StatusCode) -> Bool)
+		
+		
+		var httpMethod: String {
+			switch self {
+				case .headWith2XX:
+					"HEAD"
+				case .getWith2XX:
+					"GET"
+				case .custom(let httpMethod, _):
+					httpMethod
+			}
+		}
 		
 		func isValid(statusCode: StatusCode) -> Bool {
 			switch self {
-				case .is2XX:
-					return statusCode.class == .successful
+				case .headWith2XX, .getWith2XX:
+					statusCode.class == .successful
+				case .custom(_, let statusCodeCheck):
+					statusCodeCheck(statusCode)
 			}
 		}
+		
+		func check(url: URL) async throws -> (Bool, StatusCode?) {
+			var request = URLRequest(url: url)
+			request.httpMethod = httpMethod
+			// Default User-Agent works fine while the following custom one is "outdated"
+			//request.setValue("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0", forHTTPHeaderField: "User-Agent")
+			
+			// Send request, retrieve status code and ignore body data
+			let (bytes, response) = try await URLSession.shared.bytes(for: request)
+			bytes.task.cancel()
+			guard let httpResponse = response as? HTTPURLResponse else {
+				throw RequestError.noHTTPResponse
+			}
+			guard let statusCode = StatusCode(httpResponse.statusCode) else {
+				throw RequestError.invalidStatusCode
+			}
+			
+			// Check status code
+			let isValid = isValid(statusCode: statusCode)
+			
+			return (isValid, statusCode)
+		}
+		
 	}
 }

--- a/code/dreimetadaten/Test/LinkTester.CheckMethod.swift
+++ b/code/dreimetadaten/Test/LinkTester.CheckMethod.swift
@@ -11,7 +11,7 @@ import SwiftSoup
 
 extension LinkTester {
 	protocol CheckMethod {
-		func check(url: URL) async throws -> (Bool, StatusCode?)
+		func check(url: URL) async throws -> (Bool, StatusCode)
 	}
 }
 
@@ -31,12 +31,12 @@ extension LinkTester {
 		}
 		
 		
-		func check(url: URL) async throws -> (Bool, StatusCode?) {
+		func check(url: URL) async throws -> (Bool, StatusCode) {
 			// Transform URL if specified
 			let requestURL: URL
 			if let urlTransform {
 				guard let transformedURL = urlTransform(url) else {
-					return (false, nil)
+					throw MethodError.urlTransformFailed(url: url)
 				}
 				requestURL = transformedURL
 			} else {
@@ -139,7 +139,7 @@ extension LinkTester {
 		}
 		
 		
-		func check(url: URL) async throws -> (Bool, StatusCode?) {
+		func check(url: URL) async throws -> (Bool, StatusCode) {
 			let (bodyData, statusCode) = try await sendRequest(url: url)
 			
 			// Check for successful status code

--- a/code/dreimetadaten/Test/LinkTester.CheckMethod.swift
+++ b/code/dreimetadaten/Test/LinkTester.CheckMethod.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftSoup
 
 
 extension LinkTester {
@@ -16,41 +17,45 @@ extension LinkTester {
 
 
 extension LinkTester {
-	enum MetadataCheckMethod: CheckMethod {
-		case headWith2XX
-		case getWith2XX
-		case custom(httpMethod: String, statusCodeCheck: (StatusCode) -> Bool)
+	struct MetadataCheckMethod: CheckMethod {
+		let httpMethod: String
+		let statusCodeCheck: (StatusCode) -> Bool
+		let urlTransform: ((URL) -> URL?)?
+		let userAgent: String?
 		
-		
-		var httpMethod: String {
-			switch self {
-				case .headWith2XX:
-					"HEAD"
-				case .getWith2XX:
-					"GET"
-				case .custom(let httpMethod, _):
-					httpMethod
-			}
+		static func headWith2XX(urlTransform: ((URL) -> URL?)? = nil, userAgent: String? = nil) -> Self {
+			Self(httpMethod: "HEAD", statusCodeCheck: { $0.class == .successful }, urlTransform: urlTransform, userAgent: userAgent)
+		}
+		static func getWith2XX(urlTransform: ((URL) -> URL?)? = nil, userAgent: String? = nil) -> Self {
+			Self(httpMethod: "GET", statusCodeCheck: { $0.class == .successful }, urlTransform: urlTransform, userAgent: userAgent)
 		}
 		
-		func isValid(statusCode: StatusCode) -> Bool {
-			switch self {
-				case .headWith2XX, .getWith2XX:
-					statusCode.class == .successful
-				case .custom(_, let statusCodeCheck):
-					statusCodeCheck(statusCode)
-			}
-		}
 		
 		func check(url: URL) async throws -> (Bool, StatusCode?) {
-			var request = URLRequest(url: url)
+			// Transform URL if specified
+			let requestURL: URL
+			if let urlTransform {
+				guard let transformedURL = urlTransform(url) else {
+					return (false, nil)
+				}
+				requestURL = transformedURL
+			} else {
+				requestURL = url
+			}
+			
+			var request = URLRequest(url: requestURL)
 			request.httpMethod = httpMethod
-			// Default User-Agent works fine while the following custom one is "outdated"
-			//request.setValue("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0", forHTTPHeaderField: "User-Agent")
+			
+			// Set custom User-Agent
+			if let userAgent {
+				request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+			}
 			
 			// Send request, retrieve status code and ignore body data
 			let (bytes, response) = try await URLSession.shared.bytes(for: request)
 			bytes.task.cancel()
+//			let (bodyData, response) = try await URLSession.shared.data(for: request)
+//			print(String(data: bodyData, encoding: .utf8)!)
 			guard let httpResponse = response as? HTTPURLResponse else {
 				throw RequestError.noHTTPResponse
 			}
@@ -59,10 +64,121 @@ extension LinkTester {
 			}
 			
 			// Check status code
-			let isValid = isValid(statusCode: statusCode)
+			let isValid = statusCodeCheck(statusCode)
 			
 			return (isValid, statusCode)
 		}
 		
+	}
+}
+
+
+extension LinkTester {
+	enum ContentCheckMethod: CheckMethod {
+		case youTubeMusic
+		
+		
+		private static let youTubePrivacyCookie = HTTPCookie(properties: [
+			.domain: ".youtube.com",
+			.path: "/",
+			.name: "SOCS",
+			.value: "CAESNQgREitib3FfaWRlbnRpdHlmcm9udGVuZHVpc2VydmVyXzIwMjQxMDE1LjA2X3AwGgJkZSACGgYIgO3LuAY",
+			.secure: "TRUE",
+			.discard: "TRUE",
+			.maximumAge: "31536000",
+			.sameSitePolicy: "Lax",
+		])!
+		
+		
+		private var userAgent: String? {
+			switch self {
+				case .youTubeMusic:
+					UserAgent.generic
+			}
+		}
+		
+		private var cookie: HTTPCookie? {
+			switch self {
+				case .youTubeMusic:
+					Self.youTubePrivacyCookie
+			}
+		}
+		
+		private func isValid(html: Document) throws -> Bool {
+			switch self {
+				case .youTubeMusic:
+					// Check <title> value
+					let title = try html.title()
+					return title != "undefined"
+			}
+		}
+		
+		private func sendRequest(url: URL) async throws -> (Data, StatusCode) {
+			var request = URLRequest(url: url)
+			
+			// Set custom User-Agent
+			if let userAgent {
+				request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+			}
+			
+			// Set necessary cookies
+			if let cookie {
+				HTTPCookieStorage.shared.setCookie(cookie)
+			}
+			
+			// Send request and retrieve status code and body data
+			let (bodyData, response) = try await URLSession.shared.data(for: request)
+			guard let httpResponse = response as? HTTPURLResponse else {
+				throw RequestError.noHTTPResponse
+			}
+			guard let statusCode = StatusCode(httpResponse.statusCode) else {
+				throw RequestError.invalidStatusCode
+			}
+			
+			return (bodyData, statusCode)
+		}
+		
+		
+		func check(url: URL) async throws -> (Bool, StatusCode?) {
+			let (bodyData, statusCode) = try await sendRequest(url: url)
+			
+			// Check for successful status code
+			guard statusCode.class == .successful else {
+				return (false, statusCode)
+			}
+			
+			// Parse HTML
+			guard let htmlDocument = try? SwiftSoup.parse(bodyData) else {
+				throw RequestError.invalidBodyData
+			}
+			
+			let isValid = try isValid(html: htmlDocument)
+			
+			return (isValid, statusCode)
+		}
+		
+	}
+}
+
+
+extension LinkTester {
+	enum UserAgent {
+		// Default User-Agent works fine while the following custom one is often "outdated"
+		static let generic = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0"
+		
+		static func urlSessionDynamicVersion(for date: Date = .now) -> String {
+			let dateString = dynamicVersionDateFormatter.string(from: date)
+			return urlSession(version: dateString)
+		}
+		static func urlSession(version: String) -> String {
+			"dreimetadaten (\(version)) CFNetwork/1498.700.2 Darwin/23.6.0"
+		}
+		
+		
+		private static let dynamicVersionDateFormatter: DateFormatter = {
+			let formatter = DateFormatter()
+			formatter.dateFormat = "yyMMddHHmm"
+			return formatter
+		}()
 	}
 }

--- a/code/dreimetadaten/Test/LinkTester.LinkType.swift
+++ b/code/dreimetadaten/Test/LinkTester.LinkType.swift
@@ -40,7 +40,8 @@ extension LinkTester {
 		var checkMethod: CheckMethod {
 			switch self {
 				//case .amazonMusic, .youTubeMusic: fatalError("Check method not implemented")
-				default: .is2XX
+				case .amazon: MetadataCheckMethod.getWith2XX
+				default: MetadataCheckMethod.headWith2XX
 			}
 		}
 		

--- a/code/dreimetadaten/Test/LinkTester.LinkType.swift
+++ b/code/dreimetadaten/Test/LinkTester.LinkType.swift
@@ -16,9 +16,9 @@ extension LinkTester {
 		case appleMusic
 		case spotify
 		case bookbeat
-		//case amazonMusic
+		case amazonMusic
 		case amazon
-		//case youTubeMusic
+		case youTubeMusic
 		case deezer
 		
 		
@@ -30,23 +30,37 @@ extension LinkTester {
 				case .appleMusic: \.appleMusic
 				case .spotify: \.spotify
 				case .bookbeat: \.bookbeat
-				//case .amazonMusic: \.amazonMusic
+				case .amazonMusic: \.amazonMusic
 				case .amazon: \.amazon
-				//case .youTubeMusic: \.youTubeMusic
+				case .youTubeMusic: \.youTubeMusic
 				case .deezer: \.deezer
 			}
 		}
 		
 		var checkMethod: CheckMethod {
 			switch self {
-				//case .amazonMusic, .youTubeMusic: fatalError("Check method not implemented")
-				case .amazon: MetadataCheckMethod.getWith2XX
-				default: MetadataCheckMethod.headWith2XX
+				case .amazonMusic:
+					MetadataCheckMethod.getWith2XX(
+						urlTransform: {
+							URL(string: "https://www.amazon.de/gp/product/\($0.lastPathComponent)")
+						},
+						userAgent: UserAgent.urlSessionDynamicVersion()
+					)
+					
+				case .amazon:
+					MetadataCheckMethod.getWith2XX(userAgent: UserAgent.urlSessionDynamicVersion())
+					
+				case .youTubeMusic:
+					ContentCheckMethod.youTubeMusic
+					
+				default:
+					MetadataCheckMethod.headWith2XX()
 			}
 		}
 		
 		var checkInterval: TimeInterval {
 			switch self {
+				case .amazonMusic, .amazon: 0.5
 				default: 0.25
 			}
 		}

--- a/code/dreimetadaten/Test/LinkTester.LinkType.swift
+++ b/code/dreimetadaten/Test/LinkTester.LinkType.swift
@@ -1,0 +1,54 @@
+//
+//  LinkTester.LinkType.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 03.09.25.
+//
+
+import Foundation
+
+
+extension LinkTester {
+	enum LinkType: Equatable, Hashable, CaseIterable {
+		case cover_itunes
+		case cover_kosmos
+		case dreifragezeichen
+		case appleMusic
+		case spotify
+		case bookbeat
+		//case amazonMusic
+		case amazon
+		//case youTubeMusic
+		case deezer
+		
+		
+		var keyPath: KeyPath<MetadataObjectModel.Links, String?> {
+			switch self {
+				case .cover_itunes: \.cover_itunes
+				case .cover_kosmos: \.cover_kosmos
+				case .dreifragezeichen: \.dreifragezeichen
+				case .appleMusic: \.appleMusic
+				case .spotify: \.spotify
+				case .bookbeat: \.bookbeat
+				//case .amazonMusic: \.amazonMusic
+				case .amazon: \.amazon
+				//case .youTubeMusic: \.youTubeMusic
+				case .deezer: \.deezer
+			}
+		}
+		
+		var checkMethod: CheckMethod {
+			switch self {
+				//case .amazonMusic, .youTubeMusic: fatalError("Check method not implemented")
+				default: .is2XX
+			}
+		}
+		
+		var checkInterval: TimeInterval {
+			switch self {
+				default: 0.25
+			}
+		}
+		
+	}
+}

--- a/code/dreimetadaten/Test/LinkTester.StatusCode.swift
+++ b/code/dreimetadaten/Test/LinkTester.StatusCode.swift
@@ -1,0 +1,34 @@
+//
+//  LinkTester.StatusCode.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 03.09.25.
+//
+
+extension LinkTester {
+	struct StatusCode {
+		let value: UInt16
+		
+		init?(_ value: Int) {
+			guard value >= 100, value < 1000 else {
+				return nil
+			}
+			self.value = UInt16(value)
+		}
+		
+		var numericClass: UInt8 {
+			UInt8(value / 100)
+		}
+		var `class`: Class? {
+			Class(rawValue: numericClass)
+		}
+		
+		enum Class: UInt8 {
+			case informational = 1
+			case successful = 2
+			case redirection = 3
+			case clientError = 4
+			case serverError = 5
+		}
+	}
+}

--- a/code/dreimetadaten/Test/LinkTester.TestCase.swift
+++ b/code/dreimetadaten/Test/LinkTester.TestCase.swift
@@ -1,0 +1,56 @@
+//
+//  LinkTester.TestCase.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 05.09.25.
+//
+
+extension LinkTester {
+	struct TestCase {
+		let valid: String
+		let invalid: String
+		
+		static let all: [LinkType: Self] = [
+			.cover_itunes: .init(
+				valid:   "http://a1.mzstatic.com/us/r30/Music60/v4/24/bc/06/24bc0600-02b8-1f37-dc33-7a30f9634ebd/source",
+				invalid: "http://a1.mzstatic.com/us/r30/Music60/v4/24/bc/06/24bc0600-02b8-1f37-dc33-7a30f9634ebe/source"
+			),
+			.cover_kosmos: .init(
+				valid:   "http://web.archive.org/web/20220115135349if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/a0/2a/de/0743218420627.jpg",
+				invalid: "http://web.archive.org/web/20220115135349if_/https://s3.eu-central-1.amazonaws.com/kosmos.de/media/image/a0/2a/de/0743218420628.jpg"
+			),
+			.dreifragezeichen: .init(
+				valid:   "https://dreifragezeichen.de/produktwelt/details/toteninsel",
+				invalid: "https://dreifragezeichen.de/produktwelt/details/toteninsem"
+			),
+			.appleMusic: .init(
+				valid:   "https://music.apple.com/de/album/1112996835",
+				invalid: "https://music.apple.com/de/album/1112996836"
+			),
+			.spotify: .init(
+				valid:   "https://open.spotify.com/intl-de/album/6zwBnyiy9Hy9TAser0DOuL",
+				invalid: "https://open.spotify.com/intl-de/album/6zwBnyiy9Hy9TAser0DOuM"
+			),
+			.bookbeat: .init(
+				valid:   "https://www.bookbeat.com/de/book/534766",
+				invalid: "https://www.bookbeat.com/de/book/0"
+			),
+			.amazonMusic: .init(
+				valid:   "https://music.amazon.de/albums/B01FIM4KKU",
+				invalid: "https://music.amazon.de/albums/B01FIM4KKV"
+			),
+			.amazon: .init(
+				valid:   "https://www.amazon.de/gp/product/B00005OBYS",
+				invalid: "https://www.amazon.de/gp/product/B00005OBY"
+			),
+			.youTubeMusic: .init(
+				valid:   "https://music.youtube.com/browse/MPREb_rTJZ10YuZau",
+				invalid: "https://music.youtube.com/browse/MPREb_rTJZ10YuZav"
+			),
+			.deezer: .init(
+				valid:   "https://www.deezer.com/de/album/13731970",
+				invalid: "https://www.deezer.com/de/album/13731971"
+			),
+		]
+	}
+}

--- a/code/dreimetadaten/Test/LinkTester.swift
+++ b/code/dreimetadaten/Test/LinkTester.swift
@@ -1,0 +1,149 @@
+//
+//  LinkTester.swift
+//  dreimetadaten
+//
+//  Created by YourMJK on 03.09.25.
+//
+
+import Foundation
+import CommandLineTool
+import GRDB
+
+
+struct LinkTester {
+	let items: [MetadataObjectModel.Hörspiel]
+	private let urlSession: URLSession = .shared
+	
+	init(objectModel: MetadataObjectModel) {
+		// Consider root items of every collection
+		let rootItems = [objectModel.serie, objectModel.spezial, objectModel.kurzgeschichten, objectModel.die_dr3i, objectModel.kids, objectModel.sonstige]
+			.compactMap { $0 }
+			.joined()
+			.reversed()
+		var items = Array(rootItems)
+		
+		// Also consider teile of each item
+		var teile = [MetadataObjectModel.Hörspiel]()
+		for item in items {
+			teile.append(contentsOf: item.teile ?? [])
+		}
+		items.append(contentsOf: teile)
+		
+		// Sort by hörspieldID in descending order (i.e. more recent items first)
+		items.sort {
+			$0.ids?.dreimetadaten ?? 0 > $1.ids?.dreimetadaten ?? 0
+		}
+		
+		self.items = items
+	}
+	
+	
+	func test(linkType: LinkType, startIndex: UInt = 0, syntaxOnly: Bool = false, progress: (Progress) -> Void, failedLink: (Result) -> Void) async throws {
+		let clock = ContinuousClock()
+		let interval = ContinuousClock.Duration.seconds(linkType.checkInterval)
+		
+		// Filter only for items having linkType and skip items until startIndex
+		let filteredItems = items.filter {
+			guard let links = $0.links, let _ = links[keyPath: linkType.keyPath] else {
+				return false
+			}
+			return true
+		}
+		let indices = filteredItems.indices.dropFirst(Int(startIndex))
+		
+		for index in indices {
+			let item = filteredItems[index]
+			
+			// Get URL string and hörspielID
+			guard let links = item.links, let urlString = links[keyPath: linkType.keyPath] else {
+				continue
+			}
+			guard let hörspielID = item.ids?.dreimetadaten else {
+				throw DatasetError.missingHörspielID
+			}
+			
+			// Check if string is valid URL
+			guard
+				let components = URLComponents(string: urlString),
+				components.scheme != nil,
+				components.host != nil,
+				let url = URL(string: urlString)
+			else {
+				failedLink((hörspielID, urlString, nil))
+				continue
+			}
+			guard !syntaxOnly else {
+				continue
+			}
+			
+			progress((index, filteredItems.count, (hörspielID, url)))
+			let requestInstant = clock.now
+			
+			do {
+				// Send request and retrieve status code
+				let statusCode = try await test(url: url)
+				
+				// Check status code
+				let isValid = linkType.checkMethod.isValid(statusCode: statusCode)
+				if !isValid {
+					failedLink((hörspielID, urlString, statusCode))
+				}
+			}
+			catch {
+				failedLink((hörspielID, urlString, nil))
+			}
+			
+			// Wait before next request to respect rate limits
+			try? await Task.sleep(until: requestInstant + interval, clock: clock)
+		}
+		
+		progress((filteredItems.count, filteredItems.count, nil))
+	}
+	
+	private func test(url: URL) async throws -> StatusCode {
+		let request = URLRequest(url: url)
+		// Default User-Agent works fine while the following custom one is "outdated"
+		//request.setValue("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0", forHTTPHeaderField: "User-Agent")
+		
+		let (_, response) = try await urlSession.data(for: request)
+		guard let httpResponse = response as? HTTPURLResponse else {
+			throw RequestError.noHTTPResponse
+		}
+		guard let statusCode = StatusCode(httpResponse.statusCode) else {
+			throw RequestError.invalidStatusCode
+		}
+		
+		return statusCode
+	}
+}
+
+
+extension LinkTester {
+	typealias Progress = (checked: Int, total: Int, current: (hörspielID: UInt, url: URL)?)
+	typealias Result = (hörspielID: UInt, url: String, statusCode: StatusCode?)
+	
+	enum DatasetError: LocalizedError {
+		case missingHörspielID
+		
+		var errorDescription: String? {
+			switch self {
+				case .missingHörspielID:
+					return "An item is missing a hörspielID"
+			}
+		}
+	}
+	
+	enum RequestError: LocalizedError {
+		case noHTTPResponse
+		case invalidStatusCode
+		
+		var errorDescription: String? {
+			switch self {
+				case .noHTTPResponse:
+					return "Response is not a HTTPURLResponse"
+				case .invalidStatusCode:
+					return "Response contains an invalid status code"
+			}
+		}
+	}
+}

--- a/code/dreimetadaten/Test/LinkTester.swift
+++ b/code/dreimetadaten/Test/LinkTester.swift
@@ -40,6 +40,7 @@ struct LinkTester {
 	func test(linkType: LinkType, startIndex: UInt = 0, syntaxOnly: Bool = false, progress: (Progress) -> Void, failedLink: (Result) -> Void) async throws {
 		let clock = ContinuousClock()
 		let interval = ContinuousClock.Duration.seconds(linkType.checkInterval)
+		let checkMethod = linkType.checkMethod
 		
 		// Filter only for items having linkType and skip items until startIndex
 		let filteredItems = items.filter {
@@ -80,7 +81,7 @@ struct LinkTester {
 			
 			do {
 				// Check URL
-				let (isValid, statusCode) = try await linkType.checkMethod.check(url: url)
+				let (isValid, statusCode) = try await checkMethod.check(url: url)
 				
 				if !isValid {
 					failedLink((hörspielID, urlString, statusCode))
@@ -117,6 +118,7 @@ extension LinkTester {
 	enum RequestError: LocalizedError {
 		case noHTTPResponse
 		case invalidStatusCode
+		case invalidBodyData
 		
 		var errorDescription: String? {
 			switch self {
@@ -124,6 +126,8 @@ extension LinkTester {
 					return "Response is not a HTTPURLResponse"
 				case .invalidStatusCode:
 					return "Response contains an invalid status code"
+				case .invalidBodyData:
+					return "Response contains invalid body data"
 			}
 		}
 	}

--- a/code/dreimetadaten/Test/LinkTester.swift
+++ b/code/dreimetadaten/Test/LinkTester.swift
@@ -12,7 +12,6 @@ import GRDB
 
 struct LinkTester {
 	let items: [MetadataObjectModel.Hörspiel]
-	private let urlSession: URLSession = .shared
 	
 	init(objectModel: MetadataObjectModel) {
 		// Consider root items of every collection
@@ -80,11 +79,9 @@ struct LinkTester {
 			let requestInstant = clock.now
 			
 			do {
-				// Send request and retrieve status code
-				let statusCode = try await test(url: url)
+				// Check URL
+				let (isValid, statusCode) = try await linkType.checkMethod.check(url: url)
 				
-				// Check status code
-				let isValid = linkType.checkMethod.isValid(statusCode: statusCode)
 				if !isValid {
 					failedLink((hörspielID, urlString, statusCode))
 				}
@@ -98,22 +95,6 @@ struct LinkTester {
 		}
 		
 		progress((filteredItems.count, filteredItems.count, nil))
-	}
-	
-	private func test(url: URL) async throws -> StatusCode {
-		let request = URLRequest(url: url)
-		// Default User-Agent works fine while the following custom one is "outdated"
-		//request.setValue("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0", forHTTPHeaderField: "User-Agent")
-		
-		let (_, response) = try await urlSession.data(for: request)
-		guard let httpResponse = response as? HTTPURLResponse else {
-			throw RequestError.noHTTPResponse
-		}
-		guard let statusCode = StatusCode(httpResponse.statusCode) else {
-			throw RequestError.invalidStatusCode
-		}
-		
-		return statusCode
 	}
 }
 


### PR DESCRIPTION
 This subcommand detects invalid or dead links/IDs for
 * all streaming platforms and stores
 * external cover images