### PR TITLE
fix: make BASEDIR absolute

### DIFF
--- a/tools/.config.sh
+++ b/tools/.config.sh
@@ -1,5 +1,4 @@
-BASEDIR=$(dirname "$0")/..
-BASEDIR=$(realpath --relative-to=. "$BASEDIR")
+BASEDIR=$(cd "$(dirname "$0")/.." && pwd)
 
 DBFILE=${DBFILE:-"$BASEDIR"/metadata/db.sqlite}
 SQLFILE=${SQLFILE:-"$BASEDIR"/metadata/db.sql}

--- a/tools/.config.sh
+++ b/tools/.config.sh
@@ -1,4 +1,5 @@
-BASEDIR=$(cd "$(dirname "$0")/.." && pwd)
+BASEDIR=$(dirname "$0")/..
+BASEDIR=$(realpath "$BASEDIR")
 
 DBFILE=${DBFILE:-"$BASEDIR"/metadata/db.sqlite}
 SQLFILE=${SQLFILE:-"$BASEDIR"/metadata/db.sql}


### PR DESCRIPTION
Wenn ich versuche ein Skript wie `loadDB.sh` auszuführen, lädt dieses zunächst `.config.sh` um u.a. Variablen wie `BASEDIR` zu setzen. 

Aktuell wird dort `realpath --relative-to ...` verwendet um den korrekten **relativen** Pfad vom Projekt-Root zu ermitteln. Jedoch unterstützt das in macOS eingebaute realpath nicht die `--relative-to` Option, weswegen folgender Fehler ausgegeben wird:

```
realpath: illegal option -- -
usage: realpath [-q] [path ...]
```

Ich kann mir natürlich die [GNU coreutils nachinstallieren](https://formulae.brew.sh/formula/coreutils), allerdings muss ich dann `grealpath` anstelle von `realpath` verwenden, was natürlich nicht im Skript berücksichtigt wird.

Am einfachsten wäre es daher, dass BASEDIR keinen relativen Pfad zum Projektroot darstellt, sondern einen absoluten (via pwd).